### PR TITLE
✅ [STMT-146] 토큰 재발급 API 실패 응답 테스트 작성

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -51,6 +51,24 @@ include::{snippets}/token_renew/success/request-fields.adoc[]
 include::{snippets}/token_renew/success/response-body.adoc[]
 include::{snippets}/token_renew/success/response-fields.adoc[]
 
+==== 응답 실패(400)
+.액세스 토큰과 매칭되는 리프레시 토큰이 없는 경우
+include::{snippets}/token_renew/fail/not-match-access-token/response-body.adoc[]
+include::{snippets}/token_renew/fail/not-match-access-token/response-fields.adoc[]
+
+.액세스 토큰이나 리프레시 토큰이 전달되지 않은 경우
+include::{snippets}/token_renew/fail/not-exist-request/response-body.adoc[]
+include::{snippets}/token_renew/fail/not-exist-request/response-fields.adoc[]
+
+.전달받은 리프레시 토큰과 서버의 리프레시 토큰이 다른 경우
+include::{snippets}/token_renew/fail/not-matched-refresh-token/response-body.adoc[]
+include::{snippets}/token_renew/fail/not-matched-refresh-token/response-fields.adoc[]
+
+.리프레시 토큰이 만료된 경우
+include::{snippets}/token_renew/fail/expired-refresh-token/response-body.adoc[]
+include::{snippets}/token_renew/fail/expired-refresh-token/response-fields.adoc[]
+
+
 == 분야 정보 전체 조회
 
 === GET /api/v1/professions

--- a/src/main/java/com/stumeet/server/common/response/ErrorCode.java
+++ b/src/main/java/com/stumeet/server/common/response/ErrorCode.java
@@ -21,7 +21,9 @@ public enum ErrorCode {
     INVALID_FILE_EXTENSION_EXCEPTION(HttpStatus.BAD_REQUEST, "잘못된 파일 확장자입니다."),
     DUPLICATE_NICKNAME_EXCEPTION(HttpStatus.BAD_REQUEST, "닉네임이 중복되었습니다."),
     NOT_EXIST_EXCEPTION(HttpStatus.BAD_REQUEST, "요청으로 전달한 값이 존재하지 않습니다."),
-
+    NOT_MATCHED_TOKEN_EXCEPTION(HttpStatus.BAD_REQUEST, "요청으로 전달한 토큰과 매칭되는 토큰이 없습니다."),
+    NOT_MATCHED_REFRESH_TOKEN_EXCEPTION(HttpStatus.BAD_REQUEST, "요청으로 전달한 리프레시 토큰과 서버의 리프레시 토큰이 일치하지 않습니다."),
+    EXPIRED_REFRESH_TOKEN_EXCEPTION(HttpStatus.BAD_REQUEST, "리프레시 토큰이 만료되었습니다."),
 
     /*
         500 - INTERNAL SERVER ERROR

--- a/src/main/java/com/stumeet/server/common/token/JwtTokenProvider.java
+++ b/src/main/java/com/stumeet/server/common/token/JwtTokenProvider.java
@@ -78,6 +78,7 @@ public class JwtTokenProvider {
         } catch (JwtException e) {
             log.warn("신뢰할 수 없는 JWT 토큰 입니다.", e);
         }
+
         return false;
     }
 

--- a/src/main/java/com/stumeet/server/common/token/repository/RefreshTokenRepositoryImpl.java
+++ b/src/main/java/com/stumeet/server/common/token/repository/RefreshTokenRepositoryImpl.java
@@ -1,8 +1,11 @@
 package com.stumeet.server.common.token.repository;
 
+import com.stumeet.server.common.exception.model.BusinessException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Repository;
+
+import static com.stumeet.server.common.response.ErrorCode.NOT_MATCHED_TOKEN_EXCEPTION;
 
 @Repository
 @RequiredArgsConstructor
@@ -21,7 +24,7 @@ public class RefreshTokenRepositoryImpl implements RefreshTokenRepository {
     public String getByAccessToken(String accessToken) {
         String refreshToken = redisTemplate.opsForValue().get(accessToken);
         if (refreshToken == null) {
-            throw new IllegalArgumentException("전달받은 Access Token과 매칭되는 Refresh Token이 존재하지 않습니다.");
+            throw new BusinessException(NOT_MATCHED_TOKEN_EXCEPTION);
         }
 
         return refreshToken;
@@ -31,7 +34,7 @@ public class RefreshTokenRepositoryImpl implements RefreshTokenRepository {
     public void deleteByAccessToken(String accessToken) {
         boolean isDeleted = Boolean.TRUE.equals(redisTemplate.delete(accessToken));
         if (!isDeleted) {
-            throw new IllegalArgumentException("전달받은 Access Token과 매칭되는 Refresh Token이 존재하지 않습니다.");
+            throw new BusinessException(NOT_MATCHED_TOKEN_EXCEPTION);
         }
     }
 }

--- a/src/main/java/com/stumeet/server/common/token/service/RefreshTokenService.java
+++ b/src/main/java/com/stumeet/server/common/token/service/RefreshTokenService.java
@@ -1,5 +1,7 @@
 package com.stumeet.server.common.token.service;
 
+import com.stumeet.server.common.exception.model.BusinessException;
+import com.stumeet.server.common.response.ErrorCode;
 import com.stumeet.server.common.token.JwtTokenProvider;
 import com.stumeet.server.common.token.repository.RefreshTokenRepository;
 import lombok.RequiredArgsConstructor;
@@ -22,11 +24,11 @@ public class RefreshTokenService {
         String savedRefreshToken = refreshTokenRepository.getByAccessToken(accessToken);
 
         if (!refreshToken.equals(savedRefreshToken)) {
-            throw new IllegalArgumentException(
-                    MessageFormat.format("리프레시 토큰이 일치하지 않습니다.\n전달받은 토큰 : {} 저장된 토큰{}", refreshToken, savedRefreshToken)
-            );
+            throw new BusinessException(ErrorCode.NOT_MATCHED_REFRESH_TOKEN_EXCEPTION);
         }
-        jwtTokenProvider.validateToken(refreshToken);
+        if (!jwtTokenProvider.validateToken(refreshToken)) {
+            throw new BusinessException(ErrorCode.EXPIRED_REFRESH_TOKEN_EXCEPTION);
+        }
 
         return savedRefreshToken;
     }

--- a/src/test/java/com/stumeet/server/stub/TokenStub.java
+++ b/src/test/java/com/stumeet/server/stub/TokenStub.java
@@ -5,7 +5,7 @@ public class TokenStub {
     private TokenStub() {}
 
     public static String getKakaoAccessToken() {
-        return "rjdizj7Ae09H0oWlW46Oll9_x7AhzaJkp1gKKwzTAAABjd_1h0EhI_W2iN1234";
+        return "Bearer rjdizj7Ae09H0oWlW46Oll9_x7AhzaJkp1gKKwzTAAABjd_1h0EhI_W2iN1234";
     }
 
     public static String getInvalidKakaoAccessToken() {
@@ -17,6 +17,6 @@ public class TokenStub {
     }
 
     public static String getMockAccessToken() {
-        return "eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJTVFVNRUVUIiwic3ViIjoiMSIsImF1dGgiOiJGSVJTVF9MT0dJTiIsImV4cCI6MTcwOTA0MTM1Mn0.1dU2fb1wUgJeV8R1RAjFpKxBg3qToRZnft1lxSejL7o";
+        return "Bearer eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJTVFVNRUVUIiwic3ViIjoiMSIsImF1dGgiOiJGSVJTVF9MT0dJTiIsImV4cCI6MTcwOTA0MTM1Mn0.1dU2fb1wUgJeV8R1RAjFpKxBg3qToRZnft1lxSejL7o";
     }
 }

--- a/src/test/java/com/stumeet/server/stub/TokenStub.java
+++ b/src/test/java/com/stumeet/server/stub/TokenStub.java
@@ -16,7 +16,15 @@ public class TokenStub {
         return "eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJTVFVNRUVUIiwic3ViIjoiMSIsImF1dGgiOiJGSVJTVF9MT0dJTiIsImV4cCI6MTcwOTAzOTIzNH0.5EPRp2zAJgXCOMgGKASF586R44o6U8-fla-IqTsrDBA";
     }
 
+    public static String getInvalidToken() {
+        return "invalidToken";
+    }
     public static String getMockAccessToken() {
         return "Bearer eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJTVFVNRUVUIiwic3ViIjoiMSIsImF1dGgiOiJGSVJTVF9MT0dJTiIsImV4cCI6MTcwOTA0MTM1Mn0.1dU2fb1wUgJeV8R1RAjFpKxBg3qToRZnft1lxSejL7o";
     }
+
+    public static String getExpiredRefreshToken() {
+        return "eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJTVFVNRUVUIiwiaWF0IjoxNzA5MTkzMzgwLCJzdWIiOiIxIiwiZXhwIjoxNzA5MTkzMzgwfQ.faFrP-sNlCnu5vGPfl0vQieMZ_Iydk_UjhaYIkhz4P4";
+    }
+
 }


### PR DESCRIPTION
## 💁 해결 하려는 문제를 적어주세요 

- 토큰 재발급 API 실패 응답에 대한 문서화 및 테스트 코드 작성
- API 문서에 Authorization Header에 Bearer 토큰 정보 누락

## 🤔 어떤 방식으로 해결했는지 적어주세요 

- API 문서에 Authorization Header에 Bearer 토큰 정보 추가하도록 변경
- 토큰 재발급 API에 실패 응답에 대한 문서화 및 테스트 코드 작성