### PR TITLE
:bug: [STMT-146] 멤버 레벨을 표현하기 위한 rank 칼럼의 DB 예약어로 인한 insert 쿼리 실패 버그 해결

### DIFF
--- a/src/main/java/com/stumeet/server/member/adapter/in/web/response/MemberProfileResponse.java
+++ b/src/main/java/com/stumeet/server/member/adapter/in/web/response/MemberProfileResponse.java
@@ -9,7 +9,7 @@ public record MemberProfileResponse(
         String nickname,
         String region,
         String profession,
-        String rank,
+        String tier,
         double experience
 ) {
 }

--- a/src/main/java/com/stumeet/server/member/adapter/out/persistence/MemberJpaEntity.java
+++ b/src/main/java/com/stumeet/server/member/adapter/out/persistence/MemberJpaEntity.java
@@ -2,7 +2,7 @@ package com.stumeet.server.member.adapter.out.persistence;
 
 import com.stumeet.server.common.model.BaseTimeEntity;
 import com.stumeet.server.member.domain.AuthType;
-import com.stumeet.server.member.domain.MemberRank;
+import com.stumeet.server.member.domain.MemberTier;
 import com.stumeet.server.member.domain.UserRole;
 import com.stumeet.server.profession.adapter.out.persistence.ProfessionJpaEntity;
 import jakarta.persistence.*;
@@ -37,10 +37,10 @@ public class MemberJpaEntity extends BaseTimeEntity {
     @Comment("멤버 이미지 URL")
     private String image;
 
-    @Column(name = "rank", length = 50, nullable = false)
+    @Column(name = "tier", length = 50, nullable = false)
     @Enumerated(EnumType.STRING)
     @Comment("등급")
-    private MemberRank rank;
+    private MemberTier tier;
 
     @Column(name = "experience", nullable = false)
     @Comment("경험치")

--- a/src/main/java/com/stumeet/server/member/adapter/out/persistence/MemberPersistenceMapper.java
+++ b/src/main/java/com/stumeet/server/member/adapter/out/persistence/MemberPersistenceMapper.java
@@ -17,7 +17,7 @@ public class MemberPersistenceMapper {
                 .id(domain.getId())
                 .name(domain.getName())
                 .image(domain.getImage())
-                .rank(domain.getLevel().getRank())
+                .tier(domain.getLevel().getTier())
                 .experience(domain.getLevel().getExperience())
                 .region(domain.getRegion())
                 .profession(professionPersistenceMapper.toEntity(domain.getProfession()))
@@ -28,7 +28,7 @@ public class MemberPersistenceMapper {
 
     public Member toDomain(MemberJpaEntity entity) {
         MemberLevel level = MemberLevel.builder()
-                .rank(entity.getRank())
+                .tier(entity.getTier())
                 .experience(entity.getExperience())
                 .build();
 

--- a/src/main/java/com/stumeet/server/member/application/port/in/mapper/MemberUseCaseMapper.java
+++ b/src/main/java/com/stumeet/server/member/application/port/in/mapper/MemberUseCaseMapper.java
@@ -14,7 +14,7 @@ public class MemberUseCaseMapper {
                 .nickname(member.getName())
                 .region(member.getRegion())
                 .profession(member.getProfession().getName())
-                .rank(member.getLevel().getRank().getName())
+                .tier(member.getLevel().getTier().getName())
                 .experience(member.getLevel().getExperience())
                 .build();
     }

--- a/src/main/java/com/stumeet/server/member/application/service/MemberOAuthService.java
+++ b/src/main/java/com/stumeet/server/member/application/service/MemberOAuthService.java
@@ -29,7 +29,7 @@ public class MemberOAuthService implements MemberOAuthUseCase {
             member = memberQueryPort.getByOAuthProviderId(response.id(), oAuthProvider);
         } else {
             MemberLevel initialLevel = MemberLevel.builder()
-                    .rank(MemberRank.SEED)
+                    .tier(MemberTier.SEED)
                     .experience(0.0)
                     .build();
             member = memberCommandPort.save(

--- a/src/main/java/com/stumeet/server/member/domain/MemberLevel.java
+++ b/src/main/java/com/stumeet/server/member/domain/MemberLevel.java
@@ -9,6 +9,6 @@ import lombok.*;
 @Builder
 public class MemberLevel {
 
-    private MemberRank rank;
+    private MemberTier tier;
     private double experience;
 }

--- a/src/main/java/com/stumeet/server/member/domain/MemberTier.java
+++ b/src/main/java/com/stumeet/server/member/domain/MemberTier.java
@@ -5,7 +5,7 @@ import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 @Getter
-public enum MemberRank {
+public enum MemberTier {
     SEED("씨앗"),
     SPROUT("새싹"),
     LEAF("잎"),

--- a/src/main/resources/db/migration/V1.3__modify_column_rank_to_tier.sql
+++ b/src/main/resources/db/migration/V1.3__modify_column_rank_to_tier.sql
@@ -1,0 +1,1 @@
+ALTER TABLE member RENAME COLUMN `rank` TO `tier`

--- a/src/test/java/com/stumeet/server/member/adapter/in/web/MemberProfileApiTest.java
+++ b/src/test/java/com/stumeet/server/member/adapter/in/web/MemberProfileApiTest.java
@@ -124,7 +124,7 @@ class MemberProfileApiTest extends ApiTest {
                                     fieldWithPath("data.nickname").description("닉네임"),
                                     fieldWithPath("data.region").description("지역"),
                                     fieldWithPath("data.profession").description("분야 이름"),
-                                    fieldWithPath("data.rank").description("회원 레벨 - 랭크"),
+                                    fieldWithPath("data.tier").description("회원 레벨 - 랭크"),
                                     fieldWithPath("data.experience").description("회원 레벨 - 경험치")
                             )));
         }

--- a/src/test/java/com/stumeet/server/stub/MemberStub.java
+++ b/src/test/java/com/stumeet/server/stub/MemberStub.java
@@ -45,7 +45,7 @@ public class MemberStub {
 
     public static Member getMember(WithMockMember annotation) {
         MemberLevel level = MemberLevel.builder()
-                .rank(MemberRank.SEED)
+                .tier(MemberTier.SEED)
                 .experience(0.0)
                 .build();
 
@@ -63,7 +63,7 @@ public class MemberStub {
 
     public static Member getMember() {
         MemberLevel level = MemberLevel.builder()
-                .rank(MemberRank.SEED)
+                .tier(MemberTier.SEED)
                 .experience(0.0)
                 .build();
         return Member.builder()
@@ -95,7 +95,7 @@ public class MemberStub {
                 .nickname(member.getName())
                 .region(member.getRegion())
                 .profession(member.getProfession().getName())
-                .rank(member.getLevel().getRank().getName())
+                .tier(member.getLevel().getTier().getName())
                 .experience(member.getLevel().getExperience())
                 .build();
     }

--- a/src/test/java/com/stumeet/server/stub/MemberStub.java
+++ b/src/test/java/com/stumeet/server/stub/MemberStub.java
@@ -33,7 +33,7 @@ public class MemberStub {
                 .profession(ProfessionStub.getProfessionEntity())
                 .role(UserRole.FIRST_LOGIN)
                 .authType(AuthType.OAUTH)
-                .rank(MemberRank.SEED)
+                .tier(MemberTier.SEED)
                 .experience(0.0)
                 .build();
     }

--- a/src/test/resources/db/setup.sql
+++ b/src/test/resources/db/setup.sql
@@ -1,3 +1,3 @@
-INSERT INTO member (id, name, image, region, profession_id, role, auth_type, rank, experience, is_deleted, deleted_at)
+INSERT INTO member (id, name, image, region, profession_id, role, auth_type, tier, experience, is_deleted, deleted_at)
 VALUES (1, 'test', 'http://localhost:4572/user/1/profile/2024030416531039839905-b7e8-4ad3-9552-7d9cbc01cb14-test.jpg',
         '서울', 1, 'FIRST_LOGIN', 'OAUTH', 'SEED', 0.0, false, null);


### PR DESCRIPTION
## 💁 해결 하려는 문제를 적어주세요 

- rank 예약어로 인한 DB insert 쿼리 실패 버그

## 🤔 어떤 방식으로 해결했는지 적어주세요 

- rank 칼럼의 이름을 tier로 변경하고 해당하는 코드 대응
