### PR TITLE
:bug: [STMT-146] 로그아웃 API 테스트시 Redis 컨테이너를 띄우도록 변경

### DIFF
--- a/src/test/java/com/stumeet/server/common/auth/filter/LogoutFilterTest.java
+++ b/src/test/java/com/stumeet/server/common/auth/filter/LogoutFilterTest.java
@@ -13,9 +13,12 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.transaction.annotation.Transactional;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
 
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
@@ -28,6 +31,11 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @Transactional
 public class LogoutFilterTest extends ApiTest {
+
+    @Container
+    @ServiceConnection
+    private static GenericContainer<?> REDIS_CONTAINER = new GenericContainer<>(REDIS_CONTAINER_VERSION)
+            .withExposedPorts(6379);
 
     @Autowired
     private JpaMemberRepository jpaMemberRepository;


### PR DESCRIPTION
## 💁 해결 하려는 문제를 적어주세요 

- 로그아웃 테스트시 테스트가 실패하는 증상 발생

## 🤔 어떤 방식으로 해결했는지 적어주세요 

- 레디스 컨테이너가 띄워지지 않아 발생한 문제로 레디스 컨테이너를 띄워서 문제 해결