### PR TITLE
✨ [STMT-165] 어세스 토큰 갱신 시 리프레시 토큰도 갱신

### DIFF
--- a/src/main/java/com/stumeet/server/common/token/service/RefreshTokenService.java
+++ b/src/main/java/com/stumeet/server/common/token/service/RefreshTokenService.java
@@ -7,8 +7,6 @@ import com.stumeet.server.common.token.repository.RefreshTokenRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import java.text.MessageFormat;
-
 @Service
 @RequiredArgsConstructor
 public class RefreshTokenService {
@@ -20,7 +18,7 @@ public class RefreshTokenService {
         refreshTokenRepository.save(accessToken, refreshToken);
     }
 
-    public String getRefreshToken(String accessToken, String refreshToken) {
+    public void validateRefreshToken(String accessToken, String refreshToken) {
         String savedRefreshToken = refreshTokenRepository.getByAccessToken(accessToken);
 
         if (!refreshToken.equals(savedRefreshToken)) {
@@ -29,8 +27,6 @@ public class RefreshTokenService {
         if (!jwtTokenProvider.validateToken(refreshToken)) {
             throw new BusinessException(ErrorCode.EXPIRED_REFRESH_TOKEN_EXCEPTION);
         }
-
-        return savedRefreshToken;
     }
 
     public void deleteByAccessToken(String accessToken) {

--- a/src/main/java/com/stumeet/server/member/adapter/in/web/MemberAuthApi.java
+++ b/src/main/java/com/stumeet/server/member/adapter/in/web/MemberAuthApi.java
@@ -42,10 +42,10 @@ public class MemberAuthApi {
     public ResponseEntity<ApiResponse<TokenResponse>> renewAccessToken(
             @RequestBody @Valid TokenRenewCommand request
     ) {
-        TokenResponse response = memberTokenUseCase.renewAccessToken(request);
+        TokenResponse response = memberTokenUseCase.renewTokens(request);
 
         return new ResponseEntity<>(
-                ApiResponse.success(HttpStatus.OK.value(), "액세스 토큰 재발급에 성공했습니다.", response),
+                ApiResponse.success(HttpStatus.OK.value(), "토큰 재발급에 성공했습니다.", response),
                 HttpStatus.OK
         );
     }

--- a/src/main/java/com/stumeet/server/member/adapter/in/web/response/TokenResponse.java
+++ b/src/main/java/com/stumeet/server/member/adapter/in/web/response/TokenResponse.java
@@ -1,6 +1,7 @@
 package com.stumeet.server.member.adapter.in.web.response;
 
 public record TokenResponse(
-        String accessToken
+        String accessToken,
+        String refreshToken
 ) {
 }

--- a/src/main/java/com/stumeet/server/member/application/port/in/MemberTokenUseCase.java
+++ b/src/main/java/com/stumeet/server/member/application/port/in/MemberTokenUseCase.java
@@ -5,7 +5,5 @@ import com.stumeet.server.member.application.port.in.command.TokenRenewCommand;
 
 public interface MemberTokenUseCase {
 
-
-
-    TokenResponse renewAccessToken(TokenRenewCommand request);
+    TokenResponse renewTokens(TokenRenewCommand request);
 }

--- a/src/main/java/com/stumeet/server/member/application/service/MemberTokenService.java
+++ b/src/main/java/com/stumeet/server/member/application/service/MemberTokenService.java
@@ -22,16 +22,17 @@ public class MemberTokenService implements MemberTokenUseCase {
     private final JwtTokenProvider jwtTokenProvider;
 
     @Override
-    public TokenResponse renewAccessToken(TokenRenewCommand request) {
-        String savedRefreshToken = refreshTokenService.getRefreshToken(request.accessToken(), request.refreshToken());
+    public TokenResponse renewTokens(TokenRenewCommand request) {
+        refreshTokenService.validateRefreshToken(request.accessToken(), request.refreshToken());
         refreshTokenService.deleteByAccessToken(request.accessToken());
 
         Long id = Long.parseLong(jwtTokenProvider.getSubject(request.refreshToken()));
         Member member = memberQueryPort.getById(id);
+
         String renewAccessToken = jwtTokenProvider.generateAccessToken(new LoginMember(member));
-        refreshTokenService.save(renewAccessToken, savedRefreshToken);
+        String renewRefreshToken = jwtTokenProvider.generateRefreshToken(id);
+        refreshTokenService.save(renewAccessToken, renewRefreshToken);
 
-        return new TokenResponse(renewAccessToken);
+        return new TokenResponse(renewAccessToken, renewRefreshToken);
     }
-
 }

--- a/src/test/java/com/stumeet/server/member/adapter/in/web/MemberAuthApiTest.java
+++ b/src/test/java/com/stumeet/server/member/adapter/in/web/MemberAuthApiTest.java
@@ -51,7 +51,7 @@ class MemberAuthApiTest extends ApiTest {
     private JpaMemberRepository jpaMemberRepository;
 
     @Nested
-    @DisplayName("액세스 토큰 재발급")
+    @DisplayName("토큰 재발급")
     class tokenRenew {
 
         private final String path = "/api/v1/tokens";
@@ -74,7 +74,7 @@ class MemberAuthApiTest extends ApiTest {
         }
 
         @Test
-        @DisplayName("[성공] 액세스 토큰 재발급에 성공합니다.")
+        @DisplayName("[성공] 토큰 재발급에 성공합니다.")
         void successTest() throws Exception {
             mockMvc.perform(post(path)
                             .contentType(MediaType.APPLICATION_JSON)
@@ -90,7 +90,8 @@ class MemberAuthApiTest extends ApiTest {
                                     responseFields(
                                             fieldWithPath("code").type(JsonFieldType.NUMBER).description("응답에 대한 결과 코드"),
                                             fieldWithPath("message").type(JsonFieldType.STRING).description("응답에 대한 메시지"),
-                                            fieldWithPath("data.accessToken").type(JsonFieldType.STRING).description("액세스 토큰")
+                                            fieldWithPath("data.accessToken").type(JsonFieldType.STRING).description("액세스 토큰"),
+                                            fieldWithPath("data.refreshToken").type(JsonFieldType.STRING).description("리프레시 토큰")
                                     )
                             )
                     );
@@ -371,6 +372,4 @@ class MemberAuthApiTest extends ApiTest {
 
         }
     }
-
-
 }


### PR DESCRIPTION
## 💁 해결 하려는 문제를 적어주세요 

리프레시 토큰 기한 만료 시 클라이언트에서 주기적으로 재로그인을 해야한다는 이슈가 있습니다.

## 🤔 어떤 방식으로 해결했는지 적어주세요 

앱을 지속적으로 사용하는 모바일 환경에서 단점이 될 수 있다고 생각하여 어세스 토큰 갱신 시 리프레시 토큰이 유효한 경우 리프레시 토큰도 갱신하는 방식으로 구현했습니다.