### PR TITLE
✨ [STMT-184] 활동 단일 조회 API: 권한 확인 플래그 응답값 추가 및 활동 상태값 포맷팅

### DIFF
--- a/src/main/java/com/stumeet/server/activity/adapter/in/response/ActivityDetailResponse.java
+++ b/src/main/java/com/stumeet/server/activity/adapter/in/response/ActivityDetailResponse.java
@@ -18,8 +18,9 @@ public record ActivityDetailResponse(
         LocalDateTime startDate,
         LocalDateTime endDate,
         String location,
-        LocalDateTime createdAt
-
+        LocalDateTime createdAt,
+        boolean isAuthor,
+        boolean isAdmin
 ) {
 
     @QueryProjection

--- a/src/main/java/com/stumeet/server/activity/application/port/in/mapper/ActivityUseCaseMapper.java
+++ b/src/main/java/com/stumeet/server/activity/application/port/in/mapper/ActivityUseCaseMapper.java
@@ -49,7 +49,9 @@ public class ActivityUseCaseMapper {
 			List<ActivityImageResponse> activityImages,
 			ActivityParticipantSimpleResponse author,
 			List<ActivityParticipantSimpleResponse> participants,
-			String status
+			String status,
+			boolean isAuthor,
+			boolean isAdmin
 	) {
 		return ActivityDetailResponse.builder()
 				.id(activity.getId())
@@ -64,6 +66,8 @@ public class ActivityUseCaseMapper {
 				.endDate(activity.getEndDate())
 				.location(activity.getLocation())
 				.createdAt(activity.getCreatedAt())
+				.isAuthor(isAuthor)
+				.isAdmin(isAdmin)
 				.build();
 	}
 

--- a/src/main/java/com/stumeet/server/activity/application/service/ActivityAuthorityValidationService.java
+++ b/src/main/java/com/stumeet/server/activity/application/service/ActivityAuthorityValidationService.java
@@ -17,7 +17,7 @@ public class ActivityAuthorityValidationService implements ActivityAuthorityVali
 
     @Override
     public void checkDeleteAuthority(Long studyId, Long memberId, Long activityId) {
-        if (studyMemberValidationPort.isNotAdmin(studyId, memberId) && activityAuthorValidationPort.isNotActivityAuthor(memberId, activityId)) {
+        if (!studyMemberValidationPort.isAdmin(studyId, memberId) && activityAuthorValidationPort.isNotActivityAuthor(memberId, activityId)) {
             throw new ActivityManagementAccessDeniedException();
         }
     }

--- a/src/main/java/com/stumeet/server/activity/application/service/ActivityQueryFacade.java
+++ b/src/main/java/com/stumeet/server/activity/application/service/ActivityQueryFacade.java
@@ -20,6 +20,7 @@ import com.stumeet.server.activity.domain.model.ActivityParticipant;
 import com.stumeet.server.common.annotation.UseCase;
 import com.stumeet.server.study.application.port.in.StudyValidationUseCase;
 import com.stumeet.server.studymember.application.port.in.StudyMemberValidationUseCase;
+import com.stumeet.server.studymember.application.port.out.StudyMemberValidationPort;
 
 import lombok.RequiredArgsConstructor;
 
@@ -40,6 +41,8 @@ public class ActivityQueryFacade implements ActivityQueryUseCase {
 	private final ActivityQuery activityQuery;
 	private final ActivityImageQuery activityImageQuery;
 	private final ActivityParticipantQuery activityParticipantQuery;
+
+	private final StudyMemberValidationPort studyMemberValidationPort;
 
 	private final ActivityUseCaseMapper activityUseCaseMapper;
 	private final ActivityImageUseCaseMapper activityImageUseCaseMapper;
@@ -65,7 +68,9 @@ public class ActivityQueryFacade implements ActivityQueryUseCase {
 				activityImageUseCaseMapper.toResponses(activityImages),
 				activityParticipantUseCaseMapper.toResponse(activity.getAuthor()),
 				activityParticipantUseCaseMapper.toResponses(participants),
-				me.getStatus().getDescription()
+				me.getStatus().getDescription(),
+				activity.getAuthor().getId().equals(memberId),
+				studyMemberValidationPort.isAdmin(studyId, memberId)
 		);
 	}
 

--- a/src/main/java/com/stumeet/server/activity/domain/model/Activity.java
+++ b/src/main/java/com/stumeet/server/activity/domain/model/Activity.java
@@ -36,4 +36,7 @@ public abstract class Activity {
 
     private LocalDateTime createdAt;
 
+    public boolean isAuthor(Long memberId) {
+        return author.getId() == memberId;
+    }
 }

--- a/src/main/java/com/stumeet/server/activity/domain/model/MeetStatus.java
+++ b/src/main/java/com/stumeet/server/activity/domain/model/MeetStatus.java
@@ -6,10 +6,10 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @Getter
 public enum MeetStatus implements ActivityStatus {
-    MEET_NOT_STARTED("시작전"),
+    MEET_NOT_STARTED("시작 전"),
     ATTENDANCE("출석"),
     ABSENCE("결석"),
-    ACKNOWLEDGED_ABSENCE("인정 결석"),
+    ACKNOWLEDGED_ABSENCE("인정결석"),
     TARDINESS("지각")
     ;
 

--- a/src/main/java/com/stumeet/server/studymember/adapter/out/persistence/StudyMemberPersistenceAdapter.java
+++ b/src/main/java/com/stumeet/server/studymember/adapter/out/persistence/StudyMemberPersistenceAdapter.java
@@ -39,7 +39,7 @@ public class StudyMemberPersistenceAdapter implements StudyMemberJoinPort, Study
     }
 
     @Override
-    public boolean isNotAdmin(Long studyId, Long adminId) {
-        return !jpaStudyMemberRepository.isAdmin(studyId, adminId);
+    public boolean isAdmin(Long studyId, Long adminId) {
+        return jpaStudyMemberRepository.isAdmin(studyId, adminId);
     }
 }

--- a/src/main/java/com/stumeet/server/studymember/application/port/out/StudyMemberValidationPort.java
+++ b/src/main/java/com/stumeet/server/studymember/application/port/out/StudyMemberValidationPort.java
@@ -5,5 +5,5 @@ public interface StudyMemberValidationPort {
 
     boolean isAlreadyStudyJoinMember(Long studyId, Long memberId);
 
-    boolean isNotAdmin(Long studyId, Long adminId);
+    boolean isAdmin(Long studyId, Long adminId);
 }

--- a/src/main/java/com/stumeet/server/studymember/application/service/StudyMemberValidationService.java
+++ b/src/main/java/com/stumeet/server/studymember/application/service/StudyMemberValidationService.java
@@ -32,7 +32,7 @@ public class StudyMemberValidationService implements StudyMemberValidationUseCas
 
     @Override
     public void checkAdmin(Long studyId, Long adminId) {
-        if (studyMemberValidationPort.isNotAdmin(studyId, adminId)) {
+        if (!studyMemberValidationPort.isAdmin(studyId, adminId)) {
             throw new NotStudyAdminException(studyId, adminId);
         }
     }

--- a/src/test/java/com/stumeet/server/activity/adapter/in/ActivityQueryApiTest.java
+++ b/src/test/java/com/stumeet/server/activity/adapter/in/ActivityQueryApiTest.java
@@ -75,7 +75,9 @@ class ActivityQueryApiTest extends ApiTest {
                                     fieldWithPath("data.startDate").description("활동 시작일"),
                                     fieldWithPath("data.endDate").description("활동 종료일"),
                                     fieldWithPath("data.location").description("장소"),
-                                    fieldWithPath("data.createdAt").description("활동 생성일")
+                                    fieldWithPath("data.createdAt").description("활동 생성일"),
+                                    fieldWithPath("data.isAuthor").description("작성자 여부"),
+                                    fieldWithPath("data.isAdmin").description("관리자 여부")
                             )
                     ));
         }

--- a/src/test/java/com/stumeet/server/activity/application/service/ActivityQueryFacadeTest.java
+++ b/src/test/java/com/stumeet/server/activity/application/service/ActivityQueryFacadeTest.java
@@ -13,6 +13,7 @@ import com.stumeet.server.stub.StudyStub;
 import com.stumeet.server.study.application.port.in.StudyValidationUseCase;
 import com.stumeet.server.study.domain.exception.StudyNotExistsException;
 import com.stumeet.server.studymember.application.port.in.StudyMemberValidationUseCase;
+import com.stumeet.server.studymember.application.port.out.StudyMemberValidationPort;
 import com.stumeet.server.studymember.domain.exception.StudyMemberNotJoinedException;
 import com.stumeet.server.template.UnitTest;
 import org.junit.jupiter.api.DisplayName;
@@ -50,6 +51,9 @@ class ActivityQueryFacadeTest extends UnitTest {
     @Mock
     private ActivityParticipantQuery activityParticipantQuery;
 
+    @Mock
+    private StudyMemberValidationPort studyMemberValidationPort;
+
     @Spy
     private ActivityImageUseCaseMapper activityImageUseCaseMapper = new ActivityImageUseCaseMapper();
 
@@ -77,6 +81,8 @@ class ActivityQueryFacadeTest extends UnitTest {
                     .willReturn(ActivityStub.getActivityImages(ActivityStub.getDefaultActivity()));
             given(activityParticipantQuery.findAllByActivityId(any()))
                     .willReturn(ActivityStub.getActivityParticipants(ActivityStub.getDefaultActivity()));
+            given(studyMemberValidationPort.isAdmin(studyId, memberId))
+                    .willReturn(true);
 
             ActivityDetailResponse got = activityQueryFacade.getById(studyId, activityId, memberId);
 

--- a/src/test/java/com/stumeet/server/stub/ActivityStub.java
+++ b/src/test/java/com/stumeet/server/stub/ActivityStub.java
@@ -101,8 +101,6 @@ public class ActivityStub {
                 .title("title")
                 .content("content")
                 .isNotice(true)
-                .startDate(LocalDateTime.parse("2024-04-01T00:00:00"))
-                .endDate(LocalDateTime.parse("2050-05-01T00:00:00"))
                 .location(null)
                 .createdAt(LocalDateTime.now())
                 .build();
@@ -233,6 +231,8 @@ public class ActivityStub {
                 .imageUrl(getActivityImageResponses())
                 .participants(List.of(getAuthorResponse(), getParticipantResponse()))
                 .status(DefaultStatus.NONE.getDescription())
+                .isAuthor(true)
+                .isAdmin(true)
                 .build();
     }
     public static ActivityDetailResponse getActivityDetailResponseForNotJoinedUser() {


### PR DESCRIPTION
## 💁 해결 하려는 문제를 적어주세요 

프론트에서 활동 상세 페이지의 삭제/수정 등의 권한 판단을 위한 플래그가 필요합니다.

## 🤔 어떤 방식으로 해결했는지 적어주세요 

활동 단일 조회 API DTO에 관련 속성을 추가했습니다.
- 작성자 여부: isAuthor
- 관리자 여부: isAdmin

추가적으로 요청받은 활동 상태값의 한글도 포맷팅했습니다.