### PR TITLE
:card_file_box: [STMT-220] 테이블 `study_domain` 외래키 제약조건 변경 및 각 필드 데이터 크기 증대

### DIFF
--- a/src/main/resources/db/migration/V1.4__add_study_table.sql
+++ b/src/main/resources/db/migration/V1.4__add_study_table.sql
@@ -8,10 +8,10 @@ CREATE TABLE `study_field`
 
 CREATE TABLE `study_domain`
 (
-    `id`             BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY COMMENT '스터디 태그 ID',
-    `study_field_id` BIGINT NOT NULL COMMENT '스터디 분야 ID',
+    `id`             BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY COMMENT '스터디 도메인 ID',
+    `study_field_id` BIGINT NULL COMMENT '스터디 분야 ID',
 
-    CONSTRAINT fk_study_field FOREIGN KEY (study_field_id)
+    CONSTRAINT fk_study_domain_with_field FOREIGN KEY (study_field_id)
         REFERENCES study_field (id)
         ON DELETE SET NULL ON UPDATE CASCADE
 ) ENGINE = InnoDB
@@ -24,10 +24,10 @@ CREATE TABLE `study`
     `study_domain_id` BIGINT       NOT NULL COMMENT '스터디 도메인 ID',
     `name`            VARCHAR(255) NOT NULL COMMENT '스터디명',
     `region`          VARCHAR(50)  NOT NULL COMMENT '활동 지역',
-    `intro`           VARCHAR(100) NOT NULL COMMENT '소개',
-    `rule`            VARCHAR(100) NULL COMMENT '규칙',
+    `intro`           VARCHAR(200) NOT NULL COMMENT '소개',
+    `rule`            VARCHAR(200) NULL COMMENT '규칙',
     `image`           VARCHAR(500) NOT NULL COMMENT '스터디 이미지의 URL',
-    `headcount`       TINYINT(50) NOT NULL DEFAULT 1 COMMENT '인원 수',
+    `headcount`       TINYINT(100) NOT NULL DEFAULT 1 COMMENT '인원 수',
     `start_date`      DATETIME     NOT NULL COMMENT '시작일',
     `end_date`        DATETIME     NOT NULL COMMENT '종료일',
     `created_at`      DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '생성 시간',
@@ -48,7 +48,7 @@ CREATE TABLE `study_tag`
 (
     `id`              BIGINT      NOT NULL AUTO_INCREMENT PRIMARY KEY COMMENT '스터디 태그 ID',
     `study_domain_id` BIGINT      NOT NULL COMMENT '스터디 관련 ID',
-    `name`            VARCHAR(10) NOT NULL COMMENT '태그명',
+    `name`            VARCHAR(20) NOT NULL COMMENT '태그명',
 
     CONSTRAINT fk_study_domain_with_tag FOREIGN KEY (study_domain_id)
         REFERENCES study_domain (id)


### PR DESCRIPTION
## 💁 해결 하려는 문제를 적어주세요 

- 테이블 study_domain ddl 제약조건 설정 실수로 flyway의 실행에 오류가 있었습니다.

## 🤔 어떤 방식으로 해결했는지 적어주세요
[이전 코드]
``` sql
`study_field_id` BIGINT NOT NULL COMMENT '스터디 분야 ID',

    CONSTRAINT fk_study_field FOREIGN KEY (study_field_id)
        REFERENCES study_field (id)
        ON DELETE SET NULL ON UPDATE CASCADE
```

- 이전 코드에서 외래키 제약 조건을 삭제 시 null로 설정하게 해두었는데 외래키 필드가 not null로 설정되어 있어 문제가 발생했습니다.
- 해당 부분을 nullable로 선언하였습니다.

## 🙋 중점적으로 리뷰 했으면 하는 부분이 있다면 적어주세요 

- 이전 코드는 요구사항에 딱 맞게 데이터 크기를 설정했는데, 변경하는 김에 크기를 조금씩 증가시켰습니다.
- 일반적으로 데이터 크기를 조금 여유있게 잡는 것은 데이터 무결성을 위해서 또는 미래의 요구사항 변경 시 데이터 크기 변경이 성능에 영향을 주기 때문이라고 합니다.
- 하지만 조금 고민이 되는게 만약에 (저의 잘못이겠지만) 예외처리가 잘못되어 스터디 인원에 50명 이상이 들어간다던가, 소개글, 규칙 등에 100자 이상이 들어갈 수 있는 가능성이 생기는 것이 걱정이 됩니다.
- DB로부터 에러가 발생하여 서버 에러 (Internal Exception)이 응답되는 것보다는 낫다고 생각하지만 이에 대해서 어떻게 생각하시는지 궁금합니다!