### PR TITLE
[STMT-262] 활동 이미지 일괄 삭제 비동기 이벤트로 구현

### DIFF
--- a/src/main/java/com/stumeet/server/ServerApplication.java
+++ b/src/main/java/com/stumeet/server/ServerApplication.java
@@ -3,9 +3,11 @@ package com.stumeet.server;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.scheduling.annotation.EnableAsync;
 
 @SpringBootApplication
 @EnableFeignClients
+@EnableAsync
 public class ServerApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/stumeet/server/activity/adapter/out/event/handler/ActivityImageDeleteEventHandler.java
+++ b/src/main/java/com/stumeet/server/activity/adapter/out/event/handler/ActivityImageDeleteEventHandler.java
@@ -1,0 +1,26 @@
+package com.stumeet.server.activity.adapter.out.event.handler;
+
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+import com.stumeet.server.activity.adapter.out.event.model.ActivityImageDeleteEvent;
+import com.stumeet.server.file.application.port.in.FileDeleteUseCase;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+
+@Log4j2
+@RequiredArgsConstructor
+@Component
+public class ActivityImageDeleteEventHandler {
+
+	private final FileDeleteUseCase fileDeleteUseCase;
+
+	@Async
+	@EventListener(ActivityImageDeleteEvent.class)
+	public void deleteActivityImage(ActivityImageDeleteEvent event) {
+		log.info(event.getMessage());
+		fileDeleteUseCase.deleteActivityRelatedImage(event.getStudyId(), event.getActivityId());
+	}
+}

--- a/src/main/java/com/stumeet/server/activity/adapter/out/event/model/ActivityImageDeleteEvent.java
+++ b/src/main/java/com/stumeet/server/activity/adapter/out/event/model/ActivityImageDeleteEvent.java
@@ -1,0 +1,18 @@
+package com.stumeet.server.activity.adapter.out.event.model;
+
+import com.stumeet.server.common.event.model.Event;
+
+import lombok.Getter;
+
+@Getter
+public class ActivityImageDeleteEvent extends Event {
+
+	private final Long studyId;
+	private final Long activityId;
+
+	public ActivityImageDeleteEvent(Object source, Long studyId, Long activityId) {
+		super(source, String.format("[활동 이미지 삭제] studyId: %d, activityId: %d", studyId, activityId));
+		this.studyId = studyId;
+		this.activityId = activityId;
+	}
+}

--- a/src/main/java/com/stumeet/server/activity/adapter/out/persistence/ActivityImagePersistenceAdapter.java
+++ b/src/main/java/com/stumeet/server/activity/adapter/out/persistence/ActivityImagePersistenceAdapter.java
@@ -1,5 +1,6 @@
 package com.stumeet.server.activity.adapter.out.persistence;
 
+import com.stumeet.server.activity.adapter.out.event.model.ActivityImageDeleteEvent;
 import com.stumeet.server.activity.adapter.out.mapper.ActivityImagePersistenceMapper;
 import com.stumeet.server.activity.adapter.out.model.ActivityImageJpaEntity;
 import com.stumeet.server.activity.application.port.out.ActivityImageCommandPort;
@@ -7,6 +8,8 @@ import com.stumeet.server.activity.application.port.out.ActivityImageCreatePort;
 import com.stumeet.server.activity.application.port.out.ActivityImageQueryPort;
 import com.stumeet.server.activity.domain.model.ActivityImage;
 import com.stumeet.server.common.annotation.PersistenceAdapter;
+import com.stumeet.server.common.event.EventPublisher;
+
 import lombok.RequiredArgsConstructor;
 
 import java.util.List;
@@ -33,7 +36,8 @@ public class ActivityImagePersistenceAdapter implements ActivityImageCreatePort,
     }
 
     @Override
-    public void deleteAllByActivityId(Long activityId) {
+    public void deleteAllByActivityId(Long studyId, Long activityId) {
         jpaActivityImageRepository.deleteAllByActivityId(activityId);
+        EventPublisher.raise(new ActivityImageDeleteEvent(this, studyId, activityId));
     }
 }

--- a/src/main/java/com/stumeet/server/activity/application/port/out/ActivityImageCommandPort.java
+++ b/src/main/java/com/stumeet/server/activity/application/port/out/ActivityImageCommandPort.java
@@ -2,5 +2,5 @@ package com.stumeet.server.activity.application.port.out;
 
 public interface ActivityImageCommandPort {
 
-    void deleteAllByActivityId(Long activityId);
+    void deleteAllByActivityId(Long studyId, Long activityId);
 }

--- a/src/main/java/com/stumeet/server/common/config/EventConfig.java
+++ b/src/main/java/com/stumeet/server/common/config/EventConfig.java
@@ -1,0 +1,23 @@
+package com.stumeet.server.common.config;
+
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.stumeet.server.common.event.EventPublisher;
+
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@RequiredArgsConstructor
+public class EventConfig {
+
+	private final ApplicationContext applicationContext;
+
+	@Bean
+	public InitializingBean eventsInitializer(ApplicationEventPublisher eventPublisher) {
+		return () -> EventPublisher.setPublisher(eventPublisher);
+	}
+}

--- a/src/main/java/com/stumeet/server/common/event/EventPublisher.java
+++ b/src/main/java/com/stumeet/server/common/event/EventPublisher.java
@@ -1,0 +1,24 @@
+package com.stumeet.server.common.event;
+
+import org.springframework.context.ApplicationEventPublisher;
+
+import com.stumeet.server.common.event.model.Event;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class EventPublisher {
+
+	private static ApplicationEventPublisher publisher;
+
+	public static void setPublisher(ApplicationEventPublisher publisher) {
+		EventPublisher.publisher = publisher;
+	}
+
+	public static void raise(Event event) {
+		if (publisher != null) {
+			publisher.publishEvent(event);
+		}
+	}
+}

--- a/src/main/java/com/stumeet/server/common/event/model/Event.java
+++ b/src/main/java/com/stumeet/server/common/event/model/Event.java
@@ -1,0 +1,20 @@
+package com.stumeet.server.common.event.model;
+
+import org.springframework.context.ApplicationEvent;
+
+import lombok.Getter;
+
+@Getter
+public class Event extends ApplicationEvent {
+
+	private final String message;
+
+	protected Event(Object source, String message) {
+		super(source);
+		this.message = message;
+	}
+
+	public static Event of(Object source, String message) {
+		return new Event(source, message);
+	}
+}

--- a/src/main/java/com/stumeet/server/study/application/service/ActivityImageDeleteService.java
+++ b/src/main/java/com/stumeet/server/study/application/service/ActivityImageDeleteService.java
@@ -4,7 +4,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.stumeet.server.activity.application.port.out.ActivityImageCommandPort;
 import com.stumeet.server.common.annotation.UseCase;
-import com.stumeet.server.file.application.port.in.FileDeleteUseCase;
 import com.stumeet.server.study.application.port.in.ActivityImageDeleteUseCase;
 
 import lombok.RequiredArgsConstructor;
@@ -14,12 +13,10 @@ import lombok.RequiredArgsConstructor;
 @Transactional
 public class ActivityImageDeleteService implements ActivityImageDeleteUseCase {
 
-    private final FileDeleteUseCase fileDeleteUseCase;
     private final ActivityImageCommandPort activityImageCommandPort;
 
     @Override
     public void deleteByActivityId(Long studyId, Long activityId) {
-        activityImageCommandPort.deleteAllByActivityId(activityId);
-        fileDeleteUseCase.deleteActivityRelatedImage(studyId, activityId);
+        activityImageCommandPort.deleteAllByActivityId(studyId, activityId);
     }
 }

--- a/src/test/resources/org/springframework/restdocs/templates/asciidoctor/request-fields.snippet
+++ b/src/test/resources/org/springframework/restdocs/templates/asciidoctor/request-fields.snippet
@@ -1,0 +1,10 @@
+|===
+|Path|Type|Description|Optional
+
+{{#fields}}
+|{{path}}
+|{{type}}
+|{{description}}
+|{{#optional}}Yes{{/optional}}{{^optional}}No{{/optional}}
+{{/fields}}
+|===


### PR DESCRIPTION
## 💁 해결 하려는 문제를 적어주세요 

활동을 삭제하는 상황에서 이미지 파일을 삭제하는 경우 외부 서비스인 S3에 요청해야 하기 때문에 딜레이가 생겼습니다.
## 🤔 어떤 방식으로 해결했는지 적어주세요 

- Spring Events 기능을 사용하여 활동 이미지 삭제 요청을 비동기로 요청하는 방식으로 구현했습니다.