### PR TITLE
:bug: [STMT-146] 표준 예외가 아닌 커스텀 예외를 사용하도록 변경

### DIFF
--- a/src/main/java/com/stumeet/server/common/auth/exception/IllegalKeyAlgorithmException.java
+++ b/src/main/java/com/stumeet/server/common/auth/exception/IllegalKeyAlgorithmException.java
@@ -6,6 +6,11 @@ import org.springframework.security.core.AuthenticationException;
 public class IllegalKeyAlgorithmException extends AuthenticationException {
     private final ErrorCode errorCode;
 
+    public IllegalKeyAlgorithmException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
     public IllegalKeyAlgorithmException(ErrorCode errorCode, Throwable cause) {
         super(errorCode.getMessage(), cause);
         this.errorCode = errorCode;

--- a/src/main/java/com/stumeet/server/common/auth/exception/NotExistsOAuthProviderException.java
+++ b/src/main/java/com/stumeet/server/common/auth/exception/NotExistsOAuthProviderException.java
@@ -1,0 +1,11 @@
+package com.stumeet.server.common.auth.exception;
+
+import com.stumeet.server.common.response.ErrorCode;
+import org.springframework.security.core.AuthenticationException;
+
+public class NotExistsOAuthProviderException extends AuthenticationException {
+
+    public NotExistsOAuthProviderException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+    }
+}

--- a/src/main/java/com/stumeet/server/common/client/oauth/apple/AppleIdTokenProvider.java
+++ b/src/main/java/com/stumeet/server/common/client/oauth/apple/AppleIdTokenProvider.java
@@ -31,7 +31,7 @@ public class AppleIdTokenProvider {
         ApplePublicKeyResponses.ApplePublicKeyResponse applePublicKey = publicKeys.keys().stream()
                 .filter(key -> key.kid().equals(kid))
                 .findAny()
-                .orElseThrow(() -> new IllegalArgumentException("매칭되는 kid가 존재하지 않습니다."));
+                .orElseThrow(() -> new IllegalKeyAlgorithmException(ErrorCode.ILLEGAL_KEY_ALGORITHM_EXCEPTION));
 
         BigInteger modulus = new BigInteger(1, Base64.getUrlDecoder().decode(applePublicKey.n()));
         BigInteger publicExponent = new BigInteger(1, Base64.getUrlDecoder().decode(applePublicKey.e()));

--- a/src/main/java/com/stumeet/server/common/exception/model/NotExistsException.java
+++ b/src/main/java/com/stumeet/server/common/exception/model/NotExistsException.java
@@ -1,0 +1,9 @@
+package com.stumeet.server.common.exception.model;
+
+import com.stumeet.server.common.response.ErrorCode;
+
+public class NotExistsException extends BusinessException {
+    public NotExistsException(String message, ErrorCode errorCode) {
+        super(message, errorCode);
+    }
+}

--- a/src/main/java/com/stumeet/server/common/response/ErrorCode.java
+++ b/src/main/java/com/stumeet/server/common/response/ErrorCode.java
@@ -33,6 +33,7 @@ public enum ErrorCode {
     JWT_INVALID_SIGNATURE_EXCEPTION(HttpStatus.UNAUTHORIZED, "JWT 서명이 유효하지 않습니다."),
     ILLEGAL_KEY_ALGORITHM_EXCEPTION(HttpStatus.UNAUTHORIZED, "유효하지 않은 키 알고리즘입니다."),
     JWT_TOKEN_PARSING_EXCEPTION(HttpStatus.UNAUTHORIZED, "JWT 토큰 파싱에 실패했습니다."),
+    NOT_EXIST_OAUTH_PROVIDER(HttpStatus.UNAUTHORIZED, "존재하지 않는 OAuth 제공자입니다."),
 
     /*
         403 - FORBIDDEN
@@ -43,6 +44,7 @@ public enum ErrorCode {
 	    404 - NOT FOUND
     */
     STUDY_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 스터디 입니다."),
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 멤버 입니다."),
 
     /*
         500 - INTERNAL SERVER ERROR

--- a/src/main/java/com/stumeet/server/member/adapter/out/persistence/MemberPersistenceAdapter.java
+++ b/src/main/java/com/stumeet/server/member/adapter/out/persistence/MemberPersistenceAdapter.java
@@ -1,10 +1,13 @@
 package com.stumeet.server.member.adapter.out.persistence;
 
 import com.stumeet.server.common.annotation.PersistenceAdapter;
+import com.stumeet.server.common.exception.model.NotExistsException;
+import com.stumeet.server.common.response.ErrorCode;
 import com.stumeet.server.member.application.port.out.MemberCommandPort;
 import com.stumeet.server.member.application.port.out.MemberQueryPort;
 import com.stumeet.server.member.domain.Member;
 import com.stumeet.server.member.domain.OAuthProvider;
+import com.stumeet.server.member.domain.exception.MemberNotExistsException;
 import lombok.RequiredArgsConstructor;
 
 @PersistenceAdapter
@@ -36,7 +39,7 @@ public class MemberPersistenceAdapter implements MemberQueryPort, MemberCommandP
     @Override
     public Member getById(Long id) {
         MemberJpaEntity memberJpaEntity = jpaMemberRepository.findById(id)
-                .orElseThrow(() -> new IllegalArgumentException("해당하는 ID의 유저가 존재하지 않습니다."));
+                .orElseThrow(() -> new MemberNotExistsException("해당하는 ID의 유저가 존재하지 않습니다. 전달받은 id : " + id, ErrorCode.MEMBER_NOT_FOUND));
 
         return memberMapper.toDomain(memberJpaEntity);
     }

--- a/src/main/java/com/stumeet/server/member/domain/OAuthProvider.java
+++ b/src/main/java/com/stumeet/server/member/domain/OAuthProvider.java
@@ -1,5 +1,7 @@
 package com.stumeet.server.member.domain;
 
+import com.stumeet.server.common.auth.exception.NotExistsOAuthProviderException;
+import com.stumeet.server.common.response.ErrorCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -17,6 +19,6 @@ public enum OAuthProvider {
         return Arrays.stream(values())
                 .filter(p -> p.getProvider().equals(provider))
                 .findAny()
-                .orElseThrow(() -> new IllegalArgumentException("알 수 없는 OAuth provider 입니다."));
+                .orElseThrow(() -> new NotExistsOAuthProviderException(ErrorCode.NOT_EXIST_OAUTH_PROVIDER));
     }
 }

--- a/src/main/java/com/stumeet/server/member/domain/exception/MemberNotExistsException.java
+++ b/src/main/java/com/stumeet/server/member/domain/exception/MemberNotExistsException.java
@@ -1,0 +1,10 @@
+package com.stumeet.server.member.domain.exception;
+
+import com.stumeet.server.common.exception.model.NotExistsException;
+import com.stumeet.server.common.response.ErrorCode;
+
+public class MemberNotExistsException extends NotExistsException {
+    public MemberNotExistsException(String message, ErrorCode errorCode) {
+        super(message, errorCode);
+    }
+}


### PR DESCRIPTION
## 💁 해결 하려는 문제를 적어주세요 

- 표준 예외를 사용하여 핸들링 되지 않았던 예외들을 커스텀 예외를 사용하도록 변경 필요

## 🤔 어떤 방식으로 해결했는지 적어주세요 

- 커스텀 예외를 이용하여 예외를 던지도록 변경했습니다.

## 🙋 중점적으로 리뷰 했으면 하는 부분이 있다면 적어주세요 

- 특정 데이터가 존재하지 않는 예외에 대해 계층 구조를 만들었습니다. (BusinessException -> NotExistsException -> MemberNotExistsException)
- 도메인 관련 예외들은 domain 패키지에 exception이라는 하위 패키지를 만들었는데 어떻게 생각하시는지 궁금합니다. 

## 🧑‍🏫 이해를 위해 필요한 자료가 있다면 첨부해주세요

- 다음은 계층화된 커스텀 Exception의 예시입니다.
<img width="1623" alt="image" src="https://github.com/Stumeet/STUMEET-SERVER/assets/41960243/9cb89917-aad3-422b-9991-a20bf7475df6">
