### PR TITLE
✨ [STMT-179] 생성된 활동을 응답 값으로 반환하는 기능 구현

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -459,8 +459,8 @@ include::{snippets}/create-activity/success/request-headers.adoc[]
 include::{snippets}/create-activity/success/request-fields.adoc[]
 
 ===== 응답 성공 (201)
-.응답 없음
 include::{snippets}/create-activity/success/response-body.adoc[]
+include::{snippets}/create-activity/success/response-fields.adoc[]
 
 ===== 응답 실패 (400)
 .활동 생성 요청 값이 유효하지 않은 경우

--- a/src/main/java/com/stumeet/server/activity/adapter/in/ActivityCreateApi.java
+++ b/src/main/java/com/stumeet/server/activity/adapter/in/ActivityCreateApi.java
@@ -1,6 +1,8 @@
 package com.stumeet.server.activity.adapter.in;
 
+import com.stumeet.server.activity.adapter.in.response.ActivityDetailResponse;
 import com.stumeet.server.activity.application.port.in.ActivityCreateUseCase;
+import com.stumeet.server.activity.application.port.in.ActivityQueryUseCase;
 import com.stumeet.server.activity.application.port.in.command.ActivityCreateCommand;
 import com.stumeet.server.common.annotation.WebAdapter;
 import com.stumeet.server.common.auth.model.LoginMember;
@@ -22,16 +24,18 @@ import org.springframework.web.bind.annotation.RequestMapping;
 public class ActivityCreateApi {
 
     private final ActivityCreateUseCase activityCreateUseCase;
+    private final ActivityQueryUseCase activityQueryUseCase;
 
     @PostMapping("/studies/{studyId}/activities")
-    public ResponseEntity<ApiResponse<Void>> create(
+    public ResponseEntity<ApiResponse<ActivityDetailResponse>> create(
             @PathVariable Long studyId,
             @AuthenticationPrincipal LoginMember loginMember,
             @RequestBody @Valid ActivityCreateCommand command
     ) {
-        activityCreateUseCase.create(studyId, command, loginMember.getMember().getId());
+        Long createdId = activityCreateUseCase.create(studyId, command, loginMember.getId());
+        ActivityDetailResponse response = activityQueryUseCase.getById(studyId, createdId, loginMember.getId());
 
         return ResponseEntity.status(HttpStatus.CREATED)
-                .body(ApiResponse.success(SuccessCode.ACTIVITY_CREATE_SUCCESS));
+                .body(ApiResponse.success(SuccessCode.ACTIVITY_CREATE_SUCCESS, response));
     }
 }

--- a/src/main/java/com/stumeet/server/activity/application/port/in/ActivityCreateUseCase.java
+++ b/src/main/java/com/stumeet/server/activity/application/port/in/ActivityCreateUseCase.java
@@ -3,5 +3,5 @@ package com.stumeet.server.activity.application.port.in;
 import com.stumeet.server.activity.application.port.in.command.ActivityCreateCommand;
 
 public interface ActivityCreateUseCase {
-    void create(Long studyId, ActivityCreateCommand command, Long memberId);
+    Long create(Long studyId, ActivityCreateCommand command, Long memberId);
 }

--- a/src/main/java/com/stumeet/server/activity/application/service/ActivityCreateService.java
+++ b/src/main/java/com/stumeet/server/activity/application/service/ActivityCreateService.java
@@ -37,7 +37,7 @@ public class ActivityCreateService implements ActivityCreateUseCase {
     private final ActivityParticipantUseCaseMapper activityParticipantUseCaseMapper;
 
     @Override
-    public void create(Long studyId, ActivityCreateCommand command, Long memberId) {
+    public Long create(Long studyId, ActivityCreateCommand command, Long memberId) {
         studyValidationUseCase.checkById(studyId);
         studyMemberValidationUseCase.checkStudyJoinMember(studyId, memberId);
 
@@ -50,5 +50,7 @@ public class ActivityCreateService implements ActivityCreateUseCase {
 
         List<ActivityImage> images = activityImageUseCaseMapper.toDomains(command.images(), createdActivity);
         activityImageCreatePort.create(images);
+
+        return createdActivity.getId();
     }
 }

--- a/src/test/java/com/stumeet/server/activity/adapter/in/ActivityCreateApiTest.java
+++ b/src/test/java/com/stumeet/server/activity/adapter/in/ActivityCreateApiTest.java
@@ -68,7 +68,26 @@ class ActivityCreateApiTest extends ApiTest {
                             ),
                             responseFields(
                                     fieldWithPath("code").description("응답 코드"),
-                                    fieldWithPath("message").description("응답 메시지")
+                                    fieldWithPath("message").description("응답 메시지"),
+                                    fieldWithPath("data.id").description("활동 ID"),
+                                    fieldWithPath("data.category").description("활동 유형"),
+                                    fieldWithPath("data.title").description("활동 제목"),
+                                    fieldWithPath("data.content").description("활동 내용"),
+                                    fieldWithPath("data.imageUrl[].id").description("활동 이미지의 아이디"),
+                                    fieldWithPath("data.imageUrl[].imageUrl").description("활동 이미지의 URL"),
+                                    fieldWithPath("data.author.memberId").description("활동 작성자 ID"),
+                                    fieldWithPath("data.author.name").description("활동 작성자 이름"),
+                                    fieldWithPath("data.author.profileImageUrl").description("활동 작성자 프로필 이미지 URL"),
+                                    fieldWithPath("data.participants[].memberId").description("참여자 ID"),
+                                    fieldWithPath("data.participants[].name").description("참여자 이름"),
+                                    fieldWithPath("data.participants[].profileImageUrl").description("참여자 프로필 이미지 URL"),
+                                    fieldWithPath("data.status").description("나의 활동 상태"),
+                                    fieldWithPath("data.startDate").description("활동 시작일"),
+                                    fieldWithPath("data.endDate").description("활동 종료일"),
+                                    fieldWithPath("data.location").description("장소"),
+                                    fieldWithPath("data.createdAt").description("활동 생성일"),
+                                    fieldWithPath("data.isAuthor").description("작성자 여부"),
+                                    fieldWithPath("data.isAdmin").description("관리자 여부")
                             )
                     ));
         }


### PR DESCRIPTION
## 💁 해결 하려는 문제를 적어주세요 

기획팀과의 논의에서 활동 생성 후 서버 API 호출 없이 프론트에서 자체적으로 활동 리스트에 업데이트하도록 기획이 변경되었습니다.

## 🤔 어떤 방식으로 해결했는지 적어주세요 

활동 생성 후 생성된 활동을 응답 값으로 반환하도록 구현했습니다.

## 🧑‍🏫 이해를 위해 필요한 자료가 있다면 첨부해주세요

<img src="https://github.com/user-attachments/assets/c6e5d7b2-7881-4a17-a124-827929569d9a" alt="해당 화면" width="30%" height="30%">
