### PR TITLE
🐛 [STMT-146] FIRST_LOGIN 역할의 유저가 닉네임 유효성 검증에 접근하지 못하는 에러 해결

### DIFF
--- a/src/main/java/com/stumeet/server/common/auth/config/SecurityConfig.java
+++ b/src/main/java/com/stumeet/server/common/auth/config/SecurityConfig.java
@@ -73,7 +73,7 @@ public class SecurityConfig {
             auth.requestMatchers("/docs/**").permitAll();
             auth.requestMatchers("/api/v1/signup").hasAnyAuthority(UserRole.FIRST_LOGIN.toString());
             auth.requestMatchers("/api/v1/professions").hasAnyAuthority(UserRole.FIRST_LOGIN.toString(), UserRole.MEMBER.toString());
-            auth.requestMatchers("/api/v1/validate-nickname").hasAnyAuthority(UserRole.FIRST_LOGIN.toString(), UserRole.MEMBER.toString());
+            auth.requestMatchers("/api/v1/members/validate-nickname").hasAnyAuthority(UserRole.FIRST_LOGIN.toString(), UserRole.MEMBER.toString());
             auth.anyRequest().hasAnyAuthority(UserRole.MEMBER.toString());
         });
 

--- a/src/main/java/com/stumeet/server/common/auth/config/SecurityConfig.java
+++ b/src/main/java/com/stumeet/server/common/auth/config/SecurityConfig.java
@@ -73,6 +73,7 @@ public class SecurityConfig {
             auth.requestMatchers("/docs/**").permitAll();
             auth.requestMatchers("/api/v1/signup").hasAnyAuthority(UserRole.FIRST_LOGIN.toString());
             auth.requestMatchers("/api/v1/professions").hasAnyAuthority(UserRole.FIRST_LOGIN.toString(), UserRole.MEMBER.toString());
+            auth.requestMatchers("/api/v1/validate-nickname").hasAnyAuthority(UserRole.FIRST_LOGIN.toString(), UserRole.MEMBER.toString());
             auth.anyRequest().hasAnyAuthority(UserRole.MEMBER.toString());
         });
 

--- a/src/main/java/com/stumeet/server/member/application/service/MemberProfileService.java
+++ b/src/main/java/com/stumeet/server/member/application/service/MemberProfileService.java
@@ -4,6 +4,7 @@ import com.stumeet.server.common.annotation.UseCase;
 import com.stumeet.server.file.application.port.in.FileUploadUseCase;
 import com.stumeet.server.member.adapter.in.web.response.MemberProfileResponse;
 import com.stumeet.server.member.application.port.in.MemberProfileUseCase;
+import com.stumeet.server.member.application.port.in.MemberValidationUseCase;
 import com.stumeet.server.member.application.port.in.command.MemberProfileCommand;
 import com.stumeet.server.member.application.port.in.command.MemberSignupCommand;
 import com.stumeet.server.member.application.port.in.command.MemberUpdateCommand;
@@ -23,6 +24,7 @@ public class MemberProfileService implements MemberProfileUseCase {
 
     private final ProfessionQueryUseCase professionQueryUseCase;
     private final FileUploadUseCase fileUploadUseCase;
+    private final MemberValidationUseCase memberValidationUseCase;
     private final MemberCommandPort memberCommandPort;
     private final MemberQueryPort memberQueryPort;
     private final MemberUseCaseMapper memberUseCaseMapper;
@@ -30,6 +32,8 @@ public class MemberProfileService implements MemberProfileUseCase {
 
     @Override
     public void signup(Member member, MemberSignupCommand request) {
+        memberValidationUseCase.validateNickname(request.nickname());
+
         Profession profession = professionQueryUseCase.getById(request.profession());
         String url = fileUploadUseCase.uploadUserProfileImage(member.getId(), request.image()).url();
 


### PR DESCRIPTION
## 💁 해결 하려는 문제를 적어주세요 

- security 설정 때문에 FIRST_LOGIN 역할의 유저가 닉네임 유효성 검증에 접근하지 못하는 상황이 발생했습니다.
## 🤔 어떤 방식으로 해결했는지 적어주세요 

- spring security config에 해당 api path로 FIRST_LOGIN과 MEMBER 역할이 둘 다 접근할 수 있게 설정했습니다.
- 회원가입 API에 닉네임 유효성 검사 로직이 포함되어 있지 않아 추가했습니다. 