### PR TITLE
✨ [STMT-268] 가입 스터디 리스트 조회 API 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,6 @@ out/
 
 application-secret.properties
 
-src/main/resources/static/docs/index.html
+src/main/resources/static/docs/**
 
 src/main/generated/**

--- a/src/main/java/com/stumeet/server/common/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/stumeet/server/common/exception/handler/GlobalExceptionHandler.java
@@ -93,8 +93,8 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler({
         BadRequestException.class,
-        NotExistsException.class,
-        InvalidStateException.class
+        // NotExistsException.class,
+        // InvalidStateException.class
     })
     protected ResponseEntity<ApiResponse> handleCustomBadRequestException(final BusinessException e) {
         log.warn(ERROR_LOG_MESSAGE, e.getClass().getSimpleName(), e.getMessage());

--- a/src/main/java/com/stumeet/server/common/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/stumeet/server/common/exception/handler/GlobalExceptionHandler.java
@@ -3,9 +3,12 @@ package com.stumeet.server.common.exception.handler;
 import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import com.stumeet.server.common.exception.model.BadRequestException;
 import com.stumeet.server.common.exception.model.BusinessException;
+import com.stumeet.server.common.exception.model.InvalidStateException;
+import com.stumeet.server.common.exception.model.NotExistsException;
 import com.stumeet.server.common.response.ErrorCode;
 import com.stumeet.server.common.model.ApiResponse;
 import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.BindException;
@@ -88,15 +91,18 @@ public class GlobalExceptionHandler {
             .body(response);
     }
 
-    @ExceptionHandler(BadRequestException.class)
-    protected ResponseEntity<ApiResponse> handleCustomBadRequestException(final BadRequestException e) {
+    @ExceptionHandler({
+        BadRequestException.class,
+        NotExistsException.class,
+        InvalidStateException.class
+    })
+    protected ResponseEntity<ApiResponse> handleCustomBadRequestException(final BusinessException e) {
         log.warn(ERROR_LOG_MESSAGE, e.getClass().getSimpleName(), e.getMessage());
 
         String message = String.format("%s %s", e.getErrorCode().getMessage(), e.getMessage());
         ApiResponse response = ApiResponse.fail(e.getErrorCode().getHttpStatusCode(), message);
 
-        return ResponseEntity.badRequest()
-                .body(response);
+        return new ResponseEntity<>(response, e.getErrorCode().getHttpStatus());
     }
 
     @ExceptionHandler({

--- a/src/main/java/com/stumeet/server/common/response/ErrorCode.java
+++ b/src/main/java/com/stumeet/server/common/response/ErrorCode.java
@@ -56,6 +56,7 @@ public enum ErrorCode {
     STUDY_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 스터디 입니다."),
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 멤버 입니다."),
     STUDY_FIELD_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 스터디 분야 입니다."),
+    STUDY_STATUS_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 스터디 상태 입니다."),
 
     /*
         500 - INTERNAL SERVER ERROR

--- a/src/main/java/com/stumeet/server/study/adapter/in/web/StudyQueryApi.java
+++ b/src/main/java/com/stumeet/server/study/adapter/in/web/StudyQueryApi.java
@@ -1,13 +1,16 @@
 package com.stumeet.server.study.adapter.in.web;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 import com.stumeet.server.common.annotation.WebAdapter;
+import com.stumeet.server.common.auth.model.LoginMember;
 import com.stumeet.server.common.model.ApiResponse;
 import com.stumeet.server.common.response.SuccessCode;
+import com.stumeet.server.study.adapter.in.web.response.JoinedStudiesResponse;
 import com.stumeet.server.study.adapter.in.web.response.StudyDetailResponse;
 import com.stumeet.server.study.application.port.in.StudyQueryUseCase;
 
@@ -22,9 +25,18 @@ public class StudyQueryApi {
 
 	@GetMapping("/{studyId}")
 	public ResponseEntity<ApiResponse<StudyDetailResponse>> getStudyDetail(
-			@PathVariable(name = "studyId") Long studyId
+		@AuthenticationPrincipal LoginMember member,
+		@PathVariable(name = "studyId") Long studyId
 	) {
 		StudyDetailResponse response = studyQueryUseCase.getStudyDetailById(studyId);
+		return ResponseEntity.ok(ApiResponse.success(SuccessCode.GET_SUCCESS, response));
+	}
+
+	@GetMapping("/involved")
+	public ResponseEntity<ApiResponse<JoinedStudiesResponse>> getStudiesInvolved(
+		@AuthenticationPrincipal LoginMember member
+	) {
+		JoinedStudiesResponse response = studyQueryUseCase.getJoinedStudies(member.getMember().getId());
 		return ResponseEntity.ok(ApiResponse.success(SuccessCode.GET_SUCCESS, response));
 	}
 }

--- a/src/main/java/com/stumeet/server/study/adapter/in/web/StudyQueryApi.java
+++ b/src/main/java/com/stumeet/server/study/adapter/in/web/StudyQueryApi.java
@@ -32,7 +32,7 @@ public class StudyQueryApi {
 		return ResponseEntity.ok(ApiResponse.success(SuccessCode.GET_SUCCESS, response));
 	}
 
-	@GetMapping("/involved")
+	@GetMapping("/joined")
 	public ResponseEntity<ApiResponse<JoinedStudiesResponse>> getStudiesInvolved(
 		@AuthenticationPrincipal LoginMember member
 	) {

--- a/src/main/java/com/stumeet/server/study/adapter/in/web/StudyQueryApi.java
+++ b/src/main/java/com/stumeet/server/study/adapter/in/web/StudyQueryApi.java
@@ -5,6 +5,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
 import com.stumeet.server.common.annotation.WebAdapter;
 import com.stumeet.server.common.auth.model.LoginMember;
@@ -13,6 +14,7 @@ import com.stumeet.server.common.response.SuccessCode;
 import com.stumeet.server.study.adapter.in.web.response.JoinedStudiesResponse;
 import com.stumeet.server.study.adapter.in.web.response.StudyDetailResponse;
 import com.stumeet.server.study.application.port.in.StudyQueryUseCase;
+import com.stumeet.server.study.application.port.in.command.GetJoinedStudyCommand;
 
 import lombok.RequiredArgsConstructor;
 
@@ -32,11 +34,17 @@ public class StudyQueryApi {
 		return ResponseEntity.ok(ApiResponse.success(SuccessCode.GET_SUCCESS, response));
 	}
 
-	@GetMapping("/joined")
+	@GetMapping
 	public ResponseEntity<ApiResponse<JoinedStudiesResponse>> getStudiesInvolved(
-		@AuthenticationPrincipal LoginMember member
+		@AuthenticationPrincipal LoginMember member,
+		@RequestParam String status
 	) {
-		JoinedStudiesResponse response = studyQueryUseCase.getJoinedStudies(member.getMember().getId());
+		GetJoinedStudyCommand command = GetJoinedStudyCommand.builder()
+			.memberId(member.getMember().getId())
+			.studyStatus(status)
+			.build();
+
+		JoinedStudiesResponse response = studyQueryUseCase.getJoinedStudiesByStatus(command);
 		return ResponseEntity.ok(ApiResponse.success(SuccessCode.GET_SUCCESS, response));
 	}
 }

--- a/src/main/java/com/stumeet/server/study/adapter/in/web/response/JoinedStudiesResponse.java
+++ b/src/main/java/com/stumeet/server/study/adapter/in/web/response/JoinedStudiesResponse.java
@@ -1,0 +1,8 @@
+package com.stumeet.server.study.adapter.in.web.response;
+
+import java.util.List;
+
+public record JoinedStudiesResponse(
+	List<StudySimpleResponse> studySimpleResponses
+) {
+}

--- a/src/main/java/com/stumeet/server/study/adapter/in/web/response/StudySimpleResponse.java
+++ b/src/main/java/com/stumeet/server/study/adapter/in/web/response/StudySimpleResponse.java
@@ -1,28 +1,19 @@
 package com.stumeet.server.study.adapter.in.web.response;
 
 import java.time.LocalDate;
-import java.time.LocalTime;
 import java.util.List;
 
 import lombok.Builder;
 
 @Builder
-public record StudyDetailResponse(
+public record StudySimpleResponse(
 	Long id,
 	String name,
 	String field,
 	List<String> tags,
-	String intro,
-	String region,
-	String rule,
 	String image,
 	int headcount,
 	LocalDate startDate,
-	LocalDate endDate,
-	LocalTime meetingTime,
-	String meetingRepetitionType,
-	List<String> meetingRepetitionDates,
-	boolean isFinished,
-	boolean isDeleted
+	LocalDate endDate
 ) {
 }

--- a/src/main/java/com/stumeet/server/study/adapter/out/persistance/JpaStudyRepository.java
+++ b/src/main/java/com/stumeet/server/study/adapter/out/persistance/JpaStudyRepository.java
@@ -1,8 +1,18 @@
 package com.stumeet.server.study.adapter.out.persistance;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.stumeet.server.study.adapter.out.persistance.entity.StudyJpaEntity;
 
 public interface JpaStudyRepository extends JpaRepository<StudyJpaEntity, Long> {
+
+	@Query("SELECT s "
+		+ "FROM StudyJpaEntity s "
+		+ "WHERE s.id "
+		+ "IN (SELECT sm.study.id FROM StudyMemberJpaEntity sm WHERE sm.member.id = :memberId ORDER BY sm.createdAt desc)")
+	List<StudyJpaEntity> findAllByMemberIdOrderByJoinedDate(@Param("memberId") Long memberId);
 }

--- a/src/main/java/com/stumeet/server/study/adapter/out/persistance/JpaStudyRepository.java
+++ b/src/main/java/com/stumeet/server/study/adapter/out/persistance/JpaStudyRepository.java
@@ -13,6 +13,8 @@ public interface JpaStudyRepository extends JpaRepository<StudyJpaEntity, Long> 
 	@Query("SELECT s "
 		+ "FROM StudyJpaEntity s "
 		+ "WHERE s.id "
-		+ "IN (SELECT sm.study.id FROM StudyMemberJpaEntity sm WHERE sm.member.id = :memberId ORDER BY sm.createdAt desc)")
-	List<StudyJpaEntity> findAllByMemberIdOrderByJoinedDate(@Param("memberId") Long memberId);
+		+ "IN (SELECT sm.study.id FROM StudyMemberJpaEntity sm WHERE sm.member.id = :memberId ORDER BY sm.createdAt desc) "
+		+ "AND s.isFinished = false "
+		+ "AND s.isDeleted = false")
+	List<StudyJpaEntity> findActivesByMemberIdOrderByJoinedDate(@Param("memberId") Long memberId);
 }

--- a/src/main/java/com/stumeet/server/study/adapter/out/persistance/StudyPersistenceAdapter.java
+++ b/src/main/java/com/stumeet/server/study/adapter/out/persistance/StudyPersistenceAdapter.java
@@ -1,5 +1,7 @@
 package com.stumeet.server.study.adapter.out.persistance;
 
+import java.util.List;
+
 import com.stumeet.server.common.annotation.PersistenceAdapter;
 import com.stumeet.server.study.adapter.out.persistance.entity.StudyJpaEntity;
 import com.stumeet.server.study.adapter.out.persistance.mapper.StudyPersistenceMapper;
@@ -24,6 +26,13 @@ public class StudyPersistenceAdapter implements StudyQueryPort, StudyValidationP
 				.orElseThrow(() -> new StudyNotExistsException(id));
 
 		return studyPersistenceMapper.toDomain(entity);
+	}
+
+	@Override
+	public List<Study> getMemberRecentStudies(Long memberId) {
+		List<StudyJpaEntity> involvedStudies = studyRepository.findAllByMemberIdOrderByJoinedDate(memberId);
+
+		return studyPersistenceMapper.toDomains(involvedStudies);
 	}
 
 	@Override

--- a/src/main/java/com/stumeet/server/study/adapter/out/persistance/StudyPersistenceAdapter.java
+++ b/src/main/java/com/stumeet/server/study/adapter/out/persistance/StudyPersistenceAdapter.java
@@ -29,8 +29,8 @@ public class StudyPersistenceAdapter implements StudyQueryPort, StudyValidationP
 	}
 
 	@Override
-	public List<Study> getMemberRecentStudies(Long memberId) {
-		List<StudyJpaEntity> involvedStudies = studyRepository.findAllByMemberIdOrderByJoinedDate(memberId);
+	public List<Study> getMemberRecentActiveStudies(Long memberId) {
+		List<StudyJpaEntity> involvedStudies = studyRepository.findActivesByMemberIdOrderByJoinedDate(memberId);
 
 		return studyPersistenceMapper.toDomains(involvedStudies);
 	}

--- a/src/main/java/com/stumeet/server/study/adapter/out/persistance/mapper/StudyPersistenceMapper.java
+++ b/src/main/java/com/stumeet/server/study/adapter/out/persistance/mapper/StudyPersistenceMapper.java
@@ -1,5 +1,7 @@
 package com.stumeet.server.study.adapter.out.persistance.mapper;
 
+import java.util.List;
+
 import org.springframework.stereotype.Component;
 
 import com.stumeet.server.study.adapter.out.persistance.entity.StudyJpaEntity;
@@ -19,36 +21,45 @@ public class StudyPersistenceMapper {
 
 	public Study toDomain(StudyJpaEntity entity) {
 		return Study.builder()
-				.id(entity.getId())
-				.name(entity.getName())
-				.studyDomain(studyDomainPersistenceMapper.toDomain(entity))
-				.region(entity.getRegion())
-				.intro(entity.getIntro())
-				.rule(entity.getRule())
-				.period(StudyPeriod.of(entity.getStartDate(), entity.getEndDate()))
-				.imageUrl(entity.getImage())
-				.meetingSchedule(studyMeetingSchedulePersistenceMapper.toDomain(entity.getMeetingTime(), entity.getMeetingRepetition()))
-				.isFinished(entity.getIsFinished())
-				.isDeleted(entity.getIsDeleted())
-				.build();
+			.id(entity.getId())
+			.name(entity.getName())
+			.studyDomain(studyDomainPersistenceMapper.toDomain(entity))
+			.region(entity.getRegion())
+			.intro(entity.getIntro())
+			.rule(entity.getRule())
+			.headcount(entity.getHeadcount())
+			.period(StudyPeriod.of(entity.getStartDate(), entity.getEndDate()))
+			.imageUrl(entity.getImage())
+			.meetingSchedule(
+				studyMeetingSchedulePersistenceMapper.toDomain(entity.getMeetingTime(), entity.getMeetingRepetition()))
+			.isFinished(entity.getIsFinished())
+			.isDeleted(entity.getIsDeleted())
+			.build();
+	}
+
+	public List<Study> toDomains(List<StudyJpaEntity> studyJpaEntities) {
+		return studyJpaEntities.stream()
+			.map(this::toDomain)
+			.toList();
 	}
 
 	public StudyJpaEntity toEntity(Study domain) {
 		return StudyJpaEntity.builder()
-				.id(domain.getId())
-				.name(domain.getName())
-				.studyField(domain.getStudyDomain().getStudyField())
-				.studyTags(studyTagPersistenceMapper.toEntities(domain.getStudyTags(), domain.getId()))
-				.region(domain.getRegion())
-				.intro(domain.getIntro())
-				.rule(domain.getRule())
-				.startDate(domain.getStartDate())
-				.endDate(domain.getEndDate())
-				.image(domain.getImageUrl())
-				.meetingTime(domain.getMeetingSchedule().getTime())
-				.meetingRepetition(meetingRepetitionPersistenceMapper.toColumn(domain.getMeetingSchedule().getRepetition()))
-				.isFinished(domain.isFinished())
-				.isDeleted(domain.isDeleted())
-				.build();
+			.id(domain.getId())
+			.name(domain.getName())
+			.studyField(domain.getStudyDomain().getStudyField())
+			.studyTags(studyTagPersistenceMapper.toEntities(domain.getStudyTags(), domain.getId()))
+			.region(domain.getRegion())
+			.intro(domain.getIntro())
+			.rule(domain.getRule())
+			.headcount(domain.getHeadcount())
+			.startDate(domain.getStartDate())
+			.endDate(domain.getEndDate())
+			.image(domain.getImageUrl())
+			.meetingTime(domain.getMeetingSchedule().getTime())
+			.meetingRepetition(meetingRepetitionPersistenceMapper.toColumn(domain.getMeetingSchedule().getRepetition()))
+			.isFinished(domain.isFinished())
+			.isDeleted(domain.isDeleted())
+			.build();
 	}
 }

--- a/src/main/java/com/stumeet/server/study/application/port/in/StudyQueryUseCase.java
+++ b/src/main/java/com/stumeet/server/study/application/port/in/StudyQueryUseCase.java
@@ -1,8 +1,11 @@
 package com.stumeet.server.study.application.port.in;
 
+import com.stumeet.server.study.adapter.in.web.response.JoinedStudiesResponse;
 import com.stumeet.server.study.adapter.in.web.response.StudyDetailResponse;
 
 public interface StudyQueryUseCase {
 
 	StudyDetailResponse getStudyDetailById(Long id);
+
+	JoinedStudiesResponse getJoinedStudies(Long memberId);
 }

--- a/src/main/java/com/stumeet/server/study/application/port/in/StudyQueryUseCase.java
+++ b/src/main/java/com/stumeet/server/study/application/port/in/StudyQueryUseCase.java
@@ -2,10 +2,11 @@ package com.stumeet.server.study.application.port.in;
 
 import com.stumeet.server.study.adapter.in.web.response.JoinedStudiesResponse;
 import com.stumeet.server.study.adapter.in.web.response.StudyDetailResponse;
+import com.stumeet.server.study.application.port.in.command.GetJoinedStudyCommand;
 
 public interface StudyQueryUseCase {
 
 	StudyDetailResponse getStudyDetailById(Long id);
 
-	JoinedStudiesResponse getJoinedStudies(Long memberId);
+	JoinedStudiesResponse getJoinedStudiesByStatus(GetJoinedStudyCommand command);
 }

--- a/src/main/java/com/stumeet/server/study/application/port/in/command/GetJoinedStudyCommand.java
+++ b/src/main/java/com/stumeet/server/study/application/port/in/command/GetJoinedStudyCommand.java
@@ -1,0 +1,15 @@
+package com.stumeet.server.study.application.port.in.command;
+
+import com.stumeet.server.study.domain.StudyStatus;
+
+import lombok.Builder;
+
+public record GetJoinedStudyCommand(
+	Long memberId,
+	StudyStatus studyStatus
+) {
+	@Builder
+	public GetJoinedStudyCommand(Long memberId, String studyStatus) {
+		this(memberId, StudyStatus.fromValue(studyStatus));
+	}
+}

--- a/src/main/java/com/stumeet/server/study/application/port/in/mapper/StudyUseCaseMapper.java
+++ b/src/main/java/com/stumeet/server/study/application/port/in/mapper/StudyUseCaseMapper.java
@@ -21,6 +21,7 @@ public class StudyUseCaseMapper {
 			.region(study.getRegion())
 			.intro(study.getIntro())
 			.rule(study.getRule())
+			.headcount(study.getHeadcount())
 			.startDate(study.getStartDate())
 			.endDate(study.getEndDate())
 			.image(study.getImageUrl())

--- a/src/main/java/com/stumeet/server/study/application/port/in/mapper/StudyUseCaseMapper.java
+++ b/src/main/java/com/stumeet/server/study/application/port/in/mapper/StudyUseCaseMapper.java
@@ -1,10 +1,16 @@
 package com.stumeet.server.study.application.port.in.mapper;
 
+import static java.util.stream.Collectors.*;
+
+import java.util.List;
+
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.stereotype.Component;
 
+import com.stumeet.server.study.adapter.in.web.response.JoinedStudiesResponse;
 import com.stumeet.server.study.adapter.in.web.response.StudyDetailResponse;
+import com.stumeet.server.study.adapter.in.web.response.StudySimpleResponse;
 import com.stumeet.server.study.domain.Study;
 import com.stumeet.server.studymember.application.port.in.command.StudyMemberJoinCommand;
 
@@ -39,5 +45,24 @@ public class StudyUseCaseMapper {
 			.studyId(studyId)
 			.isAdmin(true)
 			.build();
+	}
+
+	public StudySimpleResponse toStudySimpleResponse(Study study) {
+		return StudySimpleResponse.builder()
+			.id(study.getId())
+			.name(study.getName())
+			.field(study.getStudyFieldName())
+			.tags(study.getStudyTags())
+			.image(study.getImageUrl())
+			.headcount(study.getHeadcount())
+			.startDate(study.getPeriod().getStartDate())
+			.endDate(study.getPeriod().getEndDate())
+			.build();
+	}
+
+	public JoinedStudiesResponse toMyStudiesResponse(List<Study> studies) {
+		return studies.stream()
+			.map(this::toStudySimpleResponse)
+			.collect(collectingAndThen(toList(), JoinedStudiesResponse::new));
 	}
 }

--- a/src/main/java/com/stumeet/server/study/application/port/out/StudyQueryPort.java
+++ b/src/main/java/com/stumeet/server/study/application/port/out/StudyQueryPort.java
@@ -8,5 +8,5 @@ public interface StudyQueryPort {
 
 	Study getById(Long id);
 
-	List<Study> getMemberRecentStudies(Long memberId);
+	List<Study> getMemberRecentActiveStudies(Long memberId);
 }

--- a/src/main/java/com/stumeet/server/study/application/port/out/StudyQueryPort.java
+++ b/src/main/java/com/stumeet/server/study/application/port/out/StudyQueryPort.java
@@ -1,8 +1,12 @@
 package com.stumeet.server.study.application.port.out;
 
+import java.util.List;
+
 import com.stumeet.server.study.domain.Study;
 
 public interface StudyQueryPort {
 
 	Study getById(Long id);
+
+	List<Study> getMemberRecentStudies(Long memberId);
 }

--- a/src/main/java/com/stumeet/server/study/application/service/StudyQueryService.java
+++ b/src/main/java/com/stumeet/server/study/application/service/StudyQueryService.java
@@ -8,9 +8,12 @@ import com.stumeet.server.common.annotation.UseCase;
 import com.stumeet.server.study.adapter.in.web.response.JoinedStudiesResponse;
 import com.stumeet.server.study.adapter.in.web.response.StudyDetailResponse;
 import com.stumeet.server.study.application.port.in.StudyQueryUseCase;
+import com.stumeet.server.study.application.port.in.command.GetJoinedStudyCommand;
 import com.stumeet.server.study.application.port.out.StudyQueryPort;
 import com.stumeet.server.study.application.port.in.mapper.StudyUseCaseMapper;
 import com.stumeet.server.study.domain.Study;
+import com.stumeet.server.study.domain.StudyStatus;
+import com.stumeet.server.study.domain.exception.StudyStatusNotExistsException;
 
 import lombok.RequiredArgsConstructor;
 
@@ -29,8 +32,20 @@ public class StudyQueryService implements StudyQueryUseCase {
 	}
 
 	@Override
-	public JoinedStudiesResponse getJoinedStudies(Long memberId) {
-		List<Study> involvedStudies = studyQueryPort.getMemberRecentStudies(memberId);
-		return studyUseCaseMapper.toMyStudiesResponse(involvedStudies);
+	public JoinedStudiesResponse getJoinedStudiesByStatus(GetJoinedStudyCommand command) {
+		StudyStatus status = command.studyStatus();
+
+		switch (status) {
+			case ACTIVE -> {
+				List<Study> activeJoinedStudies = studyQueryPort.getMemberRecentActiveStudies(command.memberId());
+				return studyUseCaseMapper.toMyStudiesResponse(activeJoinedStudies);
+			}
+
+			// case FINISHED -> {
+			//
+			// }
+
+			default -> throw new StudyStatusNotExistsException(status.name());
+		}
 	}
 }

--- a/src/main/java/com/stumeet/server/study/application/service/StudyQueryService.java
+++ b/src/main/java/com/stumeet/server/study/application/service/StudyQueryService.java
@@ -1,8 +1,11 @@
 package com.stumeet.server.study.application.service;
 
+import java.util.List;
+
 import org.springframework.transaction.annotation.Transactional;
 
 import com.stumeet.server.common.annotation.UseCase;
+import com.stumeet.server.study.adapter.in.web.response.JoinedStudiesResponse;
 import com.stumeet.server.study.adapter.in.web.response.StudyDetailResponse;
 import com.stumeet.server.study.application.port.in.StudyQueryUseCase;
 import com.stumeet.server.study.application.port.out.StudyQueryPort;
@@ -23,5 +26,11 @@ public class StudyQueryService implements StudyQueryUseCase {
 	public StudyDetailResponse getStudyDetailById(Long id) {
 		Study study = studyQueryPort.getById(id);
 		return studyUseCaseMapper.toStudyDetailResponse(study);
+	}
+
+	@Override
+	public JoinedStudiesResponse getJoinedStudies(Long memberId) {
+		List<Study> involvedStudies = studyQueryPort.getMemberRecentStudies(memberId);
+		return studyUseCaseMapper.toMyStudiesResponse(involvedStudies);
 	}
 }

--- a/src/main/java/com/stumeet/server/study/application/service/StudyUpdateService.java
+++ b/src/main/java/com/stumeet/server/study/application/service/StudyUpdateService.java
@@ -34,7 +34,7 @@ public class StudyUpdateService implements StudyUpdateUseCase {
 		validateMemberCanUpdate(studyId, memberId);
 
 		Study existingStudy = studyQueryPort.getById(studyId);
-		Study updatedStudy = Study.update(command, existingStudy);
+		Study updatedStudy = Study.updateInfo(command, existingStudy);
 		studyCommandPort.save(updatedStudy);
 		studyImageUpdateUseCase.updateMainImage(studyId, mainImageFile);
 

--- a/src/main/java/com/stumeet/server/study/domain/Study.java
+++ b/src/main/java/com/stumeet/server/study/domain/Study.java
@@ -47,7 +47,7 @@ public class Study {
 
 	public static Study create(StudyCreateCommand command) {
 		return Study.builder()
-			.studyDomain(StudyDomain.of(StudyField.getByName(command.studyField()), command.studyTags()))
+			.studyDomain(StudyDomain.of(StudyField.fromName(command.studyField()), command.studyTags()))
 			.name(command.name())
 			.intro(command.intro())
 			.rule(command.rule())
@@ -66,7 +66,7 @@ public class Study {
 	public static Study updateInfo(StudyUpdateCommand command, Study existingStudy) {
 		return Study.builder()
 			.id(existingStudy.getId())
-			.studyDomain(StudyDomain.of(StudyField.getByName(command.studyField()), command.studyTags()))
+			.studyDomain(StudyDomain.of(StudyField.fromName(command.studyField()), command.studyTags()))
 			.name(command.name())
 			.intro(command.intro())
 			.rule(command.rule())

--- a/src/main/java/com/stumeet/server/study/domain/Study.java
+++ b/src/main/java/com/stumeet/server/study/domain/Study.java
@@ -19,7 +19,7 @@ import lombok.Getter;
 @Getter
 public class Study {
 
-	private static final int INITIAL_STUDY_HEAD_COUNT = 1;
+	private static final int INITIAL_STUDY_HEAD_COUNT = 0;
 
 	private Long id;
 
@@ -34,6 +34,8 @@ public class Study {
 	private String intro;
 
 	private String rule;
+
+	private Integer headcount;
 
 	private StudyPeriod period;
 
@@ -50,6 +52,7 @@ public class Study {
 			.intro(command.intro())
 			.rule(command.rule())
 			.region(command.region())
+			.headcount(INITIAL_STUDY_HEAD_COUNT)
 			.period(StudyPeriod.of(command.startDate(), command.endDate()))
 			.meetingSchedule(
 				StudyMeetingSchedule.of(
@@ -60,7 +63,7 @@ public class Study {
 			.build();
 	}
 
-	public static Study update(StudyUpdateCommand command, Study existingStudy) {
+	public static Study updateInfo(StudyUpdateCommand command, Study existingStudy) {
 		return Study.builder()
 			.id(existingStudy.getId())
 			.studyDomain(StudyDomain.of(StudyField.getByName(command.studyField()), command.studyTags()))
@@ -68,6 +71,7 @@ public class Study {
 			.intro(command.intro())
 			.rule(command.rule())
 			.region(command.region())
+			.headcount(existingStudy.headcount)
 			.period(StudyPeriod.of(command.startDate(), command.endDate()))
 			.meetingSchedule(
 				StudyMeetingSchedule.of(

--- a/src/main/java/com/stumeet/server/study/domain/StudyField.java
+++ b/src/main/java/com/stumeet/server/study/domain/StudyField.java
@@ -24,7 +24,7 @@ public enum StudyField {
         this.name = name;
     }
 
-    public static StudyField getByName(String name) {
+    public static StudyField fromName(String name) {
         return Arrays.stream(StudyField.values())
                 .filter(field -> field.name.equals(name))
                 .findFirst()

--- a/src/main/java/com/stumeet/server/study/domain/StudyStatus.java
+++ b/src/main/java/com/stumeet/server/study/domain/StudyStatus.java
@@ -1,0 +1,17 @@
+package com.stumeet.server.study.domain;
+
+import com.stumeet.server.study.domain.exception.StudyStatusNotExistsException;
+
+public enum StudyStatus {
+
+	ACTIVE,
+	FINISHED;
+
+	public static StudyStatus fromValue(String value) {
+		try {
+			return StudyStatus.valueOf(value);
+		} catch (IllegalArgumentException exception) {
+			throw new StudyStatusNotExistsException(value);
+		}
+	}
+}

--- a/src/main/java/com/stumeet/server/study/domain/exception/StudyStatusNotExistsException.java
+++ b/src/main/java/com/stumeet/server/study/domain/exception/StudyStatusNotExistsException.java
@@ -1,0 +1,15 @@
+package com.stumeet.server.study.domain.exception;
+
+import java.text.MessageFormat;
+
+import com.stumeet.server.common.exception.model.NotExistsException;
+import com.stumeet.server.common.response.ErrorCode;
+
+public class StudyStatusNotExistsException extends NotExistsException {
+
+	public static final String MESSAGE = "존재하지 않는 스터디 상태 입니다. 전달받은 상태 : {0}";
+
+	public StudyStatusNotExistsException(String status) {
+		super(MessageFormat.format(MESSAGE, status), ErrorCode.STUDY_STATUS_NOT_FOUND);
+	}
+}

--- a/src/main/java/com/stumeet/server/studymember/application/service/StudyMemberJoinService.java
+++ b/src/main/java/com/stumeet/server/studymember/application/service/StudyMemberJoinService.java
@@ -31,6 +31,7 @@ public class StudyMemberJoinService implements StudyMemberJoinUseCase {
 
         StudyMember studyMember = studyMemberUseCaseMapper.toDomain(command);
 
+        // todo: headcount 검사 및 인원 수 증가 로직 추가 필요
         studyMemberJoinPort.join(studyMember);
     }
 }

--- a/src/test/java/com/stumeet/server/stub/StudyStub.java
+++ b/src/test/java/com/stumeet/server/stub/StudyStub.java
@@ -170,4 +170,8 @@ public class StudyStub {
 			List.of("영어", "회화", "언어 교환", "어학")
 		);
 	}
+
+	public static String getInvalidStudyStatus() {
+		return "INVALID_STUDY_STATUS";
+	}
 }

--- a/src/test/java/com/stumeet/server/study/adapter/in/web/StudyQueryApiTest.java
+++ b/src/test/java/com/stumeet/server/study/adapter/in/web/StudyQueryApiTest.java
@@ -16,6 +16,7 @@ import com.stumeet.server.common.auth.model.AuthenticationHeader;
 import com.stumeet.server.helper.WithMockMember;
 import com.stumeet.server.stub.StudyStub;
 import com.stumeet.server.stub.TokenStub;
+import com.stumeet.server.study.domain.StudyStatus;
 import com.stumeet.server.template.ApiTest;
 
 class StudyQueryApiTest extends ApiTest {
@@ -82,6 +83,58 @@ class StudyQueryApiTest extends ApiTest {
 									fieldWithPath("code").description("응답 상태"),
 									fieldWithPath("message").description("응답 메시지")
 							)));
+		}
+	}
+
+	@Nested
+	@DisplayName("가입 스터디 리스트 조회 API")
+	class GetJoinedStudies {
+
+		@Test
+		@WithMockMember
+		@DisplayName("[성공] 가입 스터디 리스트 조회를 성공한다.")
+		void successTest() throws Exception {
+			mockMvc.perform(get("/api/v1/studies")
+					.param("status", StudyStatus.ACTIVE.toString())
+					.header(AuthenticationHeader.ACCESS_TOKEN.getName(), TokenStub.getMockAccessToken()))
+				.andExpect(status().isOk())
+				.andDo(document("get-joined-studies/success",
+					preprocessRequest(prettyPrint()),
+					preprocessResponse(prettyPrint()),
+					requestHeaders(headerWithName(AuthenticationHeader.ACCESS_TOKEN.getName()).description(
+						"서버로부터 전달받은 액세스 토큰")),
+					responseFields(
+						fieldWithPath("code").description("응답 상태"),
+						fieldWithPath("message").description("응답 메시지"),
+						fieldWithPath("data.studySimpleResponses").description("스터디 간단 정보 리스트"),
+						fieldWithPath("data.studySimpleResponses[].id").description("스터디 ID"),
+						fieldWithPath("data.studySimpleResponses[].name").description("스터디 이름"),
+						fieldWithPath("data.studySimpleResponses[].field").description("분야"),
+						fieldWithPath("data.studySimpleResponses[].tags").description("태그 리스트"),
+						fieldWithPath("data.studySimpleResponses[].image").description("이미지 URL"),
+						fieldWithPath("data.studySimpleResponses[].headcount").description("참여 인원 수"),
+						fieldWithPath("data.studySimpleResponses[].startDate").description("시작 날짜"),
+						fieldWithPath("data.studySimpleResponses[].endDate").description("종료 날짜")
+					)));
+		}
+
+		@Test
+		@WithMockMember
+		@DisplayName("[실패] 유효하지 않은 스터디 상태로 요청한 경우 가입 스터디 리스트 조회를 실패한다.")
+		void fail_when_study_status_not_found() throws Exception {
+			mockMvc.perform(get("/api/v1/studies")
+					.param("status", StudyStub.getInvalidStudyStatus())
+					.header(AuthenticationHeader.ACCESS_TOKEN.getName(), TokenStub.getMockAccessToken()))
+				.andExpect(status().isNotFound())
+				.andDo(document("get-joined-studies/fail/study-status-not-found",
+					preprocessRequest(prettyPrint()),
+					preprocessResponse(prettyPrint()),
+					requestHeaders(headerWithName(AuthenticationHeader.ACCESS_TOKEN.getName()).description(
+						"서버로부터 전달받은 액세스 토큰")),
+					responseFields(
+						fieldWithPath("code").description("응답 상태"),
+						fieldWithPath("message").description("응답 메시지")
+					)));
 		}
 	}
 }

--- a/src/test/java/com/stumeet/server/study/adapter/in/web/StudyQueryApiTest.java
+++ b/src/test/java/com/stumeet/server/study/adapter/in/web/StudyQueryApiTest.java
@@ -101,8 +101,12 @@ class StudyQueryApiTest extends ApiTest {
 				.andDo(document("get-joined-studies/success",
 					preprocessRequest(prettyPrint()),
 					preprocessResponse(prettyPrint()),
-					requestHeaders(headerWithName(AuthenticationHeader.ACCESS_TOKEN.getName()).description(
-						"서버로부터 전달받은 액세스 토큰")),
+					requestHeaders(
+						headerWithName(AuthenticationHeader.ACCESS_TOKEN.getName()).description("서버로부터 전달받은 액세스 토큰")
+					),
+					queryParameters(
+						parameterWithName("status").description("스터디 상태")
+					),
 					responseFields(
 						fieldWithPath("code").description("응답 상태"),
 						fieldWithPath("message").description("응답 메시지"),
@@ -129,8 +133,12 @@ class StudyQueryApiTest extends ApiTest {
 				.andDo(document("get-joined-studies/fail/study-status-not-found",
 					preprocessRequest(prettyPrint()),
 					preprocessResponse(prettyPrint()),
-					requestHeaders(headerWithName(AuthenticationHeader.ACCESS_TOKEN.getName()).description(
-						"서버로부터 전달받은 액세스 토큰")),
+					requestHeaders(
+						headerWithName(AuthenticationHeader.ACCESS_TOKEN.getName()).description("서버로부터 전달받은 액세스 토큰")
+					),
+					queryParameters(
+						parameterWithName("status").description("스터디 상태 (`ACTIVE` / `FINISHED`)")
+					),
 					responseFields(
 						fieldWithPath("code").description("응답 상태"),
 						fieldWithPath("message").description("응답 메시지")


### PR DESCRIPTION
## 💁 해결 하려는 문제를 적어주세요 

- 가입 스터디 리스트 조회 API 구현

## 🤔 어떤 방식으로 해결했는지 적어주세요 

- 가입 스터디 리스트를 스터디 상태(`ACTIVE`, `FINISH`)를 기준으로 최신 가입 순으로 불러오는 API를 구현했습니다.
- status가 `FINISH`인 경우 스터디 히스토리를 불러오는 것으로 생각하고 있는데, 아직 구현은 하지 않았습니다.

## 🙋 중점적으로 리뷰 했으면 하는 부분이 있다면 적어주세요 

- 커스텀 예외에서 예외 메시지를 지정하는 경우가 있는데, `NotExistsException`과 `InvalidStateException`의 경우 부모뿐만 아니라 커스텀 예외에 메시지가 따로 설정되어 있어도 출력되고 있지 않았습니다.

[이전 코드]
``` java
  @ExceptionHandler(BadRequestException.class)
  protected ResponseEntity<ApiResponse> handleCustomBadRequestException(final BadRequestException e) {
      log.warn(ERROR_LOG_MESSAGE, e.getClass().getSimpleName(), e.getMessage());

      String message = String.format("%s %s", e.getErrorCode().getMessage(), e.getMessage());
      ApiResponse response = ApiResponse.fail(e.getErrorCode().getHttpStatusCode(), message);

      return ResponseEntity.badRequest()
              .body(response);
  }
```

[변경 후 코드]
``` java
    @ExceptionHandler({
        BadRequestException.class,
        // NotExistsException.class,
        // InvalidStateException.class
    })
    protected ResponseEntity<ApiResponse> handleCustomBadRequestException(final BusinessException e) {
        log.warn(ERROR_LOG_MESSAGE, e.getClass().getSimpleName(), e.getMessage());

        String message = String.format("%s %s", e.getErrorCode().getMessage(), e.getMessage());
        ApiResponse response = ApiResponse.fail(e.getErrorCode().getHttpStatusCode(), message);

        return new ResponseEntity<>(response, e.getErrorCode().getHttpStatus());
    }
```
그래서 `BadRequestException`뿐만 아니라 다른 두 예외도 커스텀된 예외 메시지를 출력하도록 변경했는데 에러 메시지를 검증하는 테스트에서 실패하여 위처럼 주석을 달았습니다.

혹시 자세한 예외 메시지를 출력하지 않는 것이 누락이 아니라 의도된 것일까요?


## 🧑‍🏫 이해를 위해 필요한 자료가 있다면 첨부해주세요

![image](https://github.com/Stumeet/STUMEET-SERVER/assets/83827023/96a09373-0fff-4985-9bc1-b7d7e7dcaef5)
