### PR TITLE
[STMT-151] :sparkles: 공통적으로 사용되는 생성 시간, 수정 시간 추가를 위한 추상 클래스 구현

### DIFF
--- a/src/main/java/com/stumeet/server/common/config/AuditConfig.java
+++ b/src/main/java/com/stumeet/server/common/config/AuditConfig.java
@@ -1,7 +1,9 @@
 package com.stumeet.server.common.config;
 
+import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@Configuration
 @EnableJpaAuditing
 public class AuditConfig {
 }

--- a/src/main/java/com/stumeet/server/common/config/AuditConfig.java
+++ b/src/main/java/com/stumeet/server/common/config/AuditConfig.java
@@ -1,0 +1,7 @@
+package com.stumeet.server.common.config;
+
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@EnableJpaAuditing
+public class AuditConfig {
+}

--- a/src/main/java/com/stumeet/server/common/model/BaseTimeEntity.java
+++ b/src/main/java/com/stumeet/server/common/model/BaseTimeEntity.java
@@ -1,0 +1,29 @@
+package com.stumeet.server.common.model;
+
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.hibernate.annotations.Comment;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+public abstract class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(name = "created_at", updatable = false)
+    @Comment("생성 시간")
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    @Comment("수정 시간")
+    private LocalDateTime updatedAt;
+}


### PR DESCRIPTION
## 💁 해결 하려는 문제를 적어주세요 

- 공통적으로 사용되는 생성 시간, 수정 시간을 중복해서 작성해야는 문제가 존재

## 🤔 어떤 방식으로 해결했는지 적어주세요 

- JPA Auditing을 통해 생성 시간, 수정 시간을 자동으로 감지하고 이를 추상 클래스로 만들어서 상속하여 중복 코드를 줄일 수 있게 했습니다.
