### PR TITLE
[STMT-146] :sparkles: 애플 로그인 기능 추가

### DIFF
--- a/src/main/java/com/stumeet/server/common/auth/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/stumeet/server/common/auth/filter/JwtAuthenticationFilter.java
@@ -3,6 +3,7 @@ package com.stumeet.server.common.auth.filter;
 import com.stumeet.server.common.auth.model.AuthenticationHeader;
 import com.stumeet.server.common.auth.service.JwtAuthenticationService;
 import com.stumeet.server.common.token.JwtTokenProvider;
+import com.stumeet.server.common.util.JwtUtil;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -27,7 +28,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         SecurityContext context = SecurityContextHolder.getContext();
         if (context.getAuthentication() == null) {
-            String token = resolveToken(request.getHeader(AuthenticationHeader.ACCESS_TOKEN.getName()));
+            String token = JwtUtil.resolveToken(request.getHeader(AuthenticationHeader.ACCESS_TOKEN.getName()));
 
             if (jwtTokenProvider.validateToken(token)) {
                 Authentication auth = jwtAuthenticationService.getAuthentication(token);
@@ -38,10 +39,4 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         filterChain.doFilter(request, response);
     }
 
-    private String resolveToken(String token) {
-        if (token != null && token.startsWith("Bearer ")) {
-            return token.substring(7);
-        }
-        return null;
-    }
 }

--- a/src/main/java/com/stumeet/server/common/auth/service/OAuthAuthenticationProvider.java
+++ b/src/main/java/com/stumeet/server/common/auth/service/OAuthAuthenticationProvider.java
@@ -10,21 +10,23 @@ import com.stumeet.server.member.application.port.in.MemberOAuthUseCase;
 import com.stumeet.server.member.domain.Member;
 import feign.FeignException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.stereotype.Component;
 
+import java.util.Map;
+
 @Component
 @RequiredArgsConstructor
 public class OAuthAuthenticationProvider implements AuthenticationProvider {
 
-    private final OAuthClient oAuthClient;
+    private final Map<String, OAuthClient> oAuthClient;
     private final MemberOAuthUseCase memberOAuthUseCase;
     private final JwtTokenProvider jwtTokenProvider;
     private final RefreshTokenService refreshTokenService;
-
 
     @Override
     public Authentication authenticate(Authentication authentication) throws AuthenticationException {
@@ -33,7 +35,7 @@ public class OAuthAuthenticationProvider implements AuthenticationProvider {
         String provider = token.getProvider();
 
         try {
-            OAuthUserProfileResponse myProfile = oAuthClient.getMyProfile(providerAccessToken);
+            OAuthUserProfileResponse myProfile = oAuthClient.get(provider).getUserId(providerAccessToken);
             Member member = memberOAuthUseCase.getMemberOrCreate(myProfile, provider);
             LoginMember loginMember = new LoginMember(member);
 

--- a/src/main/java/com/stumeet/server/common/client/oauth/OAuthClient.java
+++ b/src/main/java/com/stumeet/server/common/client/oauth/OAuthClient.java
@@ -3,5 +3,5 @@ package com.stumeet.server.common.client.oauth;
 import com.stumeet.server.common.client.oauth.model.OAuthUserProfileResponse;
 
 public interface OAuthClient {
-    OAuthUserProfileResponse getMyProfile(String accessToken);
+    OAuthUserProfileResponse getUserId(String accessToken);
 }

--- a/src/main/java/com/stumeet/server/common/client/oauth/apple/AppleIdTokenProvider.java
+++ b/src/main/java/com/stumeet/server/common/client/oauth/apple/AppleIdTokenProvider.java
@@ -1,0 +1,53 @@
+package com.stumeet.server.common.client.oauth.apple;
+
+import com.stumeet.server.common.client.oauth.apple.model.ApplePublicKeyResponses;
+import io.jsonwebtoken.Jwts;
+import org.springframework.stereotype.Component;
+
+import java.math.BigInteger;
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.PublicKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.RSAPublicKeySpec;
+import java.util.Base64;
+
+@Component
+public class AppleIdTokenProvider {
+    public PublicKey getSecretKey(ApplePublicKeyResponses publicKeys, String accessToken) {
+        String kid = Jwts.parser()
+                .build()
+                .parseSignedClaims(accessToken)
+                .getHeader()
+                .getKeyId();
+
+        ApplePublicKeyResponses.ApplePublicKeyResponse applePublicKey = publicKeys.keys().stream()
+                .filter(key -> key.kid().equals(kid))
+                .findAny()
+                .orElseThrow(() -> new IllegalArgumentException("매칭되는 kid가 존재하지 않습니다."));
+
+        BigInteger modulus = new BigInteger(1, Base64.getUrlDecoder().decode(applePublicKey.n()));
+        BigInteger publicExponent = new BigInteger(1, Base64.getUrlDecoder().decode(applePublicKey.e()));
+
+        RSAPublicKeySpec keySpec = new RSAPublicKeySpec(modulus, publicExponent);
+        try {
+            KeyFactory keyFactory = KeyFactory.getInstance("RSA");
+
+            return keyFactory.generatePublic(keySpec);
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        } catch (InvalidKeySpecException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+
+    public String extractUserId(PublicKey publicKey, String idToken) {
+        return Jwts.parser()
+                .verifyWith(publicKey)
+                .build()
+                .parseSignedClaims(idToken)
+                .getPayload()
+                .getSubject();
+    }
+}

--- a/src/main/java/com/stumeet/server/common/client/oauth/apple/AppleOAuthClient.java
+++ b/src/main/java/com/stumeet/server/common/client/oauth/apple/AppleOAuthClient.java
@@ -1,0 +1,26 @@
+package com.stumeet.server.common.client.oauth.apple;
+
+import com.stumeet.server.common.client.oauth.OAuthClient;
+import com.stumeet.server.common.client.oauth.apple.model.ApplePublicKeyResponses;
+import com.stumeet.server.common.client.oauth.model.OAuthUserProfileResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.security.PublicKey;
+
+@Component(value = "apple")
+@RequiredArgsConstructor
+public class AppleOAuthClient implements OAuthClient {
+
+    private final AppleOAuthFeignClient appleOAuthClient;
+    private final AppleIdTokenProvider appleIdTokenProvider;
+
+    @Override
+    public OAuthUserProfileResponse getUserId(String accessToken) {
+        ApplePublicKeyResponses publicKeys = appleOAuthClient.getPublicKeys();
+        PublicKey publicKey = appleIdTokenProvider.getSecretKey(publicKeys, accessToken);
+        String id = appleIdTokenProvider.extractUserId(publicKey, accessToken);
+
+        return new OAuthUserProfileResponse(id);
+    }
+}

--- a/src/main/java/com/stumeet/server/common/client/oauth/apple/AppleOAuthClient.java
+++ b/src/main/java/com/stumeet/server/common/client/oauth/apple/AppleOAuthClient.java
@@ -3,6 +3,7 @@ package com.stumeet.server.common.client.oauth.apple;
 import com.stumeet.server.common.client.oauth.OAuthClient;
 import com.stumeet.server.common.client.oauth.apple.model.ApplePublicKeyResponses;
 import com.stumeet.server.common.client.oauth.model.OAuthUserProfileResponse;
+import com.stumeet.server.common.util.JwtUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -18,8 +19,9 @@ public class AppleOAuthClient implements OAuthClient {
     @Override
     public OAuthUserProfileResponse getUserId(String accessToken) {
         ApplePublicKeyResponses publicKeys = appleOAuthClient.getPublicKeys();
-        PublicKey publicKey = appleIdTokenProvider.getSecretKey(publicKeys, accessToken);
-        String id = appleIdTokenProvider.extractUserId(publicKey, accessToken);
+        String parseAccessToken = JwtUtil.resolveToken(accessToken);
+        PublicKey publicKey = appleIdTokenProvider.getSecretKey(publicKeys, parseAccessToken);
+        String id = appleIdTokenProvider.extractUserId(publicKey, parseAccessToken);
 
         return new OAuthUserProfileResponse(id);
     }

--- a/src/main/java/com/stumeet/server/common/client/oauth/apple/AppleOAuthFeignClient.java
+++ b/src/main/java/com/stumeet/server/common/client/oauth/apple/AppleOAuthFeignClient.java
@@ -1,0 +1,13 @@
+package com.stumeet.server.common.client.oauth.apple;
+
+import com.stumeet.server.common.client.oauth.apple.model.ApplePublicKeyResponses;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@FeignClient(name = "appleOAuthClient", url = "https://appleid.apple.com")
+public interface AppleOAuthFeignClient {
+
+    @GetMapping("/auth/keys")
+    ApplePublicKeyResponses getPublicKeys();
+
+}

--- a/src/main/java/com/stumeet/server/common/client/oauth/apple/model/ApplePublicKeyResponses.java
+++ b/src/main/java/com/stumeet/server/common/client/oauth/apple/model/ApplePublicKeyResponses.java
@@ -1,0 +1,16 @@
+package com.stumeet.server.common.client.oauth.apple.model;
+
+import java.util.List;
+
+public record ApplePublicKeyResponses(
+        List<ApplePublicKeyResponse> keys
+
+) {
+    public record ApplePublicKeyResponse(
+            String kid,
+            String n,
+            String e
+    ) {
+    }
+
+}

--- a/src/main/java/com/stumeet/server/common/client/oauth/kakao/KakaoOAuthClient.java
+++ b/src/main/java/com/stumeet/server/common/client/oauth/kakao/KakaoOAuthClient.java
@@ -7,14 +7,14 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 
-@Component
+@Component(value = "kakao")
 @RequiredArgsConstructor
 public class KakaoOAuthClient implements OAuthClient {
 
     private final KakaoOAuthFeignClient kakaoOAuthClient;
 
     @Override
-    public OAuthUserProfileResponse getMyProfile(String accessToken) {
+    public OAuthUserProfileResponse getUserId(String accessToken) {
         ResponseEntity<KakaoUserProfileResponse> response = kakaoOAuthClient.getUserId(accessToken);
 
         KakaoUserProfileResponse responseBody = response.getBody();

--- a/src/main/java/com/stumeet/server/common/util/JwtUtil.java
+++ b/src/main/java/com/stumeet/server/common/util/JwtUtil.java
@@ -1,0 +1,16 @@
+package com.stumeet.server.common.util;
+
+public class JwtUtil {
+
+    private JwtUtil() {
+
+    }
+
+    public static String resolveToken(String token) {
+        if (token != null && token.startsWith("Bearer ")) {
+            return token.substring(7);
+        }
+        return null;
+    }
+
+}


### PR DESCRIPTION
## 💁 해결 하려는 문제를 적어주세요 

- 로그인시 애플 로그인을 지원하도록 구현

## 🤔 어떤 방식으로 해결했는지 적어주세요 

- OAuthClient를 구현하는 구현체들을 빈 이름, 구현 객체와 같은 형식으로 Map 형태로 저장해서 provider에 따라 실행되는 로직이 바뀌도록 변경
- 애플의 Public Key 목록을 받아와서 id_token이 유효한지 확인하는 로직 추가