### PR TITLE
:rocket: [STMT-165] 서버 타임존 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -110,7 +110,8 @@ jib {
     container {
         jvmFlags = ["-Xms128m", "-Xmx128m"]
         environment = [
-                'SPRING_PROFILES_ACTIVE': 'prod'
+                'SPRING_PROFILES_ACTIVE': 'prod',
+                'TZ': 'Asia/Seoul'
         ]
     }
     extraDirectories {


### PR DESCRIPTION
## 💁 해결 하려는 문제를 적어주세요 

- 서버의 타임존이 UTC로 설정되어 있어 jwt 토큰의 만료 기한이 제대로 설정되지 않는 문제가 있었습니다.

## 🤔 어떤 방식으로 해결했는지 적어주세요 

- jib 설정의 환경변수에 타임존 설정을 추가했습니다.