### PR TITLE
🚧 [STMT-146] 파일 업로드 기능 코드 리뷰 반영

### DIFF
--- a/src/main/java/com/stumeet/server/common/annotation/validator/NullOrImageFileValidator.java
+++ b/src/main/java/com/stumeet/server/common/annotation/validator/NullOrImageFileValidator.java
@@ -12,6 +12,6 @@ public class NullOrImageFileValidator implements ConstraintValidator<NullOrImage
             return true;
         }
 
-        return FileUtil.isImageFile(value.getOriginalFilename());
+        return FileUtil.isValidImageFile(value.getContentType());
     }
 }

--- a/src/main/java/com/stumeet/server/common/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/stumeet/server/common/exception/handler/GlobalExceptionHandler.java
@@ -20,8 +20,8 @@ import org.springframework.web.method.annotation.MethodArgumentTypeMismatchExcep
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
-    private static final String ERROR_LOG_MESSAGE = "[ERROR] {} : {}";
-    private static final String WARN_LOG_MESSAGE = "[WARN] {} : {}";
+    public static final String ERROR_LOG_MESSAGE = "[ERROR] {} : {}";
+    public static final String WARN_LOG_MESSAGE = "[WARN] {} : {}";
 
     @ExceptionHandler(BusinessException.class)
     protected ResponseEntity<ApiResponse> handleBusinessException(final BusinessException e) {

--- a/src/main/java/com/stumeet/server/common/exception/model/BusinessException.java
+++ b/src/main/java/com/stumeet/server/common/exception/model/BusinessException.java
@@ -6,12 +6,12 @@ public class BusinessException extends RuntimeException {
 
     private final ErrorCode errorCode;
 
-    public BusinessException(String message, ErrorCode errorCode) {
-        super(message);
+    public BusinessException(ErrorCode errorCode) {
         this.errorCode = errorCode;
     }
 
-    public BusinessException(ErrorCode errorCode) {
+    public BusinessException(String message, ErrorCode errorCode) {
+        super(message);
         this.errorCode = errorCode;
     }
 

--- a/src/main/java/com/stumeet/server/common/exception/model/NotImplementedException.java
+++ b/src/main/java/com/stumeet/server/common/exception/model/NotImplementedException.java
@@ -1,0 +1,9 @@
+package com.stumeet.server.common.exception.model;
+
+import com.stumeet.server.common.response.ErrorCode;
+
+public class NotImplementedException extends BusinessException{
+	public NotImplementedException() {
+		super(ErrorCode.NOT_IMPLEMENTED_ERROR);
+	}
+}

--- a/src/main/java/com/stumeet/server/common/model/ApiResponse.java
+++ b/src/main/java/com/stumeet/server/common/model/ApiResponse.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.stumeet.server.common.exception.error.Error;
 import com.stumeet.server.common.response.ErrorCode;
 import com.stumeet.server.common.exception.error.ErrorField;
+import com.stumeet.server.common.response.SuccessCode;
+
 import java.util.List;
 import org.springframework.validation.BindingResult;
 
@@ -13,17 +15,9 @@ public record ApiResponse<T>(
         @JsonInclude(value = JsonInclude.Include.NON_NULL)
         T data
 ) {
-    public static <T> ApiResponse<T> success(int code, String message, T data) {
-        return new ApiResponse<>(code, message, data);
-    }
 
-    public static ApiResponse<Void> success(int code, String message) {
-        return new ApiResponse<>(code, message, null);
-    }
-
-    // TODO: 삭제 예정 메서드 : 해당 메서드를 사용 부분 수정 요망
-    public static ApiResponse<Void> fail(int code, String message) {
-        return new ApiResponse<>(code, message, null);
+    public static <T> ApiResponse<T> success(SuccessCode code, T data) {
+        return new ApiResponse<>(code.getHttpStatusCode(), code.getMessage(), data);
     }
 
     public static ApiResponse<Void> fail(ErrorCode errorCode) {
@@ -40,5 +34,18 @@ public record ApiResponse<T>(
                 errorCode.getMessage(),
                 ErrorField.toErrors(bindingResult)
         );
+    }
+
+    // TODO: 삭제 예정 메서드 : 해당 메서드를 사용 부분 수정 요망
+    public static <T> ApiResponse<T> success(int code, String message, T data) {
+        return new ApiResponse<>(code, message, data);
+    }
+
+    public static ApiResponse<Void> success(int code, String message) {
+        return new ApiResponse<>(code, message, null);
+    }
+
+    public static ApiResponse<Void> fail(int code, String message) {
+        return new ApiResponse<>(code, message, null);
     }
 }

--- a/src/main/java/com/stumeet/server/common/response/ErrorCode.java
+++ b/src/main/java/com/stumeet/server/common/response/ErrorCode.java
@@ -34,7 +34,9 @@ public enum ErrorCode {
         500 - INTERNAL SERVER ERROR
     */
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부에서 에러가 발생하였습니다."),
-    UPLOAD_FILE_FAIL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "파일 업로드에 실패하였습니다.");
+    UPLOAD_FILE_FAIL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "파일 업로드에 실패하였습니다."),
+    NOT_IMPLEMENTED_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "구현되지 않은 메서드를 사용했습니다.")
+    ;
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/stumeet/server/common/response/SuccessCode.java
+++ b/src/main/java/com/stumeet/server/common/response/SuccessCode.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public enum SuccessCode {
 
-    SIGN_UP_SUCCESS(HttpStatus.CREATED, "회원가입에 성공했습니다.")
+    SIGN_UP_SUCCESS(HttpStatus.CREATED, "회원가입에 성공했습니다."),
+    FILE_UPLOAD_SUCCESS(HttpStatus.CREATED, "파일 업로드에 성공했습니다.")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/stumeet/server/common/util/FileUtil.java
+++ b/src/main/java/com/stumeet/server/common/util/FileUtil.java
@@ -2,13 +2,11 @@ package com.stumeet.server.common.util;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.HashSet;
-import java.util.Locale;
-import java.util.Set;
 import java.util.UUID;
 
 import com.stumeet.server.common.exception.model.BusinessException;
 import com.stumeet.server.common.response.ErrorCode;
+import com.stumeet.server.common.util.model.ValidImageContentType;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -16,44 +14,33 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class FileUtil {
 
-	private static final Set<String> VALID_CONTENT_TYPES = new HashSet<>();
+	private static final String FILE_NAME_FORMAT = "%s/%s%s-%s";
+	private static final String FILE_DATE_TIME_FORMAT = "yyyyMMddHHmmss";
 
-	static {
-		VALID_CONTENT_TYPES.add("jpg");
-		VALID_CONTENT_TYPES.add("jpeg");
-		VALID_CONTENT_TYPES.add("png");
-	}
-
-	public static String getContentType(String fileName) {
-		if (fileName.isEmpty()) {
-			throw new BusinessException(ErrorCode.INVALID_IMAGE_EXCEPTION);
-		}
-
-        String contentType = extractContentType(fileName);
-
-        if (!VALID_CONTENT_TYPES.contains(contentType)) {
-			throw new BusinessException(ErrorCode.INVALID_FILE_EXTENSION_EXCEPTION);
-		}
+	public static String getValidImageContentType(String contentType) {
+		validateImageFile(contentType);
 
 		return contentType;
 	}
 
-    private static String extractContentType(String fileName) {
-        return fileName
-            .substring(fileName.lastIndexOf(".") + 1)
-            .toLowerCase(Locale.ROOT);
-    }
+	private static void validateImageFile(String contentType) {
+		if (contentType == null) {
+			throw new BusinessException(ErrorCode.INVALID_IMAGE_EXCEPTION);
+		}
+
+		if (!isValidImageFile(contentType)) {
+			throw new BusinessException(ErrorCode.INVALID_FILE_EXTENSION_EXCEPTION);
+		}
+	}
 
     public static String createFileName(String directoryPath, String fileName) {
 		String dateTime = LocalDateTime.now()
-			.format(DateTimeFormatter.ofPattern("yyyyMMddHHmmss"));
+			.format(DateTimeFormatter.ofPattern(FILE_DATE_TIME_FORMAT));
 
-		return String.format("%s/%s%s-%s", directoryPath, dateTime, UUID.randomUUID(), fileName);
+		return String.format(FILE_NAME_FORMAT, directoryPath, dateTime, UUID.randomUUID(), fileName);
 	}
 
-	public static boolean isImageFile(String fileName) {
-        String contentType = extractContentType(fileName);
-
-        return VALID_CONTENT_TYPES.contains(contentType);
+	public static boolean isValidImageFile(String contentType) {
+        return ValidImageContentType.hasContentType(contentType);
 	}
 }

--- a/src/main/java/com/stumeet/server/common/util/FileUtil.java
+++ b/src/main/java/com/stumeet/server/common/util/FileUtil.java
@@ -18,12 +18,12 @@ public class FileUtil {
 	private static final String FILE_DATE_TIME_FORMAT = "yyyyMMddHHmmss";
 
 	public static String getValidImageContentType(String contentType) {
-		validateImageFile(contentType);
+		validateImageContentType(contentType);
 
 		return contentType;
 	}
 
-	private static void validateImageFile(String contentType) {
+	private static void validateImageContentType(String contentType) {
 		if (contentType == null) {
 			throw new BusinessException(ErrorCode.INVALID_IMAGE_EXCEPTION);
 		}
@@ -33,14 +33,14 @@ public class FileUtil {
 		}
 	}
 
+	public static boolean isValidImageFile(String contentType) {
+		return ValidImageContentType.hasContentType(contentType);
+	}
+
     public static String createFileName(String directoryPath, String fileName) {
 		String dateTime = LocalDateTime.now()
 			.format(DateTimeFormatter.ofPattern(FILE_DATE_TIME_FORMAT));
 
 		return String.format(FILE_NAME_FORMAT, directoryPath, dateTime, UUID.randomUUID(), fileName);
-	}
-
-	public static boolean isValidImageFile(String contentType) {
-        return ValidImageContentType.hasContentType(contentType);
 	}
 }

--- a/src/main/java/com/stumeet/server/common/util/model/ValidImageContentType.java
+++ b/src/main/java/com/stumeet/server/common/util/model/ValidImageContentType.java
@@ -1,0 +1,27 @@
+package com.stumeet.server.common.util.model;
+
+public enum ValidImageContentType {
+	JPG("image/jpg"),
+	JPEG("image/jpeg"),
+	PNG("image/png")
+	;
+
+	private final String contentType;
+
+	ValidImageContentType(String contentType) {
+		this.contentType = contentType;
+	}
+
+	private String getContentType() {
+		return contentType;
+	}
+
+	public static boolean hasContentType(String contentType) {
+		for (ValidImageContentType type : ValidImageContentType.values()) {
+			if(type.getContentType().equalsIgnoreCase(contentType)) {
+				return true;
+			}
+		}
+		return false;
+	}
+}

--- a/src/main/java/com/stumeet/server/file/adapter/in/FileUploadApi.java
+++ b/src/main/java/com/stumeet/server/file/adapter/in/FileUploadApi.java
@@ -1,0 +1,34 @@
+package com.stumeet.server.file.adapter.in;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.stumeet.server.common.annotation.WebAdapter;
+import com.stumeet.server.common.model.ApiResponse;
+import com.stumeet.server.common.response.SuccessCode;
+import com.stumeet.server.file.application.port.in.FileUploadUseCase;
+
+import lombok.RequiredArgsConstructor;
+
+@WebAdapter
+@RequestMapping("/api/v1/files")
+@RequiredArgsConstructor
+public class FileUploadApi {
+
+	private final FileUploadUseCase fileUploadUseCase;
+
+	@PostMapping
+	public ResponseEntity<ApiResponse<String>> uploadTestImage(
+		@RequestPart("file")MultipartFile file
+	) {
+		return new ResponseEntity<>(
+			ApiResponse.success(
+				SuccessCode.FILE_UPLOAD_SUCCESS,
+				fileUploadUseCase.uploadImage(file).url()),
+			HttpStatus.CREATED);
+	}
+}

--- a/src/main/java/com/stumeet/server/file/adapter/out/S3ImageStorageAdapter.java
+++ b/src/main/java/com/stumeet/server/file/adapter/out/S3ImageStorageAdapter.java
@@ -1,5 +1,7 @@
 package com.stumeet.server.file.adapter.out;
 
+import static com.stumeet.server.common.exception.handler.GlobalExceptionHandler.*;
+
 import java.io.IOException;
 import java.util.List;
 
@@ -8,18 +10,21 @@ import org.springframework.web.multipart.MultipartFile;
 
 import com.stumeet.server.common.annotation.StorageAdapter;
 import com.stumeet.server.common.exception.model.BusinessException;
+import com.stumeet.server.common.exception.model.NotImplementedException;
 import com.stumeet.server.common.response.ErrorCode;
 import com.stumeet.server.common.util.FileUtil;
 import com.stumeet.server.file.application.port.out.FileCommandPort;
 import com.stumeet.server.file.application.port.out.FileUrl;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
 @StorageAdapter
 @RequiredArgsConstructor
+@Slf4j
 public class S3ImageStorageAdapter implements FileCommandPort {
 
 	@Value("${spring.cloud.config.server.awss3.bucket}")
@@ -36,7 +41,7 @@ public class S3ImageStorageAdapter implements FileCommandPort {
 		String key = FileUtil.createFileName(directoryPath, originalFileName);
 
 		PutObjectRequest objectRequest = PutObjectRequest.builder()
-			.contentType(FileUtil.getContentType(originalFileName))
+			.contentType(FileUtil.getValidImageContentType(multipartFile.getContentType()))
 			.bucket(bucket)
 			.key(key)
 			.build();
@@ -49,6 +54,9 @@ public class S3ImageStorageAdapter implements FileCommandPort {
 						multipartFile.getInputStream(),
 						multipartFile.getSize()));
 		} catch (IOException e) {
+			log.warn(WARN_LOG_MESSAGE, e.getClass().getSimpleName(), e.getMessage());
+			log.debug(e.getMessage(), e);
+
 			throw new BusinessException(ErrorCode.UPLOAD_FILE_FAIL_ERROR);
 		}
 
@@ -57,7 +65,7 @@ public class S3ImageStorageAdapter implements FileCommandPort {
 
 	@Override
 	public FileUrl uploadImageFiles(List<MultipartFile> multipartFileList, String directoryPath) {
-		return null;
+		throw new NotImplementedException();
 	}
 
 	private FileUrl getS3FileUrl(String key) {

--- a/src/main/java/com/stumeet/server/file/application/port/in/FileUploadUseCase.java
+++ b/src/main/java/com/stumeet/server/file/application/port/in/FileUploadUseCase.java
@@ -6,6 +6,7 @@ import org.springframework.web.multipart.MultipartFile;
 import com.stumeet.server.file.application.port.out.FileUrl;
 
 	public interface FileUploadUseCase {
+	FileUrl uploadImage(MultipartFile multipartFile);
 
 	FileUrl uploadUserProfileImage(Long userId, MultipartFile multipartFile);
 

--- a/src/main/java/com/stumeet/server/file/application/service/FileUploadService.java
+++ b/src/main/java/com/stumeet/server/file/application/service/FileUploadService.java
@@ -15,10 +15,16 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class FileUploadService implements FileUploadUseCase {
 
+	private static final String TEST_IMAGE_DIRECTORY_PATH = "test";
 	private static final String USER_PROFILE_IMAGE_DIRECTORY_PATH = "user/%d/profile";
 	private static final String STUDY_ACTIVITY_IMAGE_DIRECTORY_PATH = "study/%d/activity";
 
 	private final FileCommandPort fileCommandPort;
+
+	@Override
+	public FileUrl uploadImage(MultipartFile multipartFile) {
+		return fileCommandPort.uploadImageFile(multipartFile, TEST_IMAGE_DIRECTORY_PATH);
+	}
 
 	@Override
 	public FileUrl uploadUserProfileImage(Long userId, MultipartFile multipartFile) {


### PR DESCRIPTION
## 💁 해결하려는 문제를 적어주세요 

- 파일 업로드 기능 코드 리뷰 반영 및 리팩터링

<br>

## 🤔 어떤 방식으로 해결했는지 적어주세요 

- `BusinessException`을 상속받는 `NotImplementedException`를 구현하여 구현되지 않은 메서드 사용 시 예외 던지기
- 파일 업로드 시 IOException 놓쳤던 로그 출력
- 유효한 이미지 확장자를 별도의 enum 타입으로 구현
- FileUtil 클래스 리팩터링: 확장자 검사를 문자열 추출에서 content type 검사로 변경
  - `originalFileName`에서 문자열을 추출하는 것보다는 `contentType`을 가져와 검사하는 것이 낫다고 판단하여 수정하였습니다.
  - null 검사 등의 로직은 동일하게 진행되고 있습니다. 혹시 추가 검증이 필요하다 생각되시면 편하게 리뷰 달아주세요!
- file upload 정상작동 테스트용 API 구현
  - 실제 서비스에서 사용되는 api는 아니지만 정상 작동을 테스트하기 위해 구현했습니다.
  - 이후 admin만 사용 가능한 api로 변경 가능하고, 사용할 일이 없을 시에는 삭제하겠습니다.

<br>

## 🙋 중점적으로 리뷰 했으면 하는 부분이 있다면 적어주세요 

- `GlobalExceptionController`의 상수 `WARN_LOG_MESSAGE`를 가져와서 사용해도 되는지, 안되는 이유가 있다면 어떻게 구현하면 좋을지.
  - 개인적으로 생각해본 방법은 common의 `Constant` 클래스를 구현하는 방법을 생각했습니다.
``` java
public class GlobalExceptionHandler {

    public static final String ERROR_LOG_MESSAGE = "[ERROR] {} : {}";
    public static final String WARN_LOG_MESSAGE = "[WARN] {} : {}";
```

- 지금 구현한 방식으로 예외를 찍는다면 중복 코드가 많아질 것 같은데 더 좋은 방법은 없을지
``` java
catch (IOException e) {
log.warn(WARN_LOG_MESSAGE, e.getClass().getSimpleName(), e.getMessage());
log.debug(e.getMessage(), e);

throw new BusinessException(ErrorCode.UPLOAD_FILE_FAIL_ERROR);
}
```

- `ValidImageContentType`의 패키지 위치
  - 현재는 `FileUtil`과 관련된 파일이니 utils에 넣었는데 비즈니스 규칙과 연관된 클래스인듯도 하여 어디에 위치시켜야 할지 고민이 됩니다.