### PR TITLE
✅ [STMT-146] 소셜 로그인시 전달한 JWT 토큰의 서명이 유효하지 않은 경우에 대한 핸들링 추가

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -32,10 +32,14 @@ include::{snippets}/social_login/success/response-fields.adoc[]
 
 .유효한 토큰이 아닌 경우
 include::{snippets}/social_login/fail/invalid-token/response-body.adoc[]
+
 .토큰이 전달되지 않은 경우
 include::{snippets}/social_login/fail/not-exist-header/response-body.adoc[]
-
 include::{snippets}/social_login/fail/invalid-token/response-fields.adoc[]
+
+.전달한 JWT 토큰의 서명이 유효하지 않은 경우
+include::{snippets}/social_login/fail/invalid-signature/response-body.adoc[]
+include::{snippets}/social_login/fail/invalid-signature/response-fields.adoc[]
 
 === 로그아웃
 

--- a/src/main/java/com/stumeet/server/common/auth/exception/IllegalKeyAlgorithmException.java
+++ b/src/main/java/com/stumeet/server/common/auth/exception/IllegalKeyAlgorithmException.java
@@ -1,0 +1,13 @@
+package com.stumeet.server.common.auth.exception;
+
+import com.stumeet.server.common.response.ErrorCode;
+import org.springframework.security.core.AuthenticationException;
+
+public class IllegalKeyAlgorithmException extends AuthenticationException {
+    private final ErrorCode errorCode;
+
+    public IllegalKeyAlgorithmException(ErrorCode errorCode, Throwable cause) {
+        super(errorCode.getMessage(), cause);
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/stumeet/server/common/auth/exception/JwtInvalidSignatureException.java
+++ b/src/main/java/com/stumeet/server/common/auth/exception/JwtInvalidSignatureException.java
@@ -1,0 +1,16 @@
+package com.stumeet.server.common.auth.exception;
+
+import com.stumeet.server.common.response.ErrorCode;
+import org.springframework.security.core.AuthenticationException;
+
+
+public class JwtInvalidSignatureException extends AuthenticationException {
+
+    private final ErrorCode errorCode;
+
+    public JwtInvalidSignatureException(ErrorCode errorCode, Throwable e) {
+        super(errorCode.getMessage(), e);
+        this.errorCode = errorCode;
+    }
+
+}

--- a/src/main/java/com/stumeet/server/common/auth/exception/JwtTokenParsingException.java
+++ b/src/main/java/com/stumeet/server/common/auth/exception/JwtTokenParsingException.java
@@ -1,0 +1,13 @@
+package com.stumeet.server.common.auth.exception;
+
+import com.stumeet.server.common.response.ErrorCode;
+import org.springframework.security.core.AuthenticationException;
+
+public class JwtTokenParsingException extends AuthenticationException {
+    private final ErrorCode errorCode;
+
+    public JwtTokenParsingException(ErrorCode errorCode, Throwable e) {
+        super(errorCode.getMessage(), e);
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/stumeet/server/common/response/ErrorCode.java
+++ b/src/main/java/com/stumeet/server/common/response/ErrorCode.java
@@ -26,6 +26,13 @@ public enum ErrorCode {
     EXPIRED_REFRESH_TOKEN_EXCEPTION(HttpStatus.BAD_REQUEST, "리프레시 토큰이 만료되었습니다."),
 
     /*
+        401 - UNAUTHORIZED
+    */
+    JWT_INVALID_SIGNATURE_EXCEPTION(HttpStatus.UNAUTHORIZED, "JWT 서명이 유효하지 않습니다."),
+    ILLEGAL_KEY_ALGORITHM_EXCEPTION(HttpStatus.UNAUTHORIZED, "유효하지 않은 키 알고리즘입니다."),
+    JWT_TOKEN_PARSING_EXCEPTION(HttpStatus.UNAUTHORIZED, "JWT 토큰 파싱에 실패했습니다."),
+
+    /*
         403 - FORBIDDEN
     */
     ACCESS_DENIED_EXCEPTION(HttpStatus.FORBIDDEN, "유효하지 않은 요청입니다."),

--- a/src/test/java/com/stumeet/server/common/auth/filter/OAuthAuthenticationFilterTest.java
+++ b/src/test/java/com/stumeet/server/common/auth/filter/OAuthAuthenticationFilterTest.java
@@ -13,7 +13,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.http.HttpStatus;
 import org.springframework.restdocs.payload.JsonFieldType;
-import org.springframework.transaction.annotation.Transactional;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.junit.jupiter.Container;
 
@@ -40,6 +39,7 @@ class OAuthAuthenticationFilterTest extends ApiTest {
     @DisplayName("OAuth2를 이용한 소셜 로그인")
     class oauthLogin {
         private final String path = "/api/v1/oauth";
+
 
         @Test
         @DisplayName("[성공] 소셜 로그인(카카오)에 성공합니다.")
@@ -74,7 +74,7 @@ class OAuthAuthenticationFilterTest extends ApiTest {
             mockFailKakaoTokenInfoApi();
 
             mockMvc.perform(post(path)
-                            .header(AuthenticationHeader.ACCESS_TOKEN.getName(), TokenStub.getKakaoAccessToken())
+                            .header(AuthenticationHeader.ACCESS_TOKEN.getName(), TokenStub.getInvalidToken())
                             .header(AuthenticationHeader.X_OAUTH_PROVIDER.getName(), OAuthProvider.KAKAO.getProvider()))
                     .andExpect(status().isUnauthorized())
                     .andDo(document("social_login/fail/invalid-token",
@@ -108,10 +108,34 @@ class OAuthAuthenticationFilterTest extends ApiTest {
                     );
         }
 
+        @Test
+        @DisplayName("[실패] 잘못 서명된 토큰을 전달하는 경우 인증에 실패합니다.")
+        void invalidSignatureTest() throws Exception {
+            mockFailAppleInvalidSignatureTokenInfoApi();
+
+            mockMvc.perform(post(path)
+                            .header(AuthenticationHeader.ACCESS_TOKEN.getName(), TokenStub.getInvalidSignatureAccessToken())
+                            .header(AuthenticationHeader.X_OAUTH_PROVIDER.getName(), OAuthProvider.APPLE.getProvider()))
+                    .andExpect(status().isUnauthorized())
+                    .andDo(document("social_login/fail/invalid-signature",
+                                    preprocessRequest(prettyPrint()),
+                                    preprocessResponse(prettyPrint()),
+                                    requestHeaders(
+                                            headerWithName(AuthenticationHeader.ACCESS_TOKEN.getName()).description("OAuth Provider로 부터 전달받은 토큰"),
+                                            headerWithName(AuthenticationHeader.X_OAUTH_PROVIDER.getName()).description("OAuth Provider 이름")
+                                    ),
+                                    responseFields(
+                                            fieldWithPath("code").type(JsonFieldType.NUMBER).description("응답에 대한 결과 코드"),
+                                            fieldWithPath("message").type(JsonFieldType.STRING).description("응답에 대한 메시지")
+                                    )
+                            )
+                    );
+        }
+
         private void mockFailKakaoTokenInfoApi() {
             stubFor(
                     WireMock.get(WireMock.urlEqualTo("/v1/user/access_token_info"))
-                            .withHeader(AuthenticationHeader.ACCESS_TOKEN.getName(), equalTo(TokenStub.getInvalidKakaoAccessToken()))
+                            .withHeader(AuthenticationHeader.ACCESS_TOKEN.getName(), equalTo(TokenStub.getInvalidToken()))
                             .willReturn(aResponse()
                                     .withStatus(HttpStatus.UNAUTHORIZED.value())
                                     .withHeader("content-type", APPLICATION_JSON)
@@ -128,6 +152,17 @@ class OAuthAuthenticationFilterTest extends ApiTest {
                                     .withStatus(HttpStatus.CREATED.value())
                                     .withHeader("content-type", APPLICATION_JSON)
                                     .withBody(MemberStub.getKakaoAccessTokenInfo())
+                            )
+            );
+        }
+
+        private void mockFailAppleInvalidSignatureTokenInfoApi() {
+            stubFor(
+                    WireMock.get(WireMock.urlEqualTo("/auth/keys"))
+                            .willReturn(aResponse()
+                                    .withStatus(HttpStatus.OK.value())
+                                    .withHeader("content-type", APPLICATION_JSON)
+                                    .withBody(MemberStub.getAppleInvalidSignatureTokenInfo())
                             )
             );
         }

--- a/src/test/java/com/stumeet/server/stub/MemberStub.java
+++ b/src/test/java/com/stumeet/server/stub/MemberStub.java
@@ -1,11 +1,10 @@
 package com.stumeet.server.stub;
 
+import com.stumeet.server.helper.WithMockMember;
 import com.stumeet.server.member.adapter.in.web.response.MemberProfileResponse;
-import com.stumeet.server.member.adapter.out.persistence.MemberJpaEntity;
 import com.stumeet.server.member.application.port.in.command.MemberSignupCommand;
 import com.stumeet.server.member.application.port.in.command.MemberUpdateCommand;
 import com.stumeet.server.member.domain.*;
-import com.stumeet.server.helper.WithMockMember;
 import org.springframework.mock.web.MockMultipartFile;
 
 public class MemberStub {
@@ -19,23 +18,8 @@ public class MemberStub {
     }
 
 
-
     public static String getInvalidKakaoAccessTokenInfo() {
         return "{\"msg\":\"this access token does not exist\",\"code\":-401}";
-    }
-
-    public static MemberJpaEntity getMemberEntity() {
-        return MemberJpaEntity.builder()
-                .id(1L)
-                .name("test")
-                .image(FileStub.getFileUrl().url())
-                .region("서울")
-                .profession(ProfessionStub.getProfessionEntity())
-                .role(UserRole.FIRST_LOGIN)
-                .authType(AuthType.OAUTH)
-                .rank(MemberRank.SEED)
-                .experience(0.0)
-                .build();
     }
 
     public static MemberSignupCommand getMemberSignupCommand() {
@@ -98,5 +82,9 @@ public class MemberStub {
                 .rank(member.getLevel().getRank().getName())
                 .experience(member.getLevel().getExperience())
                 .build();
+    }
+
+    public static String getAppleInvalidSignatureTokenInfo() {
+        return "{\"keys\":[{\"kty\":\"RSA\",\"kid\":\"lVHdOx8ltR\",\"use\":\"sig\",\"alg\":\"RS256\",\"n\":\"nXDu9MPf6dmVtFbDdAaal_0cO9ur2tqrrmCZaAe8TUWHU8AprhJG4DaQoCIa4UsOSCbCYOjPpPGGdE_p0XeP1ew55pBIquNhNtNNEMX0jNYAKcA9WAP1zGSkvH5m39GMFc4SsGiQ_8Szht9cayJX1SJALEgSyDOFLs-ekHnexqsr-KPtlYciwer5jaNcW3B7f9VNp1XCypQloQwSGVismPHwDJowPQ1xOWmhBLCK50NV38ZjobUDSBbCeLYecMtsdL5ZGv-iufddBh3RHszQiD2G-VXoGOs1yE33K4uAto2F2bHVcKOUy0__9qEsXZGf-B5ZOFucUkoN7T2iqu2E2Q\",\"e\":\"AQAB\"},{\"kty\":\"RSA\",\"kid\":\"pyaRQpAbnY\",\"use\":\"sig\",\"alg\":\"RS256\",\"n\":\"qHiwOpizi6xHG8FIOSWH4l0P1CjLIC7aBFkhbk7BrD4s9KQAs5Sj5xAtOwlZMyP2XFcqRtZBLIMM7vw_CNERtRrhc68se5hQE_vsrHy7ugcQU6ogJS6s54zqO-zTUfaa3mABM6iR-EfgSpvz33WTQZAPtwAyxaSLknHyDzWjHEZ44WqaQBdcMAvgsWMYG5dBfnV-3Or3V2r1vdbinRE5NomE2nsKDbnJ3yo3u-x9TizKazS1JV3umt71xDqbruZLybIrimrzg_i9OSIzT2o5ZWz8zdYkKHZ4cvRPh-DDt8kV7chzR2tenPF2c5WXuK-FumOrjT7WW6uwSvhnhwNZuw\",\"e\":\"AQAB\"},{\"kty\":\"RSA\",\"kid\":\"fh6Bs8C\",\"use\":\"sig\",\"alg\":\"RS256\",\"n\":\"u704gotMSZc6CSSVNCZ1d0S9dZKwO2BVzfdTKYz8wSNm7R_KIufOQf3ru7Pph1FjW6gQ8zgvhnv4IebkGWsZJlodduTC7c0sRb5PZpEyM6PtO8FPHowaracJJsK1f6_rSLstLdWbSDXeSq7vBvDu3Q31RaoV_0YlEzQwPsbCvD45oVy5Vo5oBePUm4cqi6T3cZ-10gr9QJCVwvx7KiQsttp0kUkHM94PlxbG_HAWlEZjvAlxfEDc-_xZQwC6fVjfazs3j1b2DZWsGmBRdx1snO75nM7hpyRRQB4jVejW9TuZDtPtsNadXTr9I5NjxPdIYMORj9XKEh44Z73yfv0gtw\",\"e\":\"AQAB\"},{\"kty\":\"RSA\",\"kid\":\"Bh6H7rHVmb\",\"use\":\"sig\",\"alg\":\"RS256\",\"n\":\"2HkIZ7xKMUYH_wtt2Gwq6jXKRl-Ng5vdwd-XcWn5RIW82-uxdmGJyTo3T6MPty-xWUeW7FCs9NlM4yu02GKgwep7TKfnOovP78sd3rESbZsvuN7zD_Vk6aZP7QfqblElUtiMQxh9bu-gZUeMZfa_ndX-P5C4yKtZvXGrSPLLjyAcSmSHNLZnWbZXjeIVsgXWHMr5fwVEAkftHq_4py82xgn2XEK0FK9HmWOCZ47Wcx9fWBnqSi9JTJTUX0lh-kI5TcYfv9UKX2oe3uyOn-A460E_L_4ximlM-lgi3otw26EZfAGY9FFgSZoACjhgw_z5NRbK9dycHRpeLY9GxIyiYw\",\"e\":\"AQAB\"}]}";
     }
 }

--- a/src/test/java/com/stumeet/server/stub/MemberStub.java
+++ b/src/test/java/com/stumeet/server/stub/MemberStub.java
@@ -22,20 +22,6 @@ public class MemberStub {
         return "{\"msg\":\"this access token does not exist\",\"code\":-401}";
     }
 
-    public static MemberJpaEntity getMemberEntity() {
-        return MemberJpaEntity.builder()
-                .id(1L)
-                .name("test")
-                .image(FileStub.getFileUrl().url())
-                .region("서울")
-                .profession(ProfessionStub.getProfessionEntity())
-                .role(UserRole.FIRST_LOGIN)
-                .authType(AuthType.OAUTH)
-                .tier(MemberTier.SEED)
-                .experience(0.0)
-                .build();
-    }
-
     public static MemberSignupCommand getMemberSignupCommand() {
         MockMultipartFile image = new MockMultipartFile("image", "test.jpg", "image/jpeg", "test".getBytes());
         return new MemberSignupCommand(image, "test", "서울", 1L);

--- a/src/test/java/com/stumeet/server/stub/TokenStub.java
+++ b/src/test/java/com/stumeet/server/stub/TokenStub.java
@@ -2,14 +2,15 @@ package com.stumeet.server.stub;
 
 public class TokenStub {
 
-    private TokenStub() {}
+    private TokenStub() {
+    }
 
     public static String getKakaoAccessToken() {
         return "Bearer rjdizj7Ae09H0oWlW46Oll9_x7AhzaJkp1gKKwzTAAABjd_1h0EhI_W2iN1234";
     }
 
-    public static String getInvalidKakaoAccessToken() {
-        return "invalidToken";
+    public static String getInvalidSignatureAccessToken() {
+        return "Bearer eyJraWQiOiJweWFSUXBBYm5ZIiwiYWxnIjoiUlMyNTYifQ.eyJpc3MiOiJodHRwczovL2FwcGxlaWQuYXBwbGUuY29tIiwiYXVkIjoiU3R1bWVldC5TdHVtZWV0IiwiZXhwIjoxNzEwMTQzMTM2LCJpYXQiOjE3MTAwNTY3MzYsInN1YiI6IjAwMTY2NS5iODlkNDQxZDYzMGI0Mjk5YTllYjkzNDY2OWFlMjcxMy4xNDE0IiwiY19oYXNoIjoiMlBQN1dpMUdiNzVrVWt3T0Z2YVRVUSIsImVtYWlsIjoidjRoNzRnZDRrakBwcml2YXRlcmVsYXkuYXBwbGVpZC5jb20iLCJlbWFpbF92ZXJpZmllZCI6dHJ1ZSwiaXNfcHJpdmF0ZV9lbWFpbCI6dHJ1ZSwiYXV0aF90aW1lIjoxNzEwMDU2NzM2LCJub25jZV9zdXBwb3J0ZWQiOnRydWV9.TLTJjSAU3dExWtOuPK2KFK7gthwFz1ftVc8wnrgPGhfDTy8yYnsKJ1D5uF4FzxDuKBeIVibuy8MMVNXy4attuKJ9sl7jNH-10Zh8DJMb8L9KwhFpap5lpJb1DiWxtjlolEnUtMhoyMZjEaWxvloCPhZUJtftb1MHLdAwVkDbFwy43yDxKYL-fFiJWVdoW_ERfMOpyyKaJFKq_dTAGD2TyXTxQZ9pCJyY2tY6DaiZNu6bX-TVRgN2gjPzNDSUlo0KLVZ0GOZH9-zlRp1yxQyZ97TSOLGthQ2psSQ4zMJ3HCak0dJP_jCZw50Jyyw3PDm3r_pXbC1pA8ZzvriB7ZsA";
     }
 
     public static String getExpiredAccessToken() {
@@ -19,6 +20,7 @@ public class TokenStub {
     public static String getInvalidToken() {
         return "Bearer eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJTVFVNRUVUIiwic3ViIjoiMSIsImF1dGgiOiJGSVJTVF9MT0dJTiIsImV4cCI6MTcwOTA0MTM1Mn0.1dU2fb1wUgJeV8R1RAjFpKx3g3qToRZnft1lxSejL7o";
     }
+
     public static String getMockAccessToken() {
         return "Bearer eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJTVFVNRUVUIiwic3ViIjoiMSIsImF1dGgiOiJGSVJTVF9MT0dJTiIsImV4cCI6MTcwOTA0MTM1Mn0.1dU2fb1wUgJeV8R1RAjFpKxBg3qToRZnft1lxSejL7o";
     }


### PR DESCRIPTION
## 💁 해결 하려는 문제를 적어주세요 

- 소셜 로그인시 JWT 토큰의 시그니처가 유효하지 않은 경우에 대한 메시지 핸들링 추가


## 🤔 어떤 방식으로 해결했는지 적어주세요 

- 기존 로직의 경우 Spring Security의 AuthenticationException을 이용하지 않아 정상적으로 핸들링이 되지 않는 문제가 존재하여 AuthenticationException을 상속하는 CustomException을 추가