### PR TITLE
[STMT-6] 👷 CI/CD를 위한 github-actions 추가

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -3,10 +3,12 @@ name: CI/CD using github actions & docker
 
 # event trigger
 # main 브랜치에 push가 되었을 때 실행
+# test 용도: STMT-6-github-actions에 push 되었을 때 실행
 on:
   push:
     branches:
       - main
+      - STMT-6-github-actions
 
 permissions:
   contents: read
@@ -17,12 +19,12 @@ jobs:
     steps:
 
       # JDK setting - github actions에서 사용할 JDK 설정
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up JDK 21
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '21'
-          distribution: 'adopt'
+          distribution: 'temurin'
 
       # gradle caching - 빌드 시간 향상
       - name: Gradle Caching
@@ -55,7 +57,7 @@ jobs:
       - name: Deploy to prod
         uses: appleboy/ssh-action@master
         id: deploy-prod
-        if: contains(github.ref, 'main')
+        if: contains(github.ref, 'STMT-6-github-actions')
         with:
           host: ${{ secrets.AWS_PUBLIC_IP }}
           username: ${{ secrets.AWS_USER }}

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -2,7 +2,7 @@
 name: CI/CD using github actions & docker
 
 # event trigger
-# main이나 develop 브랜치에 push가 되었을 때 실행
+# main 브랜치에 push가 되었을 때 실행
 on:
   push:
     branches:
@@ -18,10 +18,10 @@ jobs:
 
       # JDK setting - github actions에서 사용할 JDK 설정
       - uses: actions/checkout@v3
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v3
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'adopt'
 
       # gradle caching - 빌드 시간 향상
@@ -62,8 +62,9 @@ jobs:
           key: ${{ secrets.AWS_PRIVATE_KEY }}
           port: ${{ secrets.AWS_SSH_PORT }}
           script: |
-            sudo docker ps
-            sudo docker pull ${{ secrets.DOCKER_USERNAME }}/stumeet
-            sudo docker run -it -d -p 8080:8080 ${{ secrets.DOCKER_USERNAME }}/stumeet
+            sudo docker pull ${{ secrets.DOCKER_USERNAME }}/server
+            sudo docker stop stumeet-server
+            docker container prune -f
+            sudo docker run -it -d -p 8080:8080 --name stumeet-server ${{ secrets.DOCKER_USERNAME }}/server
             sudo docker image prune -f
 

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -64,6 +64,6 @@ jobs:
           script: |
             sudo docker ps
             sudo docker pull ${{ secrets.DOCKER_USERNAME }}/stumeet
-            sudo docker run -it -d --expose=8080 ${{ secrets.DOCKER_USERNAME }}/stumeet
+            sudo docker run -it -d -p 8080:8080 ${{ secrets.DOCKER_USERNAME }}/stumeet
             sudo docker image prune -f
 

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -3,7 +3,6 @@ name: CI/CD using github actions & docker
 
 # event trigger
 # main 브랜치에 push가 되었을 때 실행
-# test 용도: STMT-6-github-actions에 push 되었을 때 실행
 on:
   push:
     branches:

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -8,7 +8,6 @@ on:
   push:
     branches:
       - main
-      - STMT-6-github-actions
 
 permissions:
   contents: read
@@ -57,7 +56,7 @@ jobs:
       - name: Deploy to prod
         uses: appleboy/ssh-action@master
         id: deploy-prod
-        if: contains(github.ref, 'STMT-6-github-actions')
+        if: contains(github.ref, 'main')
         with:
           host: ${{ secrets.AWS_PUBLIC_IP }}
           username: ${{ secrets.AWS_USER }}

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -1,0 +1,69 @@
+# github repository actions 페이지에 나타날 이름
+name: CI/CD using github actions & docker
+
+# event trigger
+# main이나 develop 브랜치에 push가 되었을 때 실행
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  CI-CD:
+    runs-on: ubuntu-latest
+    steps:
+
+      # JDK setting - github actions에서 사용할 JDK 설정
+      - uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'adopt'
+
+      # gradle caching - 빌드 시간 향상
+      - name: Gradle Caching
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+
+      # docker login
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      # build gradle
+      - name: Build gradlew
+        run: |
+          chmod +x gradlew 
+          ./gradlew jib \
+          -Djib.from.auth.username=${{ secrets.DOCKER_USERNAME }} \
+          -Djib.from.auth.password=${{ secrets.DOCKER_PASSWORD }} 
+
+      ## deploy to production
+      - name: Deploy to prod
+        uses: appleboy/ssh-action@master
+        id: deploy-prod
+        if: contains(github.ref, 'main')
+        with:
+          host: ${{ secrets.AWS_PUBLIC_IP }}
+          username: ${{ secrets.AWS_USER }}
+          key: ${{ secrets.AWS_PRIVATE_KEY }}
+          port: ${{ secrets.AWS_SSH_PORT }}
+          script: |
+            sudo docker ps
+            sudo docker pull ${{ secrets.DOCKER_USERNAME }}/stumeet
+            sudo docker run -it -d --expose=8080 ${{ secrets.DOCKER_USERNAME }}/stumeet
+            sudo docker image prune -f
+

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'org.springframework.boot' version '3.2.2'
     id 'io.spring.dependency-management' version '1.1.4'
     id 'org.asciidoctor.jvm.convert' version '3.3.2'
+    id 'com.google.cloud.tools.jib' version '3.4.0'
 }
 
 group = 'com.stumeet'
@@ -61,4 +62,17 @@ tasks.named('test') {
 tasks.named('asciidoctor') {
     inputs.dir snippetsDir
     dependsOn test
+}
+
+jib {
+    from {
+        image = "eclipse-temurin:21"
+    }
+    to {
+        image = "tngtied/triplaner"
+        tags = ["latest"]
+    }
+    container {
+        jvmFlags = ["-Xms128m", "-Xmx128m"]
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -69,8 +69,8 @@ jib {
         image = "eclipse-temurin:21"
     }
     to {
-        image = "tngtied/triplaner"
-        tags = ["latest"]
+        image = "stumeet/server"
+        tags = [version]
     }
     container {
         jvmFlags = ["-Xms128m", "-Xmx128m"]


### PR DESCRIPTION
## 💁 해결 하려는 문제를 적어주세요 

- origin/main에 push 발생 시 자동으로 ec2 인스턴스에 배포되도록 CI/CD 구축

## 🤔 어떤 방식으로 해결했는지 적어주세요 

- Secret repository environment variable을 사용하여 보안적으로 이슈가 있는 정보(i.e. AWS EC2 시크릿 키)를 저장하고, 안전하게 사용하였습니다.
- stumeet.shop 도메인을 구매해 DNS를 설정했습니다.
- gradle을 caching하여 빌드 시간을 향상시켰습니다.
- CI/CD 중 도커 컨테이너 생성 시 포트 8080을 내부 포트 8080으로 바인딩하여 nginx로 하여금 stumeet server에게 http://127.0.0.1:8080를 통해 패킷을 전달하도록 하였습니다.
- 동작 테스트 목적으로 생성되어 남겨져 있던 다수의 텍스트들을  수정하였습니다.
- CD시, 기존에 실행되던 컨테이너가 중지되고 삭제되는 명령문을 넣었습니다.
- 컨테이너 생성 시 네이밍을 하여 식별에 용이하도록 하였습니다.

## 🧑‍🏫 이해를 위해 필요한 자료가 있다면 첨부해주세요

nginx의 `default.config` 파일의 경우 아래와 같이 작성하였습니다.
```
server{
	server_name stumeet.shop;
	location / {
		proxy_pass http://127.0.0.1:8080;
	}
	listen [::]:443 ssl ipv6only=on; #managed by Certbot
	listen 443 ssl; #managed by Certbot
	ssl_certificate /etc/letsencrypt/live/stumeet.shop/fullchain.pem; #managed by Certbot
	ssl_certificate_key /etc/letsencrypt/live/stumeet.shop/privatekey.pem; #managed by Certbot
	include /etc/letsencrypt/options-ssl-nginx.conf; #managed by Certbot
	ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem; #managed by Certbot
}
server{
	if ($host = stumeet.shop){
		return 301 https://$host$request_uri;
	}
	listen		80;
	listen		[::]:80;
	server_name 	stumeet.shop;
	return 404; #managed by Certbot
}
```