### PR TITLE
[STMT-146] :sparkles: 카카오 로그인시 카카오 유저 정보를 가져오지 않도록 변경

### DIFF
--- a/src/main/java/com/stumeet/server/common/client/oauth/kakao/KakaoOAuthClient.java
+++ b/src/main/java/com/stumeet/server/common/client/oauth/kakao/KakaoOAuthClient.java
@@ -15,15 +15,12 @@ public class KakaoOAuthClient implements OAuthClient {
 
     @Override
     public OAuthUserProfileResponse getMyProfile(String accessToken) {
-        String propertyKey = "property_keys=[\"kakao_account.profile\"]";
-        ResponseEntity<KakaoUserProfileResponse> response = kakaoOAuthClient.getMyProfile(accessToken, propertyKey);
+        ResponseEntity<KakaoUserProfileResponse> response = kakaoOAuthClient.getUserId(accessToken);
 
         KakaoUserProfileResponse responseBody = response.getBody();
 
         return new OAuthUserProfileResponse(
-                responseBody.id(),
-                responseBody.kakaoAccount().profile().nickname(),
-                responseBody.kakaoAccount().profile().thumbnailImageUrl()
+                responseBody.id()
         );
     }
 }

--- a/src/main/java/com/stumeet/server/common/client/oauth/kakao/KakaoOAuthFeignClient.java
+++ b/src/main/java/com/stumeet/server/common/client/oauth/kakao/KakaoOAuthFeignClient.java
@@ -1,20 +1,17 @@
 package com.stumeet.server.common.client.oauth.kakao;
 
 import com.stumeet.server.common.client.oauth.kakao.model.KakaoUserProfileResponse;
-import feign.Headers;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 
 @FeignClient(name = "kakaoOAuthClient", url = "https://kapi.kakao.com")
 public interface KakaoOAuthFeignClient {
 
-    @PostMapping("/v2/user/me")
-    @Headers("Content-Type: application/x-www-form-urlencoded")
-    ResponseEntity<KakaoUserProfileResponse> getMyProfile(
-            @RequestHeader("Authorization") String accessToken,
-            @RequestBody String propertyKey
+    @GetMapping("/v1/user/access_token_info")
+    ResponseEntity<KakaoUserProfileResponse> getUserId(
+            @RequestHeader("Authorization") String accessToken
     );
 }

--- a/src/main/java/com/stumeet/server/common/client/oauth/kakao/model/KakaoUserProfileResponse.java
+++ b/src/main/java/com/stumeet/server/common/client/oauth/kakao/model/KakaoUserProfileResponse.java
@@ -3,18 +3,6 @@ package com.stumeet.server.common.client.oauth.kakao.model;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public record KakaoUserProfileResponse(
-        String id,
-        @JsonProperty("kakao_account")
-        KakaoAccount kakaoAccount
+        String id
 ) {
-    public record KakaoAccount(
-            Profile profile
-    ) {
-        public record Profile(
-                String nickname,
-                @JsonProperty("thumbnail_image_url")
-                String thumbnailImageUrl
-        ) {
-        }
-    }
 }

--- a/src/main/java/com/stumeet/server/common/client/oauth/model/OAuthUserProfileResponse.java
+++ b/src/main/java/com/stumeet/server/common/client/oauth/model/OAuthUserProfileResponse.java
@@ -1,8 +1,6 @@
 package com.stumeet.server.common.client.oauth.model;
 
 public record OAuthUserProfileResponse(
-    String id,
-    String name,
-    String imageUrl
+    String id
 ) {
 }

--- a/src/main/java/com/stumeet/server/member/adapter/out/persistence/MemberJpaEntity.java
+++ b/src/main/java/com/stumeet/server/member/adapter/out/persistence/MemberJpaEntity.java
@@ -22,11 +22,11 @@ public class MemberJpaEntity extends BaseTimeEntity {
     @Comment("멤버 아이디")
     private Long id;
 
-    @Column(name = "name", nullable = false)
+    @Column(name = "name")
     @Comment("멤버 이름")
     private String name;
 
-    @Column(name = "image", nullable = false)
+    @Column(name = "image")
     @Comment("멤버 이미지 URL")
     private String image;
 

--- a/src/main/java/com/stumeet/server/member/application/service/MemberOAuthService.java
+++ b/src/main/java/com/stumeet/server/member/application/service/MemberOAuthService.java
@@ -30,8 +30,6 @@ public class MemberOAuthService implements MemberOAuthUseCase {
         } else {
             member = memberCommandPort.save(
                     Member.builder()
-                            .name(response.name())
-                            .image(response.imageUrl())
                             .sugarContents(0.0)
                             .authType(AuthType.OAUTH)
                             .role(UserRole.FIRST_LOGIN)


### PR DESCRIPTION
## 💁 해결 하려는 문제를 적어주세요 

- 소셜 로그인은 인증만 진행하도록 변경되었습니다

## 🤔 어떤 방식으로 해결했는지 적어주세요 

- 카카오 로그인시 카카오 유저 정보를 받아오는 부분을 제거하고 토큰의 유효성만 체크하는 API를 호출하도록 변경했습니다.
