### PR TITLE
✨ [STMT-168] 스터디 삭제 api 및 s3에 저장된 관련 파일 삭제 기능 구현

### DIFF
--- a/src/main/java/com/stumeet/server/common/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/stumeet/server/common/exception/handler/GlobalExceptionHandler.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.HandlerMethodValidationException;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
 
 @Slf4j
 @RestControllerAdvice
@@ -75,6 +76,16 @@ public class GlobalExceptionHandler {
 
         return ResponseEntity.badRequest()
                 .body(response);
+    }
+
+    @ExceptionHandler(MaxUploadSizeExceededException.class)
+    protected ResponseEntity<ApiResponse> handleMaxUploadSizeExceededException(final MaxUploadSizeExceededException e) {
+        log.warn(ERROR_LOG_MESSAGE, e.getClass().getSimpleName(), e.getMessage());
+
+        ApiResponse response = ApiResponse.fail(ErrorCode.FILE_SIZE_LIMIT_EXCEEDED_EXCEPTION);
+
+        return ResponseEntity.badRequest()
+            .body(response);
     }
 
     @ExceptionHandler(BadRequestException.class)

--- a/src/main/java/com/stumeet/server/common/response/ErrorCode.java
+++ b/src/main/java/com/stumeet/server/common/response/ErrorCode.java
@@ -17,8 +17,9 @@ public enum ErrorCode {
     METHOD_ARGUMENT_NOT_VALID_EXCEPTION(HttpStatus.BAD_REQUEST, "요청 값이 검증되지 않은 값 입니다."),
     METHOD_ARGUMENT_TYPE_MISMATCH_EXCEPTION(HttpStatus.BAD_REQUEST, "요청 값의 타입이 잘못되었습니다."),
     INVALID_FORMAT_EXCEPTION(HttpStatus.BAD_REQUEST, "요청 값이 유효하지 않은 데이터입니다."),
-    DUPLICATE_NICKNAME_EXCEPTION(HttpStatus.BAD_REQUEST, "닉네임이 중복되었습니다."),
     NOT_EXIST_EXCEPTION(HttpStatus.BAD_REQUEST, "요청으로 전달한 값이 존재하지 않습니다."),
+
+    DUPLICATE_NICKNAME_EXCEPTION(HttpStatus.BAD_REQUEST, "닉네임이 중복되었습니다."),
     NOT_MATCHED_TOKEN_EXCEPTION(HttpStatus.BAD_REQUEST, "요청으로 전달한 토큰과 매칭되는 토큰이 없습니다."),
     NOT_MATCHED_REFRESH_TOKEN_EXCEPTION(HttpStatus.BAD_REQUEST, "요청으로 전달한 리프레시 토큰과 서버의 리프레시 토큰이 일치하지 않습니다."),
     EXPIRED_REFRESH_TOKEN_EXCEPTION(HttpStatus.BAD_REQUEST, "리프레시 토큰이 만료되었습니다."),
@@ -54,6 +55,7 @@ public enum ErrorCode {
         500 - INTERNAL SERVER ERROR
     */
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부에서 에러가 발생하였습니다."),
+    FILE_IO_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "파일 입출력에 실패하였습니다."),
     UPLOAD_FILE_FAIL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "파일 업로드에 실패하였습니다."),
     NOT_IMPLEMENTED_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "구현되지 않은 메서드를 사용했습니다."),
     ;

--- a/src/main/java/com/stumeet/server/common/response/ErrorCode.java
+++ b/src/main/java/com/stumeet/server/common/response/ErrorCode.java
@@ -18,6 +18,7 @@ public enum ErrorCode {
     METHOD_ARGUMENT_TYPE_MISMATCH_EXCEPTION(HttpStatus.BAD_REQUEST, "요청 값의 타입이 잘못되었습니다."),
     INVALID_FORMAT_EXCEPTION(HttpStatus.BAD_REQUEST, "요청 값이 유효하지 않은 데이터입니다."),
     NOT_EXIST_EXCEPTION(HttpStatus.BAD_REQUEST, "요청으로 전달한 값이 존재하지 않습니다."),
+    FILE_SIZE_LIMIT_EXCEEDED_EXCEPTION(HttpStatus.BAD_REQUEST, "첨부파일은 최대 5MB 까지 가능합니다."),
 
     DUPLICATE_NICKNAME_EXCEPTION(HttpStatus.BAD_REQUEST, "닉네임이 중복되었습니다."),
     NOT_MATCHED_TOKEN_EXCEPTION(HttpStatus.BAD_REQUEST, "요청으로 전달한 토큰과 매칭되는 토큰이 없습니다."),

--- a/src/main/java/com/stumeet/server/common/response/SuccessCode.java
+++ b/src/main/java/com/stumeet/server/common/response/SuccessCode.java
@@ -14,6 +14,7 @@ public enum SuccessCode {
      */
     GET_SUCCESS(HttpStatus.OK, "조회에 성공했습니다."),
     UPDATE_SUCCESS(HttpStatus.OK, "수정에 성공했습니다."),
+    DELETE_SUCCESS(HttpStatus.OK, "삭제에 성공했습니다."),
     STUDY_LEAVE_SUCCESS(HttpStatus.OK, "스터디 탈퇴에 성공했습니다."),
     STUDY_KICK_SUCCESS(HttpStatus.OK, "스터디원 강퇴에 성공했습니다."),
 

--- a/src/main/java/com/stumeet/server/file/adapter/out/S3ImageStorageAdapter.java
+++ b/src/main/java/com/stumeet/server/file/adapter/out/S3ImageStorageAdapter.java
@@ -74,14 +74,16 @@ public class S3ImageStorageAdapter implements FileCommandPort {
 	public void deleteFolder(String folder) {
 		List<ObjectIdentifier> objectIdentifiers = getObjectIdentifiers(folder);
 
-		if (!objectIdentifiers.isEmpty()) {
-			DeleteObjectsRequest deleteObjectsRequest = DeleteObjectsRequest.builder()
-				.bucket(bucket)
-				.delete(builder -> builder.objects(objectIdentifiers))
-				.build();
-
-			s3Client.deleteObjects(deleteObjectsRequest);
+		if (objectIdentifiers.isEmpty()) {
+			return;
 		}
+
+		DeleteObjectsRequest deleteObjectsRequest = DeleteObjectsRequest.builder()
+			.bucket(bucket)
+			.delete(builder -> builder.objects(objectIdentifiers))
+			.build();
+
+		s3Client.deleteObjects(deleteObjectsRequest);
 	}
 
 	private List<ObjectIdentifier> getObjectIdentifiers(String prefix) {

--- a/src/main/java/com/stumeet/server/file/application/port/dto/FileUrl.java
+++ b/src/main/java/com/stumeet/server/file/application/port/dto/FileUrl.java
@@ -1,0 +1,6 @@
+package com.stumeet.server.file.application.port.dto;
+
+public record FileUrl(
+	String url
+) {
+}

--- a/src/main/java/com/stumeet/server/file/application/port/in/FileDeleteUseCase.java
+++ b/src/main/java/com/stumeet/server/file/application/port/in/FileDeleteUseCase.java
@@ -1,0 +1,8 @@
+package com.stumeet.server.file.application.port.in;
+
+public interface FileDeleteUseCase {
+
+	void deleteStudyRelatedImage(Long studyId);
+
+	void deleteUserRelatedImage(Long userId);
+}

--- a/src/main/java/com/stumeet/server/file/application/port/in/FileUploadUseCase.java
+++ b/src/main/java/com/stumeet/server/file/application/port/in/FileUploadUseCase.java
@@ -3,13 +3,13 @@ package com.stumeet.server.file.application.port.in;
 import java.util.List;
 
 import org.springframework.web.multipart.MultipartFile;
-import com.stumeet.server.file.application.port.out.FileUrl;
+import com.stumeet.server.file.application.port.dto.FileUrl;
 
 	public interface FileUploadUseCase {
 
 	FileUrl uploadUserProfileImage(Long userId, MultipartFile multipartFile);
 
-	FileUrl uploadStudyMainImage(MultipartFile multipartFile);
+	FileUrl uploadStudyMainImage(Long studyId, MultipartFile multipartFile);
 
 	List<FileUrl> uploadStudyActivityImage(Long studyId, List<MultipartFile> multipartFile);
 }

--- a/src/main/java/com/stumeet/server/file/application/port/out/FileCommandPort.java
+++ b/src/main/java/com/stumeet/server/file/application/port/out/FileCommandPort.java
@@ -7,6 +7,7 @@ import org.springframework.web.multipart.MultipartFile;
 import com.stumeet.server.file.application.port.dto.FileUrl;
 
 public interface FileCommandPort {
+
 	FileUrl uploadImageFile(MultipartFile multipartFile, String directoryPath);
 
 	List<FileUrl> uploadImageFiles(List<MultipartFile> multipartFileList, String directoryPath);

--- a/src/main/java/com/stumeet/server/file/application/port/out/FileCommandPort.java
+++ b/src/main/java/com/stumeet/server/file/application/port/out/FileCommandPort.java
@@ -4,8 +4,12 @@ import java.util.List;
 
 import org.springframework.web.multipart.MultipartFile;
 
+import com.stumeet.server.file.application.port.dto.FileUrl;
+
 public interface FileCommandPort {
 	FileUrl uploadImageFile(MultipartFile multipartFile, String directoryPath);
 
 	List<FileUrl> uploadImageFiles(List<MultipartFile> multipartFileList, String directoryPath);
+
+	void deleteFolder(String folder);
 }

--- a/src/main/java/com/stumeet/server/file/application/port/out/FileUrl.java
+++ b/src/main/java/com/stumeet/server/file/application/port/out/FileUrl.java
@@ -1,6 +1,0 @@
-package com.stumeet.server.file.application.port.out;
-
-public record FileUrl(
-	String url
-) {
-}

--- a/src/main/java/com/stumeet/server/file/application/service/FileDeleteService.java
+++ b/src/main/java/com/stumeet/server/file/application/service/FileDeleteService.java
@@ -1,0 +1,28 @@
+package com.stumeet.server.file.application.service;
+
+import com.stumeet.server.common.annotation.UseCase;
+import com.stumeet.server.file.application.port.in.FileDeleteUseCase;
+import com.stumeet.server.file.application.port.out.FileCommandPort;
+
+import lombok.RequiredArgsConstructor;
+
+@UseCase
+@RequiredArgsConstructor
+public class FileDeleteService implements FileDeleteUseCase {
+
+	private final String STUDY_PREFIX = "study/%d/";
+	private final String USER_PREFIX = "user/%d/";
+
+
+	private final FileCommandPort fileCommandPort;
+
+	@Override
+	public void deleteStudyRelatedImage(Long studyId) {
+		fileCommandPort.deleteFolder(String.format(STUDY_PREFIX, studyId));
+	}
+
+	@Override
+	public void deleteUserRelatedImage(Long userId) {
+		fileCommandPort.deleteFolder(String.format(USER_PREFIX, userId));
+	}
+}

--- a/src/main/java/com/stumeet/server/file/application/service/FileUploadService.java
+++ b/src/main/java/com/stumeet/server/file/application/service/FileUploadService.java
@@ -7,7 +7,7 @@ import org.springframework.web.multipart.MultipartFile;
 import com.stumeet.server.common.annotation.UseCase;
 import com.stumeet.server.file.application.port.in.FileUploadUseCase;
 import com.stumeet.server.file.application.port.out.FileCommandPort;
-import com.stumeet.server.file.application.port.out.FileUrl;
+import com.stumeet.server.file.application.port.dto.FileUrl;
 
 import lombok.RequiredArgsConstructor;
 
@@ -16,30 +16,35 @@ import lombok.RequiredArgsConstructor;
 public class FileUploadService implements FileUploadUseCase {
 
 	private static final String USER_PROFILE_IMAGE_DIRECTORY_PATH = "user/%d/profile";
-	private static final String STUDY_MAIN_IMAGE_DIRECTORY_PATH = "study/main";
+	private static final String STUDY_MAIN_IMAGE_DIRECTORY_PATH = "study/%d/main";
 	private static final String STUDY_ACTIVITY_IMAGE_DIRECTORY_PATH = "study/%d/activity";
+	private static final String EMPTY_URL = "";
 
 	private final FileCommandPort fileCommandPort;
 
 	@Override
 	public FileUrl uploadUserProfileImage(Long userId, MultipartFile multipartFile) {
-		String path = String.format(USER_PROFILE_IMAGE_DIRECTORY_PATH, userId);
+		if (multipartFile == null) {
+			return new FileUrl(EMPTY_URL);
+		}
 
+		String path = String.format(USER_PROFILE_IMAGE_DIRECTORY_PATH, userId);
 		return fileCommandPort.uploadImageFile(multipartFile, path);
 	}
 
 	@Override
-	public FileUrl uploadStudyMainImage(MultipartFile multipartFile) {
+	public FileUrl uploadStudyMainImage(Long studyId, MultipartFile multipartFile) {
 		if (multipartFile == null) {
-			return new FileUrl(null);
+			return new FileUrl(EMPTY_URL);
 		}
-		return fileCommandPort.uploadImageFile(multipartFile, STUDY_MAIN_IMAGE_DIRECTORY_PATH);
+
+		String path = String.format(STUDY_MAIN_IMAGE_DIRECTORY_PATH, studyId);
+		return fileCommandPort.uploadImageFile(multipartFile, path);
 	}
 
 	@Override
 	public List<FileUrl> uploadStudyActivityImage(Long studyId, List<MultipartFile> multipartFiles) {
 		String path = String.format(STUDY_ACTIVITY_IMAGE_DIRECTORY_PATH, studyId);
-
 		return fileCommandPort.uploadImageFiles(multipartFiles, path);
 	}
 }

--- a/src/main/java/com/stumeet/server/study/adapter/in/web/StudyDeleteApi.java
+++ b/src/main/java/com/stumeet/server/study/adapter/in/web/StudyDeleteApi.java
@@ -1,0 +1,36 @@
+package com.stumeet.server.study.adapter.in.web;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import com.stumeet.server.common.annotation.WebAdapter;
+import com.stumeet.server.common.auth.model.LoginMember;
+import com.stumeet.server.common.model.ApiResponse;
+import com.stumeet.server.common.response.SuccessCode;
+import com.stumeet.server.study.application.port.in.StudyDeleteUseCase;
+
+import lombok.RequiredArgsConstructor;
+
+@WebAdapter
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/studies")
+public class StudyDeleteApi {
+
+	private final StudyDeleteUseCase studyDeleteUseCase;
+
+	@DeleteMapping("/{studyId}")
+	public ResponseEntity<ApiResponse<Void>> delete(
+		@AuthenticationPrincipal LoginMember member,
+		@PathVariable Long studyId
+	) {
+		studyDeleteUseCase.delete(studyId, member.getMember().getId());
+
+		return new ResponseEntity<>(
+			ApiResponse.success(SuccessCode.DELETE_SUCCESS),
+			HttpStatus.OK);
+	}
+}

--- a/src/main/java/com/stumeet/server/study/adapter/out/persistance/JpaStudyTagRepository.java
+++ b/src/main/java/com/stumeet/server/study/adapter/out/persistance/JpaStudyTagRepository.java
@@ -4,15 +4,12 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-import org.springframework.transaction.annotation.Propagation;
-import org.springframework.transaction.annotation.Transactional;
 
 import com.stumeet.server.study.adapter.out.persistance.entity.StudyTagJpaEntity;
 
 public interface JpaStudyTagRepository extends JpaRepository<StudyTagJpaEntity, Long> {
 
 	@Modifying
-	@Transactional(propagation = Propagation.MANDATORY)
 	@Query("DELETE FROM StudyTagJpaEntity s WHERE s.studyId = :studyId")
 	void deleteAllByStudyId(@Param("studyId") Long studyId);
 }

--- a/src/main/java/com/stumeet/server/study/adapter/out/persistance/JpaStudyTagRepository.java
+++ b/src/main/java/com/stumeet/server/study/adapter/out/persistance/JpaStudyTagRepository.java
@@ -1,10 +1,18 @@
 package com.stumeet.server.study.adapter.out.persistance;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.stumeet.server.study.adapter.out.persistance.entity.StudyTagJpaEntity;
 
 public interface JpaStudyTagRepository extends JpaRepository<StudyTagJpaEntity, Long> {
 
-	void deleteAllByStudyId(Long studyId);
+	@Modifying
+	@Transactional(propagation = Propagation.MANDATORY)
+	@Query("DELETE FROM StudyTagJpaEntity s WHERE s.studyId = :studyId")
+	void deleteAllByStudyId(@Param("studyId") Long studyId);
 }

--- a/src/main/java/com/stumeet/server/study/adapter/out/persistance/StudyPersistenceAdapter.java
+++ b/src/main/java/com/stumeet/server/study/adapter/out/persistance/StudyPersistenceAdapter.java
@@ -37,4 +37,9 @@ public class StudyPersistenceAdapter implements StudyQueryPort, StudyValidationP
 
 		return studyPersistenceMapper.toDomain(entity);
 	}
+
+	@Override
+	public void delete(Long studyId) {
+		studyRepository.deleteById(studyId);
+	}
 }

--- a/src/main/java/com/stumeet/server/study/adapter/out/persistance/entity/StudyJpaEntity.java
+++ b/src/main/java/com/stumeet/server/study/adapter/out/persistance/entity/StudyJpaEntity.java
@@ -15,6 +15,7 @@ import java.util.List;
 
 import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.Comment;
+import org.hibernate.annotations.SQLDelete;
 
 import com.stumeet.server.common.model.BaseTimeEntity;
 
@@ -32,10 +33,11 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "study")
-@Getter
+@SQLDelete(sql = "UPDATE study SET is_deleted = true WHERE id = ? AND is_deleted = false")
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
 public class StudyJpaEntity extends BaseTimeEntity {
 
 	@Id

--- a/src/main/java/com/stumeet/server/study/adapter/out/persistance/mapper/StudyTagPersistenceMapper.java
+++ b/src/main/java/com/stumeet/server/study/adapter/out/persistance/mapper/StudyTagPersistenceMapper.java
@@ -1,6 +1,7 @@
 package com.stumeet.server.study.adapter.out.persistance.mapper;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Component;
 
@@ -21,6 +22,6 @@ public class StudyTagPersistenceMapper {
 				.studyId(studyId)
 				.name(domain)
 				.build())
-			.toList();
+			.collect(Collectors.toList());
 	}
 }

--- a/src/main/java/com/stumeet/server/study/application/port/in/StudyDeleteUseCase.java
+++ b/src/main/java/com/stumeet/server/study/application/port/in/StudyDeleteUseCase.java
@@ -1,0 +1,6 @@
+package com.stumeet.server.study.application.port.in;
+
+public interface StudyDeleteUseCase {
+
+	void delete(Long studyId, Long memberId);
+}

--- a/src/main/java/com/stumeet/server/study/application/port/in/StudyImageUpdateUseCase.java
+++ b/src/main/java/com/stumeet/server/study/application/port/in/StudyImageUpdateUseCase.java
@@ -1,0 +1,8 @@
+package com.stumeet.server.study.application.port.in;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public interface StudyImageUpdateUseCase {
+
+	void updateMainImage(Long studyId, MultipartFile imageFile);
+}

--- a/src/main/java/com/stumeet/server/study/application/port/out/StudyCommandPort.java
+++ b/src/main/java/com/stumeet/server/study/application/port/out/StudyCommandPort.java
@@ -5,4 +5,6 @@ import com.stumeet.server.study.domain.Study;
 public interface StudyCommandPort {
 
 	Study save(Study study);
+
+	void delete(Long studyId);
 }

--- a/src/main/java/com/stumeet/server/study/application/service/StudyDeleteService.java
+++ b/src/main/java/com/stumeet/server/study/application/service/StudyDeleteService.java
@@ -1,0 +1,38 @@
+package com.stumeet.server.study.application.service;
+
+import org.springframework.transaction.annotation.Transactional;
+
+import com.stumeet.server.common.annotation.UseCase;
+import com.stumeet.server.member.application.port.in.MemberValidationUseCase;
+import com.stumeet.server.study.application.port.in.StudyDeleteUseCase;
+import com.stumeet.server.study.application.port.out.StudyCommandPort;
+import com.stumeet.server.study.application.port.out.StudyTagCommandPort;
+import com.stumeet.server.studymember.application.port.in.StudyMemberValidationUseCase;
+import com.stumeet.server.studymember.application.port.out.StudyMemberLeavePort;
+
+import lombok.RequiredArgsConstructor;
+
+@UseCase
+@RequiredArgsConstructor
+@Transactional
+public class StudyDeleteService implements StudyDeleteUseCase {
+
+	private final MemberValidationUseCase memberValidationUseCase;
+	private final StudyMemberValidationUseCase studyMemberValidationUseCase;
+
+	private final StudyCommandPort studyCommandPort;
+	private final StudyTagCommandPort studyTagCommandPort;
+	private final StudyMemberLeavePort studyMemberLeavePort;
+
+	@Override
+	public void delete(Long studyId, Long memberId) {
+		memberValidationUseCase.checkById(memberId);
+		studyMemberValidationUseCase.checkStudyJoinMember(studyId, memberId);
+		studyMemberValidationUseCase.checkAdmin(studyId, memberId);
+
+		studyTagCommandPort.clearStudyTags(studyId);
+		studyMemberLeavePort.removeAllStudyMember(studyId);
+		studyCommandPort.delete(studyId);
+	}
+}
+

--- a/src/main/java/com/stumeet/server/study/application/service/StudyDeleteService.java
+++ b/src/main/java/com/stumeet/server/study/application/service/StudyDeleteService.java
@@ -3,10 +3,11 @@ package com.stumeet.server.study.application.service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.stumeet.server.common.annotation.UseCase;
+import com.stumeet.server.file.application.port.in.FileDeleteUseCase;
 import com.stumeet.server.member.application.port.in.MemberValidationUseCase;
 import com.stumeet.server.study.application.port.in.StudyDeleteUseCase;
+import com.stumeet.server.study.application.port.in.StudyValidationUseCase;
 import com.stumeet.server.study.application.port.out.StudyCommandPort;
-import com.stumeet.server.study.application.port.out.StudyTagCommandPort;
 import com.stumeet.server.studymember.application.port.in.StudyMemberValidationUseCase;
 import com.stumeet.server.studymember.application.port.out.StudyMemberLeavePort;
 
@@ -18,21 +19,28 @@ import lombok.RequiredArgsConstructor;
 public class StudyDeleteService implements StudyDeleteUseCase {
 
 	private final MemberValidationUseCase memberValidationUseCase;
+	private final StudyValidationUseCase studyValidationUseCase;
 	private final StudyMemberValidationUseCase studyMemberValidationUseCase;
+	private final FileDeleteUseCase fileDeleteUseCase;
 
 	private final StudyCommandPort studyCommandPort;
-	private final StudyTagCommandPort studyTagCommandPort;
 	private final StudyMemberLeavePort studyMemberLeavePort;
 
 	@Override
 	public void delete(Long studyId, Long memberId) {
-		memberValidationUseCase.checkById(memberId);
-		studyMemberValidationUseCase.checkStudyJoinMember(studyId, memberId);
-		studyMemberValidationUseCase.checkAdmin(studyId, memberId);
+		validateMemberCanDelete(studyId, memberId);
 
-		studyTagCommandPort.clearStudyTags(studyId);
 		studyMemberLeavePort.removeAllStudyMember(studyId);
 		studyCommandPort.delete(studyId);
+
+		fileDeleteUseCase.deleteStudyRelatedImage(studyId);
+	}
+
+	private void validateMemberCanDelete(long studyId, long memberId) {
+		memberValidationUseCase.checkById(memberId);
+		studyValidationUseCase.checkById(studyId);
+		studyMemberValidationUseCase.checkStudyJoinMember(studyId, memberId);
+		studyMemberValidationUseCase.checkAdmin(studyId, memberId);
 	}
 }
 

--- a/src/main/java/com/stumeet/server/study/application/service/StudyImageUpdateService.java
+++ b/src/main/java/com/stumeet/server/study/application/service/StudyImageUpdateService.java
@@ -1,0 +1,34 @@
+package com.stumeet.server.study.application.service;
+
+import org.springframework.web.multipart.MultipartFile;
+
+import com.stumeet.server.common.annotation.UseCase;
+import com.stumeet.server.file.application.port.dto.FileUrl;
+import com.stumeet.server.file.application.port.in.FileUploadUseCase;
+import com.stumeet.server.study.application.port.in.StudyImageUpdateUseCase;
+import com.stumeet.server.study.application.port.out.StudyCommandPort;
+import com.stumeet.server.study.application.port.out.StudyQueryPort;
+import com.stumeet.server.study.domain.Study;
+
+import lombok.RequiredArgsConstructor;
+
+@UseCase
+@RequiredArgsConstructor
+public class StudyImageUpdateService implements StudyImageUpdateUseCase {
+
+	private final FileUploadUseCase fileUploadUseCase;
+
+	private final StudyQueryPort studyQueryPort;
+	private final StudyCommandPort studyCommandPort;
+
+	@Override
+	public void updateMainImage(Long studyId, MultipartFile imageFile) {
+		if (imageFile != null) {
+			Study study = studyQueryPort.getById(studyId);
+
+			FileUrl mainImageUrl = fileUploadUseCase.uploadStudyMainImage(study.getId(), imageFile);
+			study.updateMainImageUrl(mainImageUrl.url());
+			studyCommandPort.save(study);
+		}
+	}
+}

--- a/src/main/java/com/stumeet/server/study/domain/Study.java
+++ b/src/main/java/com/stumeet/server/study/domain/Study.java
@@ -41,7 +41,7 @@ public class Study {
 
 	private boolean isDeleted;
 
-	public static Study create(StudyCreateCommand command, String imageUrl) {
+	public static Study create(StudyCreateCommand command) {
 		return Study.builder()
 			.studyDomain(StudyDomain.of(StudyField.getByName(command.studyField()), command.studyTags()))
 			.name(command.name())
@@ -53,13 +53,12 @@ public class Study {
 				StudyMeetingSchedule.of(
 					command.meetingTime(),
 					Repetition.of(command.meetingRepetitionType(), command.meetingRepetitionDates())))
-			.imageUrl(imageUrl)
 			.isFinished(false)
 			.isDeleted(false)
 			.build();
 	}
 
-	public static Study update(StudyUpdateCommand command, Study existingStudy, String mainImageUrl) {
+	public static Study update(StudyUpdateCommand command, Study existingStudy) {
 		return Study.builder()
 			.id(existingStudy.getId())
 			.studyDomain(StudyDomain.of(StudyField.getByName(command.studyField()), command.studyTags()))
@@ -72,14 +71,17 @@ public class Study {
 				StudyMeetingSchedule.of(
 					command.meetingTime(),
 					Repetition.of(command.meetingRepetitionType(), command.meetingRepetitionDates())))
-			.imageUrl(mainImageUrl)
 			.isFinished(existingStudy.isFinished)
 			.isDeleted(existingStudy.isDeleted)
 			.build();
 	}
 
-	public boolean isStudyTagsEquals(List<String> studyTags) {
-		return getStudyTags().equals(studyTags);
+	public void updateMainImageUrl(String imageUrl) {
+		this.imageUrl = imageUrl;
+	}
+
+	public boolean isStudyTagChanged(List<String> studyTags) {
+		return !getStudyTags().equals(studyTags);
 	}
 
 	public String getStudyFieldName() {

--- a/src/main/java/com/stumeet/server/studymember/adapter/out/persistence/JpaStudyMemberRepository.java
+++ b/src/main/java/com/stumeet/server/studymember/adapter/out/persistence/JpaStudyMemberRepository.java
@@ -7,5 +7,5 @@ public interface JpaStudyMemberRepository extends JpaRepository<StudyMemberJpaEn
 
     void deleteByStudyIdAndMemberId(Long studyId, Long memberId);
 
-    void deleteAllByStudy_Id(Long studyId);
+    void deleteAllByStudyId(Long studyId);
 }

--- a/src/main/java/com/stumeet/server/studymember/adapter/out/persistence/JpaStudyMemberRepository.java
+++ b/src/main/java/com/stumeet/server/studymember/adapter/out/persistence/JpaStudyMemberRepository.java
@@ -7,4 +7,5 @@ public interface JpaStudyMemberRepository extends JpaRepository<StudyMemberJpaEn
 
     void deleteByStudyIdAndMemberId(Long studyId, Long memberId);
 
+    void deleteAllByStudy_Id(Long studyId);
 }

--- a/src/main/java/com/stumeet/server/studymember/adapter/out/persistence/StudyMemberLeavePersistenceAdapter.java
+++ b/src/main/java/com/stumeet/server/studymember/adapter/out/persistence/StudyMemberLeavePersistenceAdapter.java
@@ -16,6 +16,6 @@ public class StudyMemberLeavePersistenceAdapter implements StudyMemberLeavePort 
 
     @Override
     public void removeAllStudyMember(Long studyId) {
-        jpaStudyMemberRepository.deleteAllByStudy_Id(studyId);
+        jpaStudyMemberRepository.deleteAllByStudyId(studyId);
     }
 }

--- a/src/main/java/com/stumeet/server/studymember/adapter/out/persistence/StudyMemberLeavePersistenceAdapter.java
+++ b/src/main/java/com/stumeet/server/studymember/adapter/out/persistence/StudyMemberLeavePersistenceAdapter.java
@@ -13,4 +13,9 @@ public class StudyMemberLeavePersistenceAdapter implements StudyMemberLeavePort 
     public void leave(Long studyId, Long memberId) {
         jpaStudyMemberRepository.deleteByStudyIdAndMemberId(studyId, memberId);
     }
+
+    @Override
+    public void removeAllStudyMember(Long studyId) {
+        jpaStudyMemberRepository.deleteAllByStudy_Id(studyId);
+    }
 }

--- a/src/main/java/com/stumeet/server/studymember/application/port/out/StudyMemberLeavePort.java
+++ b/src/main/java/com/stumeet/server/studymember/application/port/out/StudyMemberLeavePort.java
@@ -2,4 +2,6 @@ package com.stumeet.server.studymember.application.port.out;
 
 public interface StudyMemberLeavePort {
     void leave(Long studyId, Long memberId);
+
+    void removeAllStudyMember(Long studyId);
 }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -3,6 +3,9 @@ spring:
     activate:
       on-profile: local
     import: application-secret.properties
+  servlet:
+    multipart:
+      max-file-size: 5MB
   datasource:
     url: jdbc:h2:mem:testdb;DATABASE_TO_UPPER=false;MODE=MYSQL
     username: sa

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -6,6 +6,9 @@ spring:
     activate:
       on-profile: prod
     import: application-secret.properties
+  servlet:
+    multipart:
+      max-file-size: 5MB
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
     url: jdbc:mysql://${DEV_DB_ENDPOINT_URL}:3306/${DEV_DB_NAME}?serverTimezone=Asia/Seoul&autoReconnect=true&useSSL=true&useUnicode=true

--- a/src/test/java/com/stumeet/server/stub/FileStub.java
+++ b/src/test/java/com/stumeet/server/stub/FileStub.java
@@ -1,6 +1,6 @@
 package com.stumeet.server.stub;
 
-import com.stumeet.server.file.application.port.out.FileUrl;
+import com.stumeet.server.file.application.port.dto.FileUrl;
 
 public class FileStub {
     private FileStub() {

--- a/src/test/java/com/stumeet/server/stub/MemberStub.java
+++ b/src/test/java/com/stumeet/server/stub/MemberStub.java
@@ -13,6 +13,18 @@ public class MemberStub {
 
     }
 
+    public static Long getStudyAdminMemberId() {
+        return 1L;
+    }
+
+    public static Long getStudyMemberId() {
+        return 2L;
+    }
+
+    public static Long getNotStudyMemberId() {
+        return 3L;
+    }
+
     public static String getKakaoAccessTokenInfo() {
         return "{\"expiresInMillis\":20978166,\"id\":1,\"expires_in\":20978,\"app_id\":1,\"appId\":1}";
     }

--- a/src/test/java/com/stumeet/server/stub/StudyMemberStub.java
+++ b/src/test/java/com/stumeet/server/stub/StudyMemberStub.java
@@ -16,7 +16,7 @@ public class StudyMemberStub {
     public static StudyMemberJoinCommand getJoinCommand() {
         return StudyMemberJoinCommand.builder()
                 .studyId(1L)
-                .memberId(2L)
+                .memberId(3L)
                 .isAdmin(true)
                 .build();
     }

--- a/src/test/java/com/stumeet/server/study/adapter/in/web/StudyDeleteApiTest.java
+++ b/src/test/java/com/stumeet/server/study/adapter/in/web/StudyDeleteApiTest.java
@@ -46,7 +46,7 @@ class StudyDeleteApiTest extends ApiTest {
 		}
 
 		@Test
-		@WithMockMember(id = 3)
+		@WithMockMember(id = 3L)
 		@DisplayName("[실패] 삭제를 시도하는 멤버가 스터디 멤버가 아닌 경우 스터디 삭제에 실패한다.")
 		void fail_to_delete_when_member_not_joined_study() throws Exception {
 			mockMvc.perform(delete("/api/v1/studies/{id}", StudyStub.getStudyId())
@@ -67,7 +67,7 @@ class StudyDeleteApiTest extends ApiTest {
 		}
 
 		@Test
-		@WithMockMember(id = 2)
+		@WithMockMember(id = 2L)
 		@DisplayName("[실패] 삭제를 시도하는 멤버가 관리자가 아닌 경우 스터디 삭제에 실패한다.")
 		void fail_to_delete_when_study_member_is_not_admin() throws Exception {
 			mockMvc.perform(delete("/api/v1/studies/{id}", StudyStub.getStudyId())

--- a/src/test/java/com/stumeet/server/study/adapter/in/web/StudyDeleteApiTest.java
+++ b/src/test/java/com/stumeet/server/study/adapter/in/web/StudyDeleteApiTest.java
@@ -44,5 +44,47 @@ class StudyDeleteApiTest extends ApiTest {
 						fieldWithPath("message").description("응답 메시지")
 					)));
 		}
+
+		@Test
+		@WithMockMember(id = 3)
+		@DisplayName("[실패] 삭제를 시도하는 멤버가 스터디 멤버가 아닌 경우 스터디 삭제에 실패한다.")
+		void fail_to_delete_when_member_not_joined_study() throws Exception {
+			mockMvc.perform(delete("/api/v1/studies/{id}", StudyStub.getStudyId())
+					.header(AuthenticationHeader.ACCESS_TOKEN.getName(), TokenStub.getMockAccessToken()))
+				.andExpect(status().isForbidden())
+				.andDo(document("delete-study/fail/member-not-admin",
+					preprocessRequest(prettyPrint()),
+					preprocessResponse(prettyPrint()),
+					requestHeaders(headerWithName(AuthenticationHeader.ACCESS_TOKEN.getName()).description(
+						"서버로부터 전달받은 액세스 토큰")),
+					pathParameters(
+						parameterWithName("id").description("스터디 ID")
+					),
+					responseFields(
+						fieldWithPath("code").description("응답 상태"),
+						fieldWithPath("message").description("응답 메시지")
+					)));
+		}
+
+		@Test
+		@WithMockMember(id = 2)
+		@DisplayName("[실패] 삭제를 시도하는 멤버가 관리자가 아닌 경우 스터디 삭제에 실패한다.")
+		void fail_to_delete_when_study_member_is_not_admin() throws Exception {
+			mockMvc.perform(delete("/api/v1/studies/{id}", StudyStub.getStudyId())
+					.header(AuthenticationHeader.ACCESS_TOKEN.getName(), TokenStub.getMockAccessToken()))
+				.andExpect(status().isForbidden())
+				.andDo(document("delete-study/fail/member-not-joined_study",
+					preprocessRequest(prettyPrint()),
+					preprocessResponse(prettyPrint()),
+					requestHeaders(headerWithName(AuthenticationHeader.ACCESS_TOKEN.getName()).description(
+						"서버로부터 전달받은 액세스 토큰")),
+					pathParameters(
+						parameterWithName("id").description("스터디 ID")
+					),
+					responseFields(
+						fieldWithPath("code").description("응답 상태"),
+						fieldWithPath("message").description("응답 메시지")
+					)));
+		}
 	}
 }

--- a/src/test/java/com/stumeet/server/study/adapter/in/web/StudyDeleteApiTest.java
+++ b/src/test/java/com/stumeet/server/study/adapter/in/web/StudyDeleteApiTest.java
@@ -27,7 +27,7 @@ class StudyDeleteApiTest extends ApiTest {
 		@Test
 		@WithMockMember
 		@DisplayName("[성공] 스터디 삭제를 성공한다.")
-		void successDeleteStudy() throws Exception {
+		void success_delete_study() throws Exception {
 			mockMvc.perform(delete("/api/v1/studies/{id}", StudyStub.getStudyId())
 					.header(AuthenticationHeader.ACCESS_TOKEN.getName(), TokenStub.getMockAccessToken()))
 				.andExpect(status().isOk())

--- a/src/test/java/com/stumeet/server/study/adapter/in/web/StudyDeleteApiTest.java
+++ b/src/test/java/com/stumeet/server/study/adapter/in/web/StudyDeleteApiTest.java
@@ -1,0 +1,48 @@
+package com.stumeet.server.study.adapter.in.web;
+
+import static org.springframework.restdocs.headers.HeaderDocumentation.*;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import com.stumeet.server.common.auth.model.AuthenticationHeader;
+import com.stumeet.server.helper.WithMockMember;
+import com.stumeet.server.stub.StudyStub;
+import com.stumeet.server.stub.TokenStub;
+import com.stumeet.server.template.ApiTest;
+
+class StudyDeleteApiTest extends ApiTest {
+
+	@Nested
+	@DisplayName("스터디 삭제 API")
+	class DeleteStudy {
+
+		@Test
+		@WithMockMember
+		@DisplayName("[성공] 스터디 삭제를 성공한다.")
+		void successDeleteStudy() throws Exception {
+			mockMvc.perform(delete("/api/v1/studies/{id}", StudyStub.getStudyId())
+					.header(AuthenticationHeader.ACCESS_TOKEN.getName(), TokenStub.getMockAccessToken()))
+				.andExpect(status().isOk())
+				.andDo(document("delete-study/success",
+					preprocessRequest(prettyPrint()),
+					preprocessResponse(prettyPrint()),
+					requestHeaders(headerWithName(AuthenticationHeader.ACCESS_TOKEN.getName()).description(
+						"서버로부터 전달받은 액세스 토큰")),
+					pathParameters(
+						parameterWithName("id").description("스터디 ID")
+					),
+					responseFields(
+						fieldWithPath("code").description("응답 상태"),
+						fieldWithPath("message").description("응답 메시지")
+					)));
+		}
+	}
+}

--- a/src/test/java/com/stumeet/server/study/adapter/in/web/StudyUpdateApiTest.java
+++ b/src/test/java/com/stumeet/server/study/adapter/in/web/StudyUpdateApiTest.java
@@ -82,7 +82,7 @@ class StudyUpdateApiTest extends ApiTest {
 
 		@Test
 		@WithMockMember
-		@DisplayName("[성공] 이미지이 없는 요청으로 스터디 정보 수정에 성공한다.")
+		@DisplayName("[성공] 이미지가 없는 요청으로 스터디 정보 수정에 성공한다.")
 		void successUpdateWithoutImageTest() throws Exception {
 			StudyUpdateCommand request = StudyStub.getStudyUpdateCommand();
 

--- a/src/test/java/com/stumeet/server/studymember/adapter/in/web/StudyMemberJoinApiTest.java
+++ b/src/test/java/com/stumeet/server/studymember/adapter/in/web/StudyMemberJoinApiTest.java
@@ -3,6 +3,7 @@ package com.stumeet.server.studymember.adapter.in.web;
 import com.stumeet.server.common.auth.model.AuthenticationHeader;
 import com.stumeet.server.common.response.ErrorCode;
 import com.stumeet.server.helper.WithMockMember;
+import com.stumeet.server.stub.MemberStub;
 import com.stumeet.server.stub.StudyStub;
 import com.stumeet.server.stub.TokenStub;
 import com.stumeet.server.template.ApiTest;
@@ -31,7 +32,7 @@ class StudyMemberJoinApiTest extends ApiTest {
         private static final String PATH = "/api/v1/studies/{studyId}/members";
 
         @Test
-        @WithMockMember(id = 2L)
+        @WithMockMember(id = 3L)
         @DisplayName("[성공] 스터디 가입에 성공한다.")
         void successTest() throws Exception {
             Long studyId = StudyStub.getStudyId();

--- a/src/test/java/com/stumeet/server/studymember/adapter/out/persistence/JpaStudyMemberRepositoryCustomImplTest.java
+++ b/src/test/java/com/stumeet/server/studymember/adapter/out/persistence/JpaStudyMemberRepositoryCustomImplTest.java
@@ -26,7 +26,7 @@ class JpaStudyMemberRepositoryCustomImplTest extends IntegrationTest {
         @Test
         @DisplayName("[성공] 스터디 멤버를 조회한다.")
         void successTest() {
-            int want = 1;
+            int want = 2;
 
             List<SimpleStudyMemberResponse> got = studyMemberRepositoryCustom.findStudyMembersByStudyId(StudyStub.getStudyId());
 

--- a/src/test/resources/db/setup.sql
+++ b/src/test/resources/db/setup.sql
@@ -11,13 +11,23 @@ VALUES (1, 'java');
 INSERT INTO study_tag (study_id, name)
 VALUES (1, '객체지향프로그래밍');
 
+-- member id 1: study id 1의 멤버이자 관리자
 INSERT INTO member (id, name, image, region, profession_id, role, auth_type, tier, experience, is_deleted, deleted_at)
 VALUES (1, 'test1', 'http://localhost:4572/user/1/profile/2024030416531039839905-b7e8-4ad3-9552-7d9cbc01cb14-test.jpg',
         '서울', 1, 'MEMBER', 'OAUTH', 'SEED', 0.0, false, null);
 
+INSERT INTO study_member(member_id, study_id, is_admin, is_sent_grape)
+VALUES (1, 1, true, false);
+
+-- member id 2: study id 1의 멤버
 INSERT INTO member (id, name, image, region, profession_id, role, auth_type, tier, experience, is_deleted, deleted_at)
 VALUES (2, 'test2', 'http://localhost:4572/user/1/profile/2024030416531039839905-b7e8-4ad3-9552-7d9cbc01cb14-test.jpg',
         '서울', 1, 'MEMBER', 'OAUTH', 'SEED', 0.0, false, null);
 
 INSERT INTO study_member(member_id, study_id, is_admin, is_sent_grape)
-VALUES (1, 1, true, false);
+VALUES (2, 1, false, false);
+
+-- member id 3: study id 1의 외부자
+INSERT INTO member (id, name, image, region, profession_id, role, auth_type, tier, experience, is_deleted, deleted_at)
+VALUES (3, 'test3', 'http://localhost:4572/user/1/profile/2024030416531039839905-b7e8-4ad3-9552-7d9cbc01cb14-test.jpg',
+        '서울', 1, 'MEMBER', 'OAUTH', 'SEED', 0.0, false, null);


### PR DESCRIPTION
## 💁 해결 하려는 문제를 적어주세요 

- 스터디 삭제 기능을 구현합니다.
## 🤔 어떤 방식으로 해결했는지 적어주세요 

- 스터디 삭제 api
 - 전에 논의했던 내용대로 스터디는 soft delete하고, study member는 다 삭제, study tag는 남겨두었습니다.
 - 혹시 이에 대해서 추가 의견이 있다면 코멘트 부탁 드립니다.
- 관련 s3 객체 일괄 삭제
 - 현재 study/{studyId}/main과 study/{studyId}/activity 경로로 파일 객체들이 저장되고 있는데, studyId를 이용하여 해당하는 폳더를 삭제하는 기능을 구현했습니다.

## 🙋 중점적으로 리뷰 했으면 하는 부분이 있다면 적어주세요 

- soft delete에 대한 의견이 궁금합니다.
 - 어떤 것을 남기고, 어떤 것을 삭제할지에 대한 의견이 추가로 있으시면 공유해주세요!
- 최대 첨부파일 크기를 클라이언트에서 압축을 해온다는 가정하에 5mb로 정했는데 이에 대한 의견이 궁금합니다.
- test setup 파일에서 member 1을 admin, member 2를 그냥 study member, member 3을 외부자로 추가하면서 테스트 관련 코드가 조금 변경됐는데 이에 대해 의견이 있으시다면 공유해주시면 감사하겠습니다!