### PR TITLE
🔨 [STMT-6] fork repository를 위한 CI workflow 구축 - 에러 해결

### DIFF
--- a/.github/workflows/ci-trigger.yml
+++ b/.github/workflows/ci-trigger.yml
@@ -4,9 +4,7 @@ on:
   pull_request:
     branches:
       - dev
-  push:
-    branches:
-      - dev
+      - main
 
 jobs:
   run-CI-workflow:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
   workflow_run:
-    workflows: ["CI trigger"]
+    workflows: [CI trigger]
     types: [completed]
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,8 @@ on:
     branches:
       - main
   workflow_run:
-    workflows:
-      - CI trigger
+    workflows: ["CI trigger"]
+    types: [completed]
 
 jobs:
   ci:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,6 @@
-name: CI triggered by PR
+name: CI triggered by CI trigger
 
 on:
-  pull_request:
-    branches:
-      - main
   workflow_run:
     workflows: [CI trigger]
     types: [completed]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,10 @@ name: CI triggered by PR
 on:
   pull_request:
     branches:
-      - dev
       - main
+  workflow_run:
+    workflows:
+      - CI trigger
 
 jobs:
   ci:

--- a/.github/workflows/ci_trigger.yml
+++ b/.github/workflows/ci_trigger.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches:
       - dev
+  push:
+    branches:
+      - dev
 
 jobs:
   run-CI-workflow:

--- a/.github/workflows/ci_trigger.yml
+++ b/.github/workflows/ci_trigger.yml
@@ -1,0 +1,14 @@
+name: CI trigger
+
+on:
+  pull_request:
+    branches:
+      - dev
+
+jobs:
+  run-CI-workflow:
+    runs-on: ubuntu-latest
+    name: run CI workflow
+    steps:
+      - name: run
+        run: echo "this is a dummy workflow that triggers a workflow_run; it's necessary because otherwise the repo secrets will not be in scope for externally forked pull requests"


### PR DESCRIPTION
## 💁 해결 하려는 문제를 적어주세요 

- fork repository는 CI 워크플로우 실행 시에 origin repository의 private github action secret을 읽어오지 못함
- (추가) 기존의 방식에는 on 트리거에 main에 push할 경우와  `workflow_run`의 경우가 같이 있었는데, `workflow_run` 트리거가 인식되지 않아 CI 워크플로우가 실행되지 않음
## 🤔 어떤 방식으로 해결했는지 적어주세요 

- dev에 PR을 올리면 CI trigger 워크플로우가 실행되고, CI trigger 워크플로우가 실행되면 CI 워크플로우가 실행되도록 수정
- origin repository가 실행하는 워크플로우이므로 secret 사용 가능
- CI 워크플로우의 on 트리거를 `workflow_run` 하나만 설정하고 CI trigger 워크플로우를 각각 dev, main에 PR을 올렸을 때 실행하도록 수정

## 🧑‍🏫 이해를 위해 필요한 자료가 있다면 첨부해주세요

- 참고 자료
https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
https://stackoverflow.com/questions/67247752/how-to-use-secret-in-pull-request-review-similar-to-pull-request-target
https://docs.github.com/ko/actions/using-workflows/events-that-trigger-workflows#workflow_run
  - 이 이벤트는 워크플로 실행을 요청하거나 완료할 때 발생합니다. 이를 통해 다른 워크플로의 실행 또는 완료에 따라 워크플로를 실행할 수 있습니다. workflow_run 이벤트에 의해 시작된 워크플로는 이전 워크플로는 그렇지 않더라도 비밀에 액세스하고 토큰을 쓸 수 있습니다. 이는 이전 워크플로가 의도적으로 권한이 없지만 이후 워크플로에서 권한 있는 작업을 수행해야 하는 경우에 유용합니다.

## ⚠️ 읽어주세요!

- trigger 워크플로우를 통과했다고 해서 CI가 성공했다는 것은 아닙니다. Action에서 CI가 성공했는지 확인이 필요합니다.
- 추후 두 워크플로우가 모두 성공해야지 merge할 수 있는 방법을 찾아보겠습니다.