### PR TITLE
✨ [STMT-90] 내 정보 수정 API 구현

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -144,6 +144,24 @@ include::{snippets}/validate_nickname/fail/invalid/response-fields.adoc[]
 include::{snippets}/validate_nickname/fail/duplicate/response-body.adoc[]
 include::{snippets}/validate_nickname/fail/duplicate/response-fields.adoc[]
 
+=== 사용자 정보 수정
+
+==== PATCH /api/v1/members/me
+
+===== 요청
+include::{snippets}/update-my-profile/success/http-request.adoc[]
+include::{snippets}/update-my-profile/success/request-headers.adoc[]
+include::{snippets}/update-my-profile/success/request-parts.adoc[]
+include::{snippets}/update-my-profile/success/query-parameters.adoc[]
+
+===== 응답 성공 (200)
+include::{snippets}/update-my-profile/success/response-body.adoc[]
+include::{snippets}/update-my-profile/success/response-fields.adoc[]
+
+===== 응답 실패 (400)
+include::{snippets}/update-my-profile/fail/invalid-request/response-body.adoc[]
+include::{snippets}/update-my-profile/fail/invalid-request/response-fields.adoc[]
+
 == 분야 관리
 === 분야 정보 전체 조회
 

--- a/src/main/java/com/stumeet/server/common/annotation/validator/NullOrImageFile.java
+++ b/src/main/java/com/stumeet/server/common/annotation/validator/NullOrImageFile.java
@@ -1,0 +1,18 @@
+package com.stumeet.server.common.annotation.validator;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = NullOrImageFileValidator.class)
+@Target({ElementType.FIELD })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface NullOrImageFile {
+    String message() default "값이 전달되지 않거나 이미지 파일이어야 합니다.";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/stumeet/server/common/annotation/validator/NullOrImageFileValidator.java
+++ b/src/main/java/com/stumeet/server/common/annotation/validator/NullOrImageFileValidator.java
@@ -1,0 +1,17 @@
+package com.stumeet.server.common.annotation.validator;
+
+import com.stumeet.server.common.util.FileUtil;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import org.springframework.web.multipart.MultipartFile;
+
+public class NullOrImageFileValidator implements ConstraintValidator<NullOrImageFile, MultipartFile> {
+    @Override
+    public boolean isValid(MultipartFile value, ConstraintValidatorContext context) {
+        if (value == null) {
+            return true;
+        }
+
+        return FileUtil.isImageFile(value.getOriginalFilename());
+    }
+}

--- a/src/main/java/com/stumeet/server/common/annotation/validator/NullOrNotBlank.java
+++ b/src/main/java/com/stumeet/server/common/annotation/validator/NullOrNotBlank.java
@@ -1,0 +1,18 @@
+package com.stumeet.server.common.annotation.validator;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = NullOrNotBlankValidator.class)
+@Target({ElementType.FIELD })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface NullOrNotBlank {
+    String message() default "값이 전달되지 않거나 빈 문자열이 아니어야 합니다.";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/stumeet/server/common/annotation/validator/NullOrNotBlankValidator.java
+++ b/src/main/java/com/stumeet/server/common/annotation/validator/NullOrNotBlankValidator.java
@@ -1,0 +1,16 @@
+package com.stumeet.server.common.annotation.validator;
+
+import io.micrometer.common.util.StringUtils;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class NullOrNotBlankValidator implements ConstraintValidator<NullOrNotBlank, String> {
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        if (value == null) {
+            return true;
+        }
+
+        return StringUtils.isNotBlank(value);
+    }
+}

--- a/src/main/java/com/stumeet/server/common/annotation/validator/NullOrPositive.java
+++ b/src/main/java/com/stumeet/server/common/annotation/validator/NullOrPositive.java
@@ -1,0 +1,18 @@
+package com.stumeet.server.common.annotation.validator;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = NullOrPositiveValidator.class)
+@Target({ElementType.FIELD })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface NullOrPositive {
+    String message() default "값이 전달되지 않거나 양수여야 합니다.";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/stumeet/server/common/annotation/validator/NullOrPositiveValidator.java
+++ b/src/main/java/com/stumeet/server/common/annotation/validator/NullOrPositiveValidator.java
@@ -1,0 +1,15 @@
+package com.stumeet.server.common.annotation.validator;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class NullOrPositiveValidator implements ConstraintValidator<NullOrPositive, Long> {
+    @Override
+    public boolean isValid(Long value, ConstraintValidatorContext context) {
+        if (value == null) {
+            return true;
+        }
+
+        return value > 0;
+    }
+}

--- a/src/main/java/com/stumeet/server/common/annotation/validator/NullOrValidSize.java
+++ b/src/main/java/com/stumeet/server/common/annotation/validator/NullOrValidSize.java
@@ -1,0 +1,22 @@
+package com.stumeet.server.common.annotation.validator;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.*;
+
+
+@Documented
+@Constraint(validatedBy = NullOrValidSizeValidator.class)
+@Target({ElementType.FIELD })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface NullOrValidSize {
+    String message() default "값이 전달되지 않거나 유효한 크기여야 합니다.";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+
+    int min() default 0;
+    int max() default 255;
+}

--- a/src/main/java/com/stumeet/server/common/annotation/validator/NullOrValidSizeValidator.java
+++ b/src/main/java/com/stumeet/server/common/annotation/validator/NullOrValidSizeValidator.java
@@ -1,0 +1,23 @@
+package com.stumeet.server.common.annotation.validator;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class NullOrValidSizeValidator implements ConstraintValidator<NullOrValidSize, String> {
+    private int min;
+    private int max;
+
+    @Override
+    public void initialize(NullOrValidSize constraintAnnotation) {
+        min = constraintAnnotation.min();
+        max = constraintAnnotation.max();
+    }
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        if (value == null) {
+            return true;
+        }
+        return value.length() >= min && value.length() <= max;
+    }
+}

--- a/src/main/java/com/stumeet/server/common/auth/config/SecurityConfig.java
+++ b/src/main/java/com/stumeet/server/common/auth/config/SecurityConfig.java
@@ -9,6 +9,7 @@ import com.stumeet.server.common.auth.handler.OAuthAuthenticationSuccessHandler;
 import com.stumeet.server.common.auth.service.JwtAuthenticationService;
 import com.stumeet.server.common.auth.service.OAuthAuthenticationProvider;
 import com.stumeet.server.common.token.JwtTokenProvider;
+import com.stumeet.server.member.domain.UserRole;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -69,8 +70,9 @@ public class SecurityConfig {
             auth.requestMatchers(HttpMethod.POST, "/api/v1/tokens").permitAll();
             auth.requestMatchers("/h2-console/**").permitAll();
             auth.requestMatchers("/docs/**").permitAll();
-            auth.requestMatchers("/api/v1/signup").hasAnyAuthority("FIRST_LOGIN");
-            auth.anyRequest().authenticated();
+            auth.requestMatchers("/api/v1/signup").hasAnyAuthority(UserRole.FIRST_LOGIN.toString());
+            auth.requestMatchers("/api/v1/professions").hasAnyAuthority(UserRole.FIRST_LOGIN.toString(), UserRole.MEMBER.toString());
+            auth.anyRequest().hasAnyAuthority(UserRole.MEMBER.toString());
         });
 
         http.securityContext(securityContext -> securityContext.securityContextRepository(securityContextRepository()));

--- a/src/main/java/com/stumeet/server/common/util/FileUtil.java
+++ b/src/main/java/com/stumeet/server/common/util/FileUtil.java
@@ -29,21 +29,31 @@ public class FileUtil {
 			throw new BusinessException(ErrorCode.INVALID_IMAGE_EXCEPTION);
 		}
 
-		String contentType = fileName
-			.substring(fileName.lastIndexOf(".") + 1)
-			.toLowerCase(Locale.ROOT);
+        String contentType = extractContentType(fileName);
 
-		if (!VALID_CONTENT_TYPES.contains(contentType)) {
+        if (!VALID_CONTENT_TYPES.contains(contentType)) {
 			throw new BusinessException(ErrorCode.INVALID_FILE_EXTENSION_EXCEPTION);
 		}
 
 		return contentType;
 	}
 
-	public static String createFileName(String directoryPath, String fileName) {
+    private static String extractContentType(String fileName) {
+        return fileName
+            .substring(fileName.lastIndexOf(".") + 1)
+            .toLowerCase(Locale.ROOT);
+    }
+
+    public static String createFileName(String directoryPath, String fileName) {
 		String dateTime = LocalDateTime.now()
 			.format(DateTimeFormatter.ofPattern("yyyyMMddHHmmss"));
 
 		return String.format("%s/%s%s-%s", directoryPath, dateTime, UUID.randomUUID(), fileName);
+	}
+
+	public static boolean isImageFile(String fileName) {
+        String contentType = extractContentType(fileName);
+
+        return VALID_CONTENT_TYPES.contains(contentType);
 	}
 }

--- a/src/main/java/com/stumeet/server/member/adapter/in/web/MemberAuthApi.java
+++ b/src/main/java/com/stumeet/server/member/adapter/in/web/MemberAuthApi.java
@@ -4,9 +4,10 @@ import com.stumeet.server.common.annotation.WebAdapter;
 import com.stumeet.server.common.auth.model.LoginMember;
 import com.stumeet.server.common.model.ApiResponse;
 import com.stumeet.server.member.adapter.in.web.response.TokenResponse;
-import com.stumeet.server.member.application.port.in.MemberAuthUseCase;
-import com.stumeet.server.member.application.port.in.MemberSignupCommand;
-import com.stumeet.server.member.application.port.in.TokenRenewCommand;
+import com.stumeet.server.member.application.port.in.MemberProfileUseCase;
+import com.stumeet.server.member.application.port.in.MemberTokenUseCase;
+import com.stumeet.server.member.application.port.in.command.MemberSignupCommand;
+import com.stumeet.server.member.application.port.in.command.TokenRenewCommand;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -21,14 +22,15 @@ import org.springframework.web.bind.annotation.RequestMapping;
 @RequiredArgsConstructor
 public class MemberAuthApi {
 
-    private final MemberAuthUseCase memberAuthUseCase;
+    private final MemberTokenUseCase memberTokenUseCase;
+    private final MemberProfileUseCase memberProfileUseCase;
 
     @PostMapping("/signup")
     public ResponseEntity<ApiResponse<Void>> signup(
             @AuthenticationPrincipal LoginMember loginMember,
             @Valid MemberSignupCommand request
     ) {
-        memberAuthUseCase.signup(loginMember.getMember(), request);
+        memberProfileUseCase.signup(loginMember.getMember(), request);
 
         return new ResponseEntity<>(
                 ApiResponse.success(HttpStatus.OK.value(), "회원가입에 성공했습니다."),
@@ -40,7 +42,7 @@ public class MemberAuthApi {
     public ResponseEntity<ApiResponse<TokenResponse>> renewAccessToken(
             @RequestBody @Valid TokenRenewCommand request
     ) {
-        TokenResponse response = memberAuthUseCase.renewAccessToken(request);
+        TokenResponse response = memberTokenUseCase.renewAccessToken(request);
 
         return new ResponseEntity<>(
                 ApiResponse.success(HttpStatus.OK.value(), "액세스 토큰 재발급에 성공했습니다.", response),

--- a/src/main/java/com/stumeet/server/member/adapter/in/web/MemberProfileApi.java
+++ b/src/main/java/com/stumeet/server/member/adapter/in/web/MemberProfileApi.java
@@ -1,0 +1,34 @@
+package com.stumeet.server.member.adapter.in.web;
+
+import com.stumeet.server.common.annotation.WebAdapter;
+import com.stumeet.server.common.auth.model.LoginMember;
+import com.stumeet.server.common.model.ApiResponse;
+import com.stumeet.server.member.application.port.in.MemberProfileUseCase;
+import com.stumeet.server.member.application.port.in.command.MemberUpdateCommand;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@WebAdapter
+@RequestMapping("/api/v1/members")
+@RequiredArgsConstructor
+public class MemberProfileApi {
+
+    private final MemberProfileUseCase memberProfileUseCase;
+
+    @PatchMapping("/me")
+    public ResponseEntity<ApiResponse<Void>> updateMyProfile(
+            @AuthenticationPrincipal LoginMember member,
+            @Valid MemberUpdateCommand request
+    ) {
+        memberProfileUseCase.updateProfile(member.getMember(), request);
+        return new ResponseEntity<>(
+                ApiResponse.success(HttpStatus.OK.value(), "내 프로필 수정에 성공했습니다."),
+                HttpStatus.OK
+        );
+    }
+}

--- a/src/main/java/com/stumeet/server/member/application/port/in/MemberProfileUseCase.java
+++ b/src/main/java/com/stumeet/server/member/application/port/in/MemberProfileUseCase.java
@@ -1,0 +1,11 @@
+package com.stumeet.server.member.application.port.in;
+
+import com.stumeet.server.member.application.port.in.command.MemberSignupCommand;
+import com.stumeet.server.member.application.port.in.command.MemberUpdateCommand;
+import com.stumeet.server.member.domain.Member;
+
+public interface MemberProfileUseCase {
+    void signup(Member member, MemberSignupCommand request);
+
+    void updateProfile(Member member, MemberUpdateCommand request);
+}

--- a/src/main/java/com/stumeet/server/member/application/port/in/MemberTokenUseCase.java
+++ b/src/main/java/com/stumeet/server/member/application/port/in/MemberTokenUseCase.java
@@ -1,11 +1,11 @@
 package com.stumeet.server.member.application.port.in;
 
 import com.stumeet.server.member.adapter.in.web.response.TokenResponse;
-import com.stumeet.server.member.domain.Member;
+import com.stumeet.server.member.application.port.in.command.TokenRenewCommand;
 
-public interface MemberAuthUseCase {
+public interface MemberTokenUseCase {
 
-    void signup(Member member, MemberSignupCommand request);
+
 
     TokenResponse renewAccessToken(TokenRenewCommand request);
 }

--- a/src/main/java/com/stumeet/server/member/application/port/in/command/MemberProfileCommand.java
+++ b/src/main/java/com/stumeet/server/member/application/port/in/command/MemberProfileCommand.java
@@ -1,0 +1,14 @@
+package com.stumeet.server.member.application.port.in.command;
+
+import com.stumeet.server.profession.domain.Profession;
+import lombok.Builder;
+
+
+@Builder
+public record MemberProfileCommand(
+        Profession profession,
+        String url,
+        String nickname,
+        String region
+) {
+}

--- a/src/main/java/com/stumeet/server/member/application/port/in/command/MemberSignupCommand.java
+++ b/src/main/java/com/stumeet/server/member/application/port/in/command/MemberSignupCommand.java
@@ -1,7 +1,8 @@
-package com.stumeet.server.member.application.port.in;
+package com.stumeet.server.member.application.port.in.command;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.Size;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -16,7 +17,7 @@ public record MemberSignupCommand(
         @NotBlank(message = "지역을 입력해주세요")
         String region,
 
-        @NotNull(message = "분야를 선택해주세요")
+        @Positive(message = "분야를 선택해주세요")
         Long profession
 ) {
 }

--- a/src/main/java/com/stumeet/server/member/application/port/in/command/MemberUpdateCommand.java
+++ b/src/main/java/com/stumeet/server/member/application/port/in/command/MemberUpdateCommand.java
@@ -1,0 +1,22 @@
+package com.stumeet.server.member.application.port.in.command;
+
+import com.stumeet.server.common.annotation.validator.NullOrImageFile;
+import com.stumeet.server.common.annotation.validator.NullOrNotBlank;
+import com.stumeet.server.common.annotation.validator.NullOrPositive;
+import com.stumeet.server.common.annotation.validator.NullOrValidSize;
+import org.springframework.web.multipart.MultipartFile;
+
+public record MemberUpdateCommand(
+        @NullOrImageFile(message = "이미지 파일을 첨부해주세요")
+        MultipartFile image,
+
+        @NullOrValidSize(min = 2, max = 10, message = "닉네임을 2 ~ 10자로 입력해주세요")
+        String nickname,
+
+        @NullOrNotBlank(message = "지역을 입력해주세요")
+        String region,
+
+        @NullOrPositive(message = "존재하지 않는 분야입니다.")
+        Long profession
+) {
+}

--- a/src/main/java/com/stumeet/server/member/application/port/in/command/TokenRenewCommand.java
+++ b/src/main/java/com/stumeet/server/member/application/port/in/command/TokenRenewCommand.java
@@ -1,4 +1,4 @@
-package com.stumeet.server.member.application.port.in;
+package com.stumeet.server.member.application.port.in.command;
 
 import jakarta.validation.constraints.NotBlank;
 

--- a/src/main/java/com/stumeet/server/member/application/service/MemberProfileService.java
+++ b/src/main/java/com/stumeet/server/member/application/service/MemberProfileService.java
@@ -1,0 +1,65 @@
+package com.stumeet.server.member.application.service;
+
+import com.stumeet.server.common.annotation.UseCase;
+import com.stumeet.server.file.application.port.in.FileUploadUseCase;
+import com.stumeet.server.member.application.port.in.MemberProfileUseCase;
+import com.stumeet.server.member.application.port.in.command.MemberProfileCommand;
+import com.stumeet.server.member.application.port.in.command.MemberSignupCommand;
+import com.stumeet.server.member.application.port.in.command.MemberUpdateCommand;
+import com.stumeet.server.member.application.port.out.MemberCommandPort;
+import com.stumeet.server.member.domain.Member;
+import com.stumeet.server.profession.application.port.in.ProfessionQueryUseCase;
+import com.stumeet.server.profession.domain.Profession;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+@UseCase
+@RequiredArgsConstructor
+@Transactional
+public class MemberProfileService implements MemberProfileUseCase {
+
+    private final ProfessionQueryUseCase professionQueryUseCase;
+    private final FileUploadUseCase fileUploadUseCase;
+    private final MemberCommandPort memberCommandPort;
+
+    @Override
+    public void signup(Member member, MemberSignupCommand request) {
+        Profession profession = professionQueryUseCase.getById(request.profession());
+        String url = fileUploadUseCase.uploadUserProfileImage(member.getId(), request.image()).url();
+
+        MemberProfileCommand command = MemberProfileCommand.builder()
+                .profession(profession)
+                .url(url)
+                .nickname(request.nickname())
+                .region(request.region())
+                .build();
+
+        registerProfile(member, command);
+    }
+
+    @Override
+    public void updateProfile(Member member, MemberUpdateCommand request) {
+        Profession profession = request.profession() != null ?
+                professionQueryUseCase.getById(request.profession()) :
+                null;
+
+        String url = request.image() != null ?
+                fileUploadUseCase.uploadUserProfileImage(member.getId(), request.image()).url() :
+                null;
+
+        MemberProfileCommand command = MemberProfileCommand.builder()
+                .profession(profession)
+                .url(url)
+                .nickname(request.nickname())
+                .region(request.region())
+                .build();
+
+        registerProfile(member, command);
+    }
+
+    private void registerProfile(Member member, MemberProfileCommand command) {
+        member.registerWithAdditionalDetails(command);
+
+        memberCommandPort.save(member);
+    }
+}

--- a/src/main/java/com/stumeet/server/member/application/service/MemberTokenService.java
+++ b/src/main/java/com/stumeet/server/member/application/service/MemberTokenService.java
@@ -4,41 +4,22 @@ import com.stumeet.server.common.annotation.UseCase;
 import com.stumeet.server.common.auth.model.LoginMember;
 import com.stumeet.server.common.token.JwtTokenProvider;
 import com.stumeet.server.common.token.service.RefreshTokenService;
-import com.stumeet.server.file.application.port.in.FileUploadUseCase;
-import com.stumeet.server.file.application.port.out.FileUrl;
 import com.stumeet.server.member.adapter.in.web.response.TokenResponse;
-import com.stumeet.server.member.application.port.in.MemberAuthUseCase;
-import com.stumeet.server.member.application.port.in.MemberSignupCommand;
-import com.stumeet.server.member.application.port.in.TokenRenewCommand;
-import com.stumeet.server.member.application.port.out.MemberCommandPort;
+import com.stumeet.server.member.application.port.in.*;
+import com.stumeet.server.member.application.port.in.command.TokenRenewCommand;
 import com.stumeet.server.member.application.port.out.MemberQueryPort;
 import com.stumeet.server.member.domain.Member;
-import com.stumeet.server.profession.application.port.in.ProfessionQueryUseCase;
-import com.stumeet.server.profession.domain.Profession;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
 
 @UseCase
 @Transactional
 @RequiredArgsConstructor
-public class MemberAuthService implements MemberAuthUseCase {
+public class MemberTokenService implements MemberTokenUseCase {
 
-    private final MemberCommandPort memberCommandPort;
     private final MemberQueryPort memberQueryPort;
-    private final FileUploadUseCase fileUploadUseCase;
     private final RefreshTokenService refreshTokenService;
     private final JwtTokenProvider jwtTokenProvider;
-    private final ProfessionQueryUseCase professionQueryUseCase;
-
-    @Override
-    public void signup(Member member, MemberSignupCommand request) {
-        Profession profession = professionQueryUseCase.getById(request.profession());
-        FileUrl url = fileUploadUseCase.uploadUserProfileImage(member.getId(), request.image());
-
-        member.registerWithAdditionalDetails(request, url, profession);
-
-        memberCommandPort.save(member);
-    }
 
     @Override
     public TokenResponse renewAccessToken(TokenRenewCommand request) {

--- a/src/main/java/com/stumeet/server/member/domain/Member.java
+++ b/src/main/java/com/stumeet/server/member/domain/Member.java
@@ -1,7 +1,6 @@
 package com.stumeet.server.member.domain;
 
-import com.stumeet.server.file.application.port.out.FileUrl;
-import com.stumeet.server.member.application.port.in.MemberSignupCommand;
+import com.stumeet.server.member.application.port.in.command.MemberProfileCommand;
 import com.stumeet.server.profession.domain.Profession;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -28,11 +27,11 @@ public class Member {
 
     private UserRole role;
 
-    public void registerWithAdditionalDetails(MemberSignupCommand request, FileUrl profileImage, Profession profession) {
-        this.image = profileImage.url();
-        this.name = request.nickname();
-        this.region = request.region();
-        this.profession = profession;
+    public void registerWithAdditionalDetails(MemberProfileCommand command) {
+        this.image = command.url() == null ? this.image : command.url();
+        this.name = command.nickname() == null ? this.name : command.nickname();
+        this.region = command.region() == null ? this.region : command.region();
+        this.profession = command.profession() == null ? this.profession : command.profession();
         this.role = UserRole.MEMBER;
     }
 }

--- a/src/test/java/com/stumeet/server/member/adapter/in/web/MemberAuthApiTest.java
+++ b/src/test/java/com/stumeet/server/member/adapter/in/web/MemberAuthApiTest.java
@@ -4,8 +4,8 @@ import com.stumeet.server.common.token.JwtTokenProvider;
 import com.stumeet.server.helper.WithMockMember;
 import com.stumeet.server.member.adapter.out.persistence.JpaMemberRepository;
 import com.stumeet.server.member.adapter.out.persistence.MemberJpaEntity;
-import com.stumeet.server.member.application.port.in.MemberSignupCommand;
-import com.stumeet.server.member.application.port.in.TokenRenewCommand;
+import com.stumeet.server.member.application.port.in.command.MemberSignupCommand;
+import com.stumeet.server.member.application.port.in.command.TokenRenewCommand;
 import com.stumeet.server.member.domain.UserRole;
 import com.stumeet.server.stub.MemberStub;
 import com.stumeet.server.stub.TokenStub;
@@ -305,7 +305,7 @@ class MemberAuthApiTest extends ApiTest {
         @DisplayName("[실패] 전달한 분야 정보가 존재하지 않으면 회원가입에 실패합니다.")
         void notExistsProfessionTest() throws Exception {
             MemberSignupCommand request = MemberStub.getMemberSignupCommand();
-            String notExistsProfession = "0";
+            String notExistsProfession = "9999";
 
             mockMvc.perform(multipart(path)
                             .file((MockMultipartFile) request.image())

--- a/src/test/java/com/stumeet/server/member/adapter/in/web/MemberProfileApiTest.java
+++ b/src/test/java/com/stumeet/server/member/adapter/in/web/MemberProfileApiTest.java
@@ -1,0 +1,115 @@
+package com.stumeet.server.member.adapter.in.web;
+
+import com.stumeet.server.common.auth.model.AuthenticationHeader;
+import com.stumeet.server.helper.WithMockMember;
+import com.stumeet.server.member.adapter.out.persistence.JpaMemberRepository;
+import com.stumeet.server.member.application.port.in.command.MemberUpdateCommand;
+import com.stumeet.server.stub.MemberStub;
+import com.stumeet.server.stub.TokenStub;
+import com.stumeet.server.template.ApiTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Transactional
+class MemberProfileApiTest extends ApiTest {
+
+    @Autowired
+    private JpaMemberRepository memberRepository;
+
+    @Nested
+    @DisplayName("내 프로필 수정")
+    class UpdateMyProfile {
+
+        private final String path = "/api/v1/members/me";
+
+        @BeforeEach
+        void setUp() {
+            memberRepository.save(MemberStub.getMemberEntity());
+        }
+
+        @Test
+        @WithMockMember
+        @DisplayName("[성공] 회원 프로필 수정에 성공한다.")
+        void successTest() throws Exception {
+            MemberUpdateCommand request = MemberStub.getMemberUpdateCommand();
+
+            RequestPostProcessor patchMethod = http -> {
+                http.setMethod("PATCH");
+                return http;
+            };
+            mockMvc.perform(multipart(path)
+                            .file((MockMultipartFile) request.image())
+                            .with(patchMethod)
+                            .header(AuthenticationHeader.ACCESS_TOKEN.getName(), TokenStub.getMockAccessToken())
+                            .queryParam("nickname", request.nickname())
+                            .queryParam("region", request.region())
+                            .queryParam("profession", String.valueOf(request.profession())))
+                    .andExpect(status().isOk())
+                    .andDo(document("update-my-profile/success",
+                            preprocessRequest(prettyPrint()),
+                            preprocessResponse(prettyPrint()),
+                            requestHeaders(headerWithName(AuthenticationHeader.ACCESS_TOKEN.getName()).description("서버로부터 전달받은 액세스 토큰")),
+                            requestParts(partWithName("image").description("프로필 이미지 파일 (Optional)")),
+                            queryParameters(
+                                    parameterWithName("nickname").description("닉네임 (Optional)"),
+                                    parameterWithName("region").description("지역 (Optional)"),
+                                    parameterWithName("profession").description("직업 ID (Optional)")
+                            ),
+                            responseFields(
+                                    fieldWithPath("code").description("응답 상태"),
+                                    fieldWithPath("message").description("응답 메시지")
+                            )));
+        }
+
+        @Test
+        @WithMockMember
+        @DisplayName("[실패] 요청이 유효하지 않은 경우 프로필 수정에 실패한다.")
+        void invalidRequestTest() throws Exception {
+            MemberUpdateCommand request = MemberStub.getInvalidMemberUpdateCommand();
+
+            RequestPostProcessor patchMethod = http -> {
+                http.setMethod("PATCH");
+                return http;
+            };
+            mockMvc.perform(multipart(path)
+                            .file((MockMultipartFile) request.image())
+                            .with(patchMethod)
+                            .header(AuthenticationHeader.ACCESS_TOKEN.getName(), TokenStub.getMockAccessToken())
+                            .queryParam("nickname", request.nickname())
+                            .queryParam("region", request.region())
+                            .queryParam("profession", String.valueOf(request.profession())))
+                    .andExpect(status().isBadRequest())
+                    .andDo(document("update-my-profile/fail/invalid-request",
+                            preprocessRequest(prettyPrint()),
+                            preprocessResponse(prettyPrint()),
+                            requestHeaders(headerWithName(AuthenticationHeader.ACCESS_TOKEN.getName()).description("서버로부터 전달받은 액세스 토큰")),
+                            requestParts(partWithName("image").description("프로필 이미지 파일 (Optional)")),
+                            queryParameters(
+                                    parameterWithName("nickname").description("닉네임 (Optional)"),
+                                    parameterWithName("region").description("지역 (Optional)"),
+                                    parameterWithName("profession").description("직업 ID (Optional)")
+                            ),
+                            responseFields(
+                                    fieldWithPath("code").description("응답 상태"),
+                                    fieldWithPath("message").description("응답 메시지"),
+                                    fieldWithPath("data[].message").description("유효하지 않은 요청에 대한 상세 메시지")
+                            )));
+        }
+    }
+}

--- a/src/test/java/com/stumeet/server/stub/MemberStub.java
+++ b/src/test/java/com/stumeet/server/stub/MemberStub.java
@@ -1,7 +1,8 @@
 package com.stumeet.server.stub;
 
 import com.stumeet.server.member.adapter.out.persistence.MemberJpaEntity;
-import com.stumeet.server.member.application.port.in.MemberSignupCommand;
+import com.stumeet.server.member.application.port.in.command.MemberSignupCommand;
+import com.stumeet.server.member.application.port.in.command.MemberUpdateCommand;
 import com.stumeet.server.member.domain.AuthType;
 import com.stumeet.server.member.domain.Member;
 import com.stumeet.server.member.domain.UserRole;
@@ -50,5 +51,15 @@ public class MemberStub {
                 .region(null)
                 .image(null)
                 .build();
+    }
+
+    public static MemberUpdateCommand getMemberUpdateCommand() {
+        MockMultipartFile image = new MockMultipartFile("image", "test.jpg", "image/jpeg", "test".getBytes());
+        return new MemberUpdateCommand(image, "test2", "서울", 1L);
+    }
+
+    public static MemberUpdateCommand getInvalidMemberUpdateCommand() {
+        MockMultipartFile invalidImage = new MockMultipartFile("image", "test.jpa", "plain/text", "test".getBytes());
+        return new MemberUpdateCommand(invalidImage, "닉", "   ", -1L);
     }
 }


### PR DESCRIPTION
## 💁 해결 하려는 문제를 적어주세요 

- 내 정보 수정 API 구현
- 최초 로그인 시 호출할 수 있는 API 제한

## 🤔 어떤 방식으로 해결했는지 적어주세요 

- PATCH Method를 사용하기 때문에 값이 NULL이거나 유효한 값인지 판단할 수 있는 커스텀 Validation 어노테이션을 추가하였습니다.
- 최초 로그인시에는 회원가입과 분야정보만 조회가능하도록 수정하였습니다.
- 좀 더 기능에 맞도록 회원 관련 API의 클래스 구조 및 패키지 위치를 변경했습니다.
- 회원 프로필 수정시 NULL인 경우에는 동작하지 않고 NULL이 아닌경우에만 수정이 일어나도록 구현하였습니다.

## 🙋 중점적으로 리뷰 했으면 하는 부분이 있다면 적어주세요 

- 내 정보 수정 API를 만들면서 MemberProfileApi를 추가하였는데 최초 회원가입은 프로필에 값을 추가하는 거다보니 MemberAuthService는 어색한 것 같아 MemberProfileService에서 프로필 정보를 추가하도록 수정했습니다.
