### PR TITLE
✅ [STMT-146] 토큰 재발급 성공 테스트 추가

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -7,13 +7,18 @@ ifndef::snippets[]
 :snippets: build/generated-snippets
 endif::[]
 
-= 회원 API
+= Stumeet API 문서
 
 == 소셜 로그인
 
+소셜 로그인 시 사용되는 API입니다.
+현재 카카오, 애플 로그인이 가능합니다.
+
 === POST /api/v1/oauth
 
-.Request
+==== 요청
+
+.카카오 로그인
 include::{snippets}/social_login/success/http-request.adoc[]
 include::{snippets}/social_login/success/request-headers.adoc[]
 
@@ -30,4 +35,18 @@ include::{snippets}/social_login/fail/not-exist-header/response-body.adoc[]
 
 include::{snippets}/social_login/fail/invalid-token/response-fields.adoc[]
 
+== 토큰 재발급
 
+서버로 부터 받은 액세스 토큰이 만료된 경우 액세스 토큰 재발급을 위해 사용되는 API입니다.
+
+=== POST /api/v1/tokens
+
+==== 요청
+include::{snippets}/token_renew/success/http-request.adoc[]
+
+include::{snippets}/token_renew/success/request-body.adoc[]
+include::{snippets}/token_renew/success/request-fields.adoc[]
+
+==== 응답 성공 (200)
+include::{snippets}/token_renew/success/response-body.adoc[]
+include::{snippets}/token_renew/success/response-fields.adoc[]

--- a/src/main/java/com/stumeet/server/common/auth/service/OAuthAuthenticationProvider.java
+++ b/src/main/java/com/stumeet/server/common/auth/service/OAuthAuthenticationProvider.java
@@ -40,7 +40,7 @@ public class OAuthAuthenticationProvider implements AuthenticationProvider {
             LoginMember loginMember = new LoginMember(member);
 
             String accessToken = jwtTokenProvider.generateAccessToken(loginMember);
-            String refreshToken = jwtTokenProvider.generateRefreshToken();
+            String refreshToken = jwtTokenProvider.generateRefreshToken(member.getId());
             refreshTokenService.save(accessToken, refreshToken);
 
             return StumeetAuthenticationToken.authenticateOAuth(

--- a/src/main/java/com/stumeet/server/common/token/JwtTokenProvider.java
+++ b/src/main/java/com/stumeet/server/common/token/JwtTokenProvider.java
@@ -58,10 +58,11 @@ public class JwtTokenProvider {
                 .compact();
     }
 
-    public String generateRefreshToken() {
+    public String generateRefreshToken(Long memberId) {
         return Jwts.builder()
                 .issuer(issuer)
                 .issuedAt(new Date(System.currentTimeMillis()))
+                .subject(String.valueOf(memberId))
                 .expiration(new Date(System.currentTimeMillis() + 1000 * 60 * 60 * 24 * 3))
                 .signWith(secretKey)
                 .compact();

--- a/src/main/java/com/stumeet/server/member/application/service/MemberAuthService.java
+++ b/src/main/java/com/stumeet/server/member/application/service/MemberAuthService.java
@@ -41,7 +41,7 @@ public class MemberAuthService implements MemberAuthUseCase {
         String savedRefreshToken = refreshTokenService.getRefreshToken(request.accessToken(), request.refreshToken());
         refreshTokenService.deleteByAccessToken(request.accessToken());
 
-        Long id = Long.parseLong(jwtTokenProvider.getSubject(request.accessToken()));
+        Long id = Long.parseLong(jwtTokenProvider.getSubject(request.refreshToken()));
         Member member = memberQueryPort.getById(id);
         String renewAccessToken = jwtTokenProvider.generateAccessToken(new LoginMember(member));
         refreshTokenService.save(renewAccessToken, savedRefreshToken);

--- a/src/test/java/com/stumeet/server/common/auth/filter/OAuthAuthenticationFilterTest.java
+++ b/src/test/java/com/stumeet/server/common/auth/filter/OAuthAuthenticationFilterTest.java
@@ -10,9 +10,12 @@ import com.stumeet.server.template.ApiTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.http.HttpStatus;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.transaction.annotation.Transactional;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static org.springframework.cloud.contract.spec.internal.MediaTypes.APPLICATION_JSON;
@@ -28,6 +31,11 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WireMockTest(httpPort = 8089)
 @Transactional
 class OAuthAuthenticationFilterTest extends ApiTest {
+
+    @Container
+    @ServiceConnection
+    private static GenericContainer<?> REDIS_CONTAINER = new GenericContainer<>(REDIS_CONTAINER_VERSION)
+            .withExposedPorts(6379);
 
     @Nested
     @DisplayName("OAuth2를 이용한 소셜 로그인")

--- a/src/test/java/com/stumeet/server/common/auth/filter/OAuthAuthenticationFilterTest.java
+++ b/src/test/java/com/stumeet/server/common/auth/filter/OAuthAuthenticationFilterTest.java
@@ -5,6 +5,7 @@ import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import com.stumeet.server.common.auth.model.AuthenticationHeader;
 import com.stumeet.server.member.domain.OAuthProvider;
 import com.stumeet.server.stub.MemberStub;
+import com.stumeet.server.stub.TokenStub;
 import com.stumeet.server.template.ApiTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -29,7 +30,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 class OAuthAuthenticationFilterTest extends ApiTest {
 
     @Nested
-    @DisplayName("OAuth2를 이용한 소셜 로그인 필터")
+    @DisplayName("OAuth2를 이용한 소셜 로그인")
     class oauthLogin {
         private final String path = "/api/v1/oauth";
 
@@ -39,7 +40,7 @@ class OAuthAuthenticationFilterTest extends ApiTest {
             mockSuccessKakaoTokenInfoApi();
 
             mockMvc.perform(post(path)
-                            .header(AuthenticationHeader.ACCESS_TOKEN.getName(), MemberStub.getKakaoAccessToken())
+                            .header(AuthenticationHeader.ACCESS_TOKEN.getName(), TokenStub.getKakaoAccessToken())
                             .header(AuthenticationHeader.X_OAUTH_PROVIDER.getName(), OAuthProvider.KAKAO.getProvider()))
                     .andExpect(status().isOk())
                     .andDo(document("social_login/success",
@@ -66,7 +67,7 @@ class OAuthAuthenticationFilterTest extends ApiTest {
             mockFailKakaoTokenInfoApi();
 
             mockMvc.perform(post(path)
-                            .header(AuthenticationHeader.ACCESS_TOKEN.getName(), MemberStub.getKakaoAccessToken())
+                            .header(AuthenticationHeader.ACCESS_TOKEN.getName(), TokenStub.getKakaoAccessToken())
                             .header(AuthenticationHeader.X_OAUTH_PROVIDER.getName(), OAuthProvider.KAKAO.getProvider()))
                     .andExpect(status().isUnauthorized())
                     .andDo(document("social_login/fail/invalid-token",
@@ -103,7 +104,7 @@ class OAuthAuthenticationFilterTest extends ApiTest {
         private void mockFailKakaoTokenInfoApi() {
             stubFor(
                     WireMock.get(WireMock.urlEqualTo("/v1/user/access_token_info"))
-                            .withHeader(AuthenticationHeader.ACCESS_TOKEN.getName(), equalTo(MemberStub.getInvalidKakaoAccessToken()))
+                            .withHeader(AuthenticationHeader.ACCESS_TOKEN.getName(), equalTo(TokenStub.getInvalidKakaoAccessToken()))
                             .willReturn(aResponse()
                                     .withStatus(HttpStatus.UNAUTHORIZED.value())
                                     .withHeader("content-type", APPLICATION_JSON)
@@ -115,7 +116,7 @@ class OAuthAuthenticationFilterTest extends ApiTest {
         private void mockSuccessKakaoTokenInfoApi() {
             stubFor(
                     WireMock.get(WireMock.urlEqualTo("/v1/user/access_token_info"))
-                            .withHeader(AuthenticationHeader.ACCESS_TOKEN.getName(), equalTo(MemberStub.getKakaoAccessToken()))
+                            .withHeader(AuthenticationHeader.ACCESS_TOKEN.getName(), equalTo(TokenStub.getKakaoAccessToken()))
                             .willReturn(aResponse()
                                     .withStatus(HttpStatus.CREATED.value())
                                     .withHeader("content-type", APPLICATION_JSON)

--- a/src/test/java/com/stumeet/server/member/adapter/in/web/MemberAuthApiTest.java
+++ b/src/test/java/com/stumeet/server/member/adapter/in/web/MemberAuthApiTest.java
@@ -9,10 +9,13 @@ import com.stumeet.server.stub.TokenStub;
 import com.stumeet.server.template.ApiTest;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.transaction.annotation.Transactional;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
 
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
@@ -23,6 +26,11 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @Transactional
 class MemberAuthApiTest extends ApiTest {
+
+    @Container
+    @ServiceConnection
+    private static GenericContainer<?> REDIS_CONTAINER = new GenericContainer<>(REDIS_CONTAINER_VERSION)
+            .withExposedPorts(6379);
 
     @Autowired
     private JwtTokenProvider jwtTokenProvider;

--- a/src/test/java/com/stumeet/server/member/adapter/in/web/MemberAuthApiTest.java
+++ b/src/test/java/com/stumeet/server/member/adapter/in/web/MemberAuthApiTest.java
@@ -1,0 +1,85 @@
+package com.stumeet.server.member.adapter.in.web;
+
+import com.stumeet.server.common.token.JwtTokenProvider;
+import com.stumeet.server.member.adapter.out.persistence.JpaMemberRepository;
+import com.stumeet.server.member.adapter.out.persistence.MemberJpaEntity;
+import com.stumeet.server.member.application.port.in.TokenRenewCommand;
+import com.stumeet.server.stub.MemberStub;
+import com.stumeet.server.stub.TokenStub;
+import com.stumeet.server.template.ApiTest;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+@Transactional
+class MemberAuthApiTest extends ApiTest {
+
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
+
+    @Autowired
+    private RedisTemplate<String, String> redisTemplate;
+
+    @Autowired
+    private JpaMemberRepository jpaMemberRepository;
+
+    @Nested
+    @DisplayName("액세스 토큰 재발급")
+    class tokenRenew {
+
+        private final String path = "/api/v1/tokens";
+
+        private String refreshToken;
+
+        @BeforeEach
+        void setUp() {
+            MemberJpaEntity entity = jpaMemberRepository.save(MemberStub.getMemberEntity());
+            refreshToken = jwtTokenProvider.generateRefreshToken(entity.getId());
+            redisTemplate.opsForValue()
+                    .set(TokenStub.getExpiredAccessToken(), refreshToken);
+        }
+
+        @AfterEach
+        void tearDown() {
+            redisTemplate.getConnectionFactory()
+                    .getConnection()
+                    .serverCommands()
+                    .flushAll();
+        }
+
+        @Test
+        @DisplayName("[성공] 액세스 토큰 재발급에 성공합니다.")
+        void successTest() throws Exception {
+            mockMvc.perform(post(path)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(toJson(new TokenRenewCommand(TokenStub.getExpiredAccessToken(), refreshToken)))
+                    ).andExpect(status().isOk())
+                    .andDo(document("token_renew/success",
+                                    preprocessRequest(prettyPrint()),
+                                    preprocessResponse(prettyPrint()),
+                                    requestFields(
+                                            fieldWithPath("accessToken").type(JsonFieldType.STRING).description("서버로 부터 전달받은 액세스 토큰"),
+                                            fieldWithPath("refreshToken").type(JsonFieldType.STRING).description("서버로 부터 전달받은 리프레시 토큰")
+                                    ),
+                                    responseFields(
+                                            fieldWithPath("code").type(JsonFieldType.NUMBER).description("응답에 대한 결과 코드"),
+                                            fieldWithPath("message").type(JsonFieldType.STRING).description("응답에 대한 메시지"),
+                                            fieldWithPath("data.accessToken").type(JsonFieldType.STRING).description("액세스 토큰")
+                                    )
+                            )
+                    );
+        }
+
+    }
+
+}

--- a/src/test/java/com/stumeet/server/stub/MemberStub.java
+++ b/src/test/java/com/stumeet/server/stub/MemberStub.java
@@ -1,5 +1,9 @@
 package com.stumeet.server.stub;
 
+import com.stumeet.server.member.adapter.out.persistence.MemberJpaEntity;
+import com.stumeet.server.member.domain.AuthType;
+import com.stumeet.server.member.domain.UserRole;
+
 public class MemberStub {
 
     private MemberStub() {
@@ -10,15 +14,18 @@ public class MemberStub {
         return "{\"expiresInMillis\":20978166,\"id\":1,\"expires_in\":20978,\"app_id\":1,\"appId\":1}";
     }
 
-    public static String getKakaoAccessToken() {
-        return "rjdizj7Ae09H0oWlW46Oll9_x7AhzaJkp1gKKwzTAAABjd_1h0EhI_W2iN1234";
-    }
 
-    public static String getInvalidKakaoAccessToken() {
-        return "invalidToken";
-    }
 
     public static String getInvalidKakaoAccessTokenInfo() {
         return "{\"msg\":\"this access token does not exist\",\"code\":-401}";
+    }
+
+    public static MemberJpaEntity getMemberEntity() {
+        return MemberJpaEntity.builder()
+                .id(1L)
+                .role(UserRole.FIRST_LOGIN)
+                .authType(AuthType.OAUTH)
+                .sugarContents(0.0)
+                .build();
     }
 }

--- a/src/test/java/com/stumeet/server/stub/TokenStub.java
+++ b/src/test/java/com/stumeet/server/stub/TokenStub.java
@@ -1,0 +1,18 @@
+package com.stumeet.server.stub;
+
+public class TokenStub {
+
+    private TokenStub() {}
+
+    public static String getKakaoAccessToken() {
+        return "rjdizj7Ae09H0oWlW46Oll9_x7AhzaJkp1gKKwzTAAABjd_1h0EhI_W2iN1234";
+    }
+
+    public static String getInvalidKakaoAccessToken() {
+        return "invalidToken";
+    }
+
+    public static String getExpiredAccessToken() {
+        return "eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJTVFVNRUVUIiwic3ViIjoiMSIsImF1dGgiOiJGSVJTVF9MT0dJTiIsImV4cCI6MTcwOTAzOTIzNH0.5EPRp2zAJgXCOMgGKASF586R44o6U8-fla-IqTsrDBA";
+    }
+}

--- a/src/test/java/com/stumeet/server/template/ApiTest.java
+++ b/src/test/java/com/stumeet/server/template/ApiTest.java
@@ -32,18 +32,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 @Testcontainers
 public abstract class ApiTest {
 
-    private static final DockerImageName REDIS_CONTAINER_VERSION = DockerImageName.parse("redis:5.0.3-alpine");
+    protected static final DockerImageName REDIS_CONTAINER_VERSION = DockerImageName.parse("redis:5.0.3-alpine");
 
     protected MockMvc mockMvc;
 
     @Autowired
     protected ObjectMapper objectMapper;
-
-    @Container
-    @ServiceConnection
-    private static GenericContainer<?> REDIS_CONTAINER = new GenericContainer<>(REDIS_CONTAINER_VERSION)
-            .withExposedPorts(6379)
-            .withReuse(true);
 
     @BeforeEach
     void setUpMockMvc(WebApplicationContext context, RestDocumentationContextProvider provider) {


### PR DESCRIPTION
## 💁 해결 하려는 문제를 적어주세요 

- 토큰 재발급 API 문서화 (성공)
- 토큰 재발급시 액세스 토큰이 만료된 상태라면 실패하는 버그 수정
- 테스트 종료시 레디스 컨테이너를 다시 사용할 수 없는 버그 수정

## 🤔 어떤 방식으로 해결했는지 적어주세요 

- Restdocs를 이용한 토큰 재발급 API 문서화
- 리프레시 토큰을 이용하여 유저 정보를 확인하도록 변경
- 각 테스트마다 레디스 컨테이너를 사용하도록 변경
