### PR TITLE
:construction_worker: [STMT-6] dev 브랜치에 push가 발생해도 서버 배포를 진행하도록 변경

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -60,8 +60,6 @@ jobs:
       ## deploy to production
       - name: Deploy to prod
         uses: appleboy/ssh-action@master
-        id: deploy-prod
-        if: contains(github.ref, 'main')
         with:
           host: ${{ secrets.AWS_PUBLIC_IP }}
           username: ${{ secrets.AWS_USER }}


### PR DESCRIPTION
## 💁 해결 하려는 문제를 적어주세요 

- dev 브랜치에도 push가 발생해도 서버 배포를 진행하도록 변경

## 🤔 어떤 방식으로 해결했는지 적어주세요 

- 제어문을 제거하여 dev 브랜치에도 push가 발생하면 배포가 이루어지도록 처리했습니다.
