### PR TITLE
✨ [STMT-187] 복수의 presigned url 발급 API 구현

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -425,24 +425,24 @@ include::{snippets}/study-member-join/fail/not-exist-member/response-fields.adoc
 
 ===== 요청
 
-include::{snippets}/presigned-url-generate/success/http-request.adoc[]
-include::{snippets}/presigned-url-generate/success/request-headers.adoc[]
-include::{snippets}/presigned-url-generate/success/request-fields.adoc[]
+include::{snippets}/presigned-urls-generate/success/http-request.adoc[]
+include::{snippets}/presigned-urls-generate/success/request-headers.adoc[]
+include::{snippets}/presigned-urls-generate/success/request-fields.adoc[]
 
 include::file-management-path.adoc[]
 
 ===== 응답 성공 (200)
-include::{snippets}/presigned-url-generate/success/response-body.adoc[]
-include::{snippets}/presigned-url-generate/success/response-fields.adoc[]
+include::{snippets}/presigned-urls-generate/success/response-body.adoc[]
+include::{snippets}/presigned-urls-generate/success/response-fields.adoc[]
 
 ===== 응답 실패 (400)
 .파일이름이 유효하지 않은 경우
-include::{snippets}/presigned-url-generate/fail/invalid-file-name/response-body.adoc[]
-include::{snippets}/presigned-url-generate/fail/invalid-file-name/response-fields.adoc[]
+include::{snippets}/presigned-urls-generate/fail/invalid-file-name/response-body.adoc[]
+include::{snippets}/presigned-urls-generate/fail/invalid-file-name/response-fields.adoc[]
 
 .파일의 확장자가 유효하지 않은 경우
-include::{snippets}/presigned-url-generate/fail/invalid-file-extension/response-body.adoc[]
-include::{snippets}/presigned-url-generate/fail/invalid-file-extension/response-fields.adoc[]
+include::{snippets}/presigned-urls-generate/fail/invalid-file-extension/response-body.adoc[]
+include::{snippets}/presigned-urls-generate/fail/invalid-file-extension/response-fields.adoc[]
 
 == 스터디 활동 관리
 

--- a/src/main/java/com/stumeet/server/common/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/stumeet/server/common/exception/handler/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.stumeet.server.common.exception.handler;
 
 import java.util.List;
+import java.util.concurrent.CompletionException;
 import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.databind.exc.InvalidFormatException;
@@ -57,6 +58,21 @@ public class GlobalExceptionHandler {
         ApiResponse response = ApiResponse.fail(errorCode);
 
         return ResponseEntity.status(errorCode.getHttpStatus())
+                .body(response);
+    }
+
+    @ExceptionHandler(CompletionException.class)
+    protected ResponseEntity<ApiResponse> handleCompletionException(final CompletionException e) {
+        String message = "비동기 작업 중 에러 발생. 원인: " + e.getCause().getMessage();
+
+        log.error(ERROR_LOG_MESSAGE, e.getClass().getSimpleName(), e.getMessage());
+        log.error(message);
+        log.debug(e.getMessage(), e);
+        e.printStackTrace();
+
+        ApiResponse response = ApiResponse.fail(500, message);
+
+        return ResponseEntity.internalServerError()
                 .body(response);
     }
 

--- a/src/main/java/com/stumeet/server/common/exception/model/BusinessException.java
+++ b/src/main/java/com/stumeet/server/common/exception/model/BusinessException.java
@@ -7,6 +7,7 @@ public class BusinessException extends RuntimeException {
     private final ErrorCode errorCode;
 
     public BusinessException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
         this.errorCode = errorCode;
     }
 

--- a/src/main/java/com/stumeet/server/common/response/ErrorCode.java
+++ b/src/main/java/com/stumeet/server/common/response/ErrorCode.java
@@ -73,6 +73,8 @@ public enum ErrorCode {
     FILE_IO_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "파일 입출력에 실패하였습니다."),
     UPLOAD_FILE_FAIL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "파일 업로드에 실패하였습니다."),
     NOT_IMPLEMENTED_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "구현되지 않은 메서드를 사용했습니다."),
+
+    ASYNC_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "비동기 작업 중 에러가 발생했습니다.")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/stumeet/server/file/adapter/in/PresignedUrlGenerateWebAdapter.java
+++ b/src/main/java/com/stumeet/server/file/adapter/in/PresignedUrlGenerateWebAdapter.java
@@ -3,9 +3,11 @@ package com.stumeet.server.file.adapter.in;
 import com.stumeet.server.common.annotation.WebAdapter;
 import com.stumeet.server.common.model.ApiResponse;
 import com.stumeet.server.common.response.SuccessCode;
+import com.stumeet.server.file.adapter.in.response.PresignedUrlResponses;
 import com.stumeet.server.file.application.port.in.PresignedUrlGenerateUseCase;
-import com.stumeet.server.file.application.port.in.command.PresignedUrlCommand;
-import com.stumeet.server.file.adapter.in.response.PresignedUrlResponse;
+import com.stumeet.server.file.application.port.in.command.PresignedUrlCommands;
+
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -14,17 +16,17 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 @WebAdapter
-@RequestMapping("/api/v1/presigned-url")
+@RequestMapping("/api/v1/presigned-urls")
 @RequiredArgsConstructor
 public class PresignedUrlGenerateWebAdapter {
 
     private final PresignedUrlGenerateUseCase presignedUrlGenerateUseCase;
 
     @PostMapping
-    public ResponseEntity<ApiResponse<PresignedUrlResponse>> generatePresignedUrl(
-            @RequestBody PresignedUrlCommand request
+    public ResponseEntity<ApiResponse<PresignedUrlResponses>> generatePresignedUrls(
+            @Valid @RequestBody PresignedUrlCommands request
     ) {
-        PresignedUrlResponse response = presignedUrlGenerateUseCase.generatePresignedUrl(request);
+        PresignedUrlResponses response = presignedUrlGenerateUseCase.generatePresignedUrls(request);
 
         return ResponseEntity.status(HttpStatus.OK)
                 .body(ApiResponse.success(SuccessCode.PRESIGNED_URL_SUCCESS, response));

--- a/src/main/java/com/stumeet/server/file/adapter/in/PresignedUrlGenerateWebAdapter.java
+++ b/src/main/java/com/stumeet/server/file/adapter/in/PresignedUrlGenerateWebAdapter.java
@@ -5,7 +5,7 @@ import com.stumeet.server.common.model.ApiResponse;
 import com.stumeet.server.common.response.SuccessCode;
 import com.stumeet.server.file.application.port.in.PresignedUrlGenerateUseCase;
 import com.stumeet.server.file.application.port.in.command.PresignedUrlCommand;
-import com.stumeet.server.file.application.port.in.response.PresignedUrlResponse;
+import com.stumeet.server.file.adapter.in.response.PresignedUrlResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/com/stumeet/server/file/adapter/in/response/PresignedUrlResponse.java
+++ b/src/main/java/com/stumeet/server/file/adapter/in/response/PresignedUrlResponse.java
@@ -1,4 +1,4 @@
-package com.stumeet.server.file.application.port.in.response;
+package com.stumeet.server.file.adapter.in.response;
 
 import lombok.Builder;
 

--- a/src/main/java/com/stumeet/server/file/adapter/in/response/PresignedUrlResponses.java
+++ b/src/main/java/com/stumeet/server/file/adapter/in/response/PresignedUrlResponses.java
@@ -1,0 +1,8 @@
+package com.stumeet.server.file.adapter.in.response;
+
+import java.util.List;
+
+public record PresignedUrlResponses(
+        List<PresignedUrlResponse> presignedUrls
+) {
+}

--- a/src/main/java/com/stumeet/server/file/adapter/out/S3ImageStorageAdapter.java
+++ b/src/main/java/com/stumeet/server/file/adapter/out/S3ImageStorageAdapter.java
@@ -10,10 +10,13 @@ import com.stumeet.server.file.application.port.dto.FileUrl;
 import com.stumeet.server.file.application.port.out.FileCommandPort;
 import com.stumeet.server.file.application.port.out.PresignedUrlGeneratePort;
 import com.stumeet.server.file.domain.FileManagementPath;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.multipart.MultipartFile;
+
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.DeleteObjectsRequest;
@@ -107,8 +110,8 @@ public class S3ImageStorageAdapter implements FileCommandPort, PresignedUrlGener
     public FileUrl generatePresignedUrl(FileManagementPath path, String fileName) {
         String key = FileUtil.generateKey(path.getPath(), fileName);
 
-        PresignedPutObjectRequest request = s3Presigner.presignPutObject(p ->
-                p.signatureDuration(Duration.ofSeconds(expiredTime))
+        PresignedPutObjectRequest request = s3Presigner.presignPutObject(
+                p -> p.signatureDuration(Duration.ofSeconds(expiredTime))
                         .putObjectRequest(pr -> pr.bucket(bucket).key(key))
         );
 

--- a/src/main/java/com/stumeet/server/file/application/port/in/PresignedUrlGenerateUseCase.java
+++ b/src/main/java/com/stumeet/server/file/application/port/in/PresignedUrlGenerateUseCase.java
@@ -1,7 +1,7 @@
 package com.stumeet.server.file.application.port.in;
 
 import com.stumeet.server.file.application.port.in.command.PresignedUrlCommand;
-import com.stumeet.server.file.application.port.in.response.PresignedUrlResponse;
+import com.stumeet.server.file.adapter.in.response.PresignedUrlResponse;
 
 public interface PresignedUrlGenerateUseCase {
 

--- a/src/main/java/com/stumeet/server/file/application/port/in/PresignedUrlGenerateUseCase.java
+++ b/src/main/java/com/stumeet/server/file/application/port/in/PresignedUrlGenerateUseCase.java
@@ -1,9 +1,8 @@
 package com.stumeet.server.file.application.port.in;
 
-import com.stumeet.server.file.application.port.in.command.PresignedUrlCommand;
-import com.stumeet.server.file.adapter.in.response.PresignedUrlResponse;
+import com.stumeet.server.file.adapter.in.response.PresignedUrlResponses;
+import com.stumeet.server.file.application.port.in.command.PresignedUrlCommands;
 
 public interface PresignedUrlGenerateUseCase {
-
-    PresignedUrlResponse generatePresignedUrl(PresignedUrlCommand request);
+    PresignedUrlResponses generatePresignedUrls(PresignedUrlCommands commands);
 }

--- a/src/main/java/com/stumeet/server/file/application/port/in/command/PresignedUrlCommands.java
+++ b/src/main/java/com/stumeet/server/file/application/port/in/command/PresignedUrlCommands.java
@@ -1,0 +1,13 @@
+package com.stumeet.server.file.application.port.in.command;
+
+import java.util.List;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record PresignedUrlCommands(
+        @NotNull(message = "Presigned URL을 요청할 이미지 정보를 입력해주세요.")
+        @Size(min = 1, max = 5, message = "요청 가능한 Presigned URL 개수는 최소 1개, 최대 5개 입니다.")
+        List<PresignedUrlCommand> commands
+) {
+}

--- a/src/main/java/com/stumeet/server/file/application/port/in/command/PresignedUrlCommands.java
+++ b/src/main/java/com/stumeet/server/file/application/port/in/command/PresignedUrlCommands.java
@@ -8,6 +8,6 @@ import jakarta.validation.constraints.Size;
 public record PresignedUrlCommands(
         @NotNull(message = "Presigned URL을 요청할 이미지 정보를 입력해주세요.")
         @Size(min = 1, max = 5, message = "요청 가능한 Presigned URL 개수는 최소 1개, 최대 5개 입니다.")
-        List<PresignedUrlCommand> commands
+        List<PresignedUrlCommand> requests
 ) {
 }

--- a/src/main/java/com/stumeet/server/file/application/service/PresignedUrlGenerateAsyncService.java
+++ b/src/main/java/com/stumeet/server/file/application/service/PresignedUrlGenerateAsyncService.java
@@ -1,0 +1,33 @@
+package com.stumeet.server.file.application.service;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+import com.stumeet.server.common.util.FileValidator;
+import com.stumeet.server.file.adapter.in.response.PresignedUrlResponse;
+import com.stumeet.server.file.application.port.dto.FileUrl;
+import com.stumeet.server.file.application.port.in.command.PresignedUrlCommand;
+import com.stumeet.server.file.application.port.out.PresignedUrlGeneratePort;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class PresignedUrlGenerateAsyncService {
+
+    private final PresignedUrlGeneratePort presignedUrlGeneratePort;
+
+    @Async
+    public CompletableFuture<PresignedUrlResponse> generatePresignedUrl(PresignedUrlCommand command) {
+        FileValidator.validateImageFile(command.fileName());
+
+        FileUrl fileUrl = presignedUrlGeneratePort.generatePresignedUrl(command.path(), command.fileName());
+
+        return CompletableFuture.completedFuture(
+                PresignedUrlResponse.builder()
+                        .url(fileUrl.url())
+                        .build());
+    }
+}

--- a/src/main/java/com/stumeet/server/file/application/service/PresignedUrlGenerateService.java
+++ b/src/main/java/com/stumeet/server/file/application/service/PresignedUrlGenerateService.java
@@ -5,7 +5,7 @@ import com.stumeet.server.common.util.FileValidator;
 import com.stumeet.server.file.application.port.dto.FileUrl;
 import com.stumeet.server.file.application.port.in.PresignedUrlGenerateUseCase;
 import com.stumeet.server.file.application.port.in.command.PresignedUrlCommand;
-import com.stumeet.server.file.application.port.in.response.PresignedUrlResponse;
+import com.stumeet.server.file.adapter.in.response.PresignedUrlResponse;
 import com.stumeet.server.file.application.port.out.PresignedUrlGeneratePort;
 import lombok.RequiredArgsConstructor;
 

--- a/src/main/java/com/stumeet/server/file/application/service/PresignedUrlGenerateService.java
+++ b/src/main/java/com/stumeet/server/file/application/service/PresignedUrlGenerateService.java
@@ -25,7 +25,7 @@ public class PresignedUrlGenerateService implements PresignedUrlGenerateUseCase 
     public PresignedUrlResponses generatePresignedUrls(PresignedUrlCommands commands) {
         List<CompletableFuture<PresignedUrlResponse>> futures = new ArrayList<>();
 
-        for (PresignedUrlCommand command : commands.commands()) {
+        for (PresignedUrlCommand command : commands.requests()) {
             CompletableFuture<PresignedUrlResponse> future =
                     presignedUrlGenerateAsyncService.generatePresignedUrl(command);
             futures.add(future);

--- a/src/main/java/com/stumeet/server/file/application/service/PresignedUrlGenerateService.java
+++ b/src/main/java/com/stumeet/server/file/application/service/PresignedUrlGenerateService.java
@@ -1,29 +1,40 @@
 package com.stumeet.server.file.application.service;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
 import com.stumeet.server.common.annotation.UseCase;
-import com.stumeet.server.common.util.FileValidator;
-import com.stumeet.server.file.application.port.dto.FileUrl;
+import com.stumeet.server.file.adapter.in.response.PresignedUrlResponses;
 import com.stumeet.server.file.application.port.in.PresignedUrlGenerateUseCase;
-import com.stumeet.server.file.application.port.in.command.PresignedUrlCommand;
 import com.stumeet.server.file.adapter.in.response.PresignedUrlResponse;
-import com.stumeet.server.file.application.port.out.PresignedUrlGeneratePort;
+import com.stumeet.server.file.application.port.in.command.PresignedUrlCommand;
+import com.stumeet.server.file.application.port.in.command.PresignedUrlCommands;
+
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @UseCase
 @RequiredArgsConstructor
+@Slf4j
 public class PresignedUrlGenerateService implements PresignedUrlGenerateUseCase {
 
-    private final PresignedUrlGeneratePort presignedUrlGeneratePort;
-
+    private final PresignedUrlGenerateAsyncService presignedUrlGenerateAsyncService;
 
     @Override
-    public PresignedUrlResponse generatePresignedUrl(PresignedUrlCommand command) {
-        FileValidator.validateImageFile(command.fileName());
+    public PresignedUrlResponses generatePresignedUrls(PresignedUrlCommands commands) {
+        List<CompletableFuture<PresignedUrlResponse>> futures = new ArrayList<>();
 
-        FileUrl fileUrl = presignedUrlGeneratePort.generatePresignedUrl(command.path(), command.fileName());
+        for (PresignedUrlCommand command : commands.commands()) {
+            CompletableFuture<PresignedUrlResponse> future =
+                    presignedUrlGenerateAsyncService.generatePresignedUrl(command);
+            futures.add(future);
+        }
 
-        return PresignedUrlResponse.builder()
-                .url(fileUrl.url())
-                .build();
+        List<PresignedUrlResponse> responses = futures.stream()
+                .map(CompletableFuture::join)
+                .toList();
+
+        return new PresignedUrlResponses(responses);
     }
 }

--- a/src/test/java/com/stumeet/server/file/adapter/in/PresignedUrlGenerateWebAdapterTest.java
+++ b/src/test/java/com/stumeet/server/file/adapter/in/PresignedUrlGenerateWebAdapterTest.java
@@ -35,12 +35,12 @@ class PresignedUrlGenerateWebAdapterTest extends ApiTest {
         @WithMockMember
         @DisplayName("[성공] 해당하는 파일 목록에 대한 PresignedUrl 목록을 생성한다.")
         void successTest() throws Exception {
-            PresignedUrlCommands commands = FileStub.getPresignedUrlCommands();
+            PresignedUrlCommands request = FileStub.getPresignedUrlCommands();
 
             mockMvc.perform(post(PATH)
                             .header(AuthenticationHeader.ACCESS_TOKEN.getName(), TokenStub.getMockAccessToken())
                             .contentType(MediaType.APPLICATION_JSON)
-                            .content(toJson(commands)))
+                            .content(toJson(request)))
                     .andExpect(status().isOk())
                     .andDo(document("presigned-urls-generate/success",
                             preprocessRequest(prettyPrint()),
@@ -49,8 +49,8 @@ class PresignedUrlGenerateWebAdapterTest extends ApiTest {
                                     headerWithName(AuthenticationHeader.ACCESS_TOKEN.getName()).description("서버로부터 전달받은 액세스 토큰")
                             ),
                             requestFields(
-                                    fieldWithPath("commands[].path").description("해당하는 파일의 도메인"),
-                                    fieldWithPath("commands[].fileName").description("파일 이름")
+                                    fieldWithPath("requests[].path").description("해당하는 파일의 도메인"),
+                                    fieldWithPath("requests[].fileName").description("파일 이름")
                             ),
                             responseFields(
                                     fieldWithPath("code").description("응답 코드"),
@@ -79,8 +79,8 @@ class PresignedUrlGenerateWebAdapterTest extends ApiTest {
                                     headerWithName(AuthenticationHeader.ACCESS_TOKEN.getName()).description("서버로부터 전달받은 액세스 토큰")
                             ),
                             requestFields(
-                                    fieldWithPath("commands[].path").description("해당하는 파일의 도메인"),
-                                    fieldWithPath("commands[].fileName").description("파일 이름")
+                                    fieldWithPath("requests[].path").description("해당하는 파일의 도메인"),
+                                    fieldWithPath("requests[].fileName").description("파일 이름")
                             ),
                             responseFields(
                                     fieldWithPath("code").description("응답 코드"),

--- a/src/test/java/com/stumeet/server/file/adapter/in/PresignedUrlGenerateWebAdapterTest.java
+++ b/src/test/java/com/stumeet/server/file/adapter/in/PresignedUrlGenerateWebAdapterTest.java
@@ -1,7 +1,7 @@
 package com.stumeet.server.file.adapter.in;
 
 import com.stumeet.server.common.auth.model.AuthenticationHeader;
-import com.stumeet.server.file.application.port.in.command.PresignedUrlCommand;
+import com.stumeet.server.file.application.port.in.command.PresignedUrlCommands;
 import com.stumeet.server.file.domain.exception.InvalidFileException;
 import com.stumeet.server.helper.WithMockMember;
 import com.stumeet.server.stub.FileStub;
@@ -29,46 +29,46 @@ class PresignedUrlGenerateWebAdapterTest extends ApiTest {
     @DisplayName("PresignedUrl 생성")
     class GeneratePresignedUrl {
 
-        private static final String PATH = "/api/v1/presigned-url";
+        private static final String PATH = "/api/v1/presigned-urls";
 
         @Test
         @WithMockMember
-        @DisplayName("[성공] 해당하는 파일에 대한 PresignedUrl을 생성한다.")
+        @DisplayName("[성공] 해당하는 파일 목록에 대한 PresignedUrl 목록을 생성한다.")
         void successTest() throws Exception {
-            PresignedUrlCommand request = FileStub.getPresignedUrlCommand();
+            PresignedUrlCommands commands = FileStub.getPresignedUrlCommands();
 
             mockMvc.perform(post(PATH)
                             .header(AuthenticationHeader.ACCESS_TOKEN.getName(), TokenStub.getMockAccessToken())
                             .contentType(MediaType.APPLICATION_JSON)
-                            .content(toJson(request)))
+                            .content(toJson(commands)))
                     .andExpect(status().isOk())
-                    .andDo(document("presigned-url-generate/success",
+                    .andDo(document("presigned-urls-generate/success",
                             preprocessRequest(prettyPrint()),
                             preprocessResponse(prettyPrint()),
                             requestHeaders(
                                     headerWithName(AuthenticationHeader.ACCESS_TOKEN.getName()).description("서버로부터 전달받은 액세스 토큰")
                             ),
                             requestFields(
-                                    fieldWithPath("path").description("해당하는 파일의 도메인"),
-                                    fieldWithPath("fileName").description("파일 이름")
+                                    fieldWithPath("commands[].path").description("해당하는 파일의 도메인"),
+                                    fieldWithPath("commands[].fileName").description("파일 이름")
                             ),
                             responseFields(
                                     fieldWithPath("code").description("응답 코드"),
                                     fieldWithPath("message").description("응답 메시지"),
-                                    fieldWithPath("data.url").description("Presigned url")
+                                    fieldWithPath("data.presignedUrls[].url").description("Presigned url")
                             )
                     ));
         }
 
         @ParameterizedTest
-        @MethodSource("com.stumeet.server.stub.FileStub#getInvalidFileTestArguments")
+        @MethodSource("com.stumeet.server.stub.FileStub#getInvalidFilesTestArguments")
         @WithMockMember
         @DisplayName("[실패] 파일 이름이 유효하지 않은 경우 예외가 발생합니다.")
-        void invalidFileTest(String documentPath, PresignedUrlCommand invalidFileRequest, InvalidFileException e) throws Exception {
+        void invalidFileTest(String documentPath, PresignedUrlCommands invalidFileRequests, InvalidFileException e) throws Exception {
             mockMvc.perform(post(PATH)
                             .header(AuthenticationHeader.ACCESS_TOKEN.getName(), TokenStub.getMockAccessToken())
                             .contentType(MediaType.APPLICATION_JSON)
-                            .content(toJson(invalidFileRequest)))
+                            .content(toJson(invalidFileRequests)))
                     .andExpect(status().isBadRequest())
                     .andExpect(jsonPath("$.code").value(e.getErrorCode().getHttpStatusCode()))
                     .andExpect(jsonPath("$.message").value(e.getErrorCode().getMessage()))
@@ -79,8 +79,8 @@ class PresignedUrlGenerateWebAdapterTest extends ApiTest {
                                     headerWithName(AuthenticationHeader.ACCESS_TOKEN.getName()).description("서버로부터 전달받은 액세스 토큰")
                             ),
                             requestFields(
-                                    fieldWithPath("path").description("해당하는 파일의 도메인"),
-                                    fieldWithPath("fileName").description("파일 이름")
+                                    fieldWithPath("commands[].path").description("해당하는 파일의 도메인"),
+                                    fieldWithPath("commands[].fileName").description("파일 이름")
                             ),
                             responseFields(
                                     fieldWithPath("code").description("응답 코드"),

--- a/src/test/java/com/stumeet/server/file/application/service/PresignedUrlGenerateAsyncServiceTest.java
+++ b/src/test/java/com/stumeet/server/file/application/service/PresignedUrlGenerateAsyncServiceTest.java
@@ -51,7 +51,7 @@ class PresignedUrlGenerateAsyncServiceTest extends UnitTest {
         @ParameterizedTest
         @MethodSource("com.stumeet.server.stub.FileStub#getInvalidFileTestArguments")
         @DisplayName("[실패] 파일 이름이 유효하지 않은 경우 예외가 발생합니다.")
-        void invalidFileTest(String documentPath, PresignedUrlCommand invalidFileRequest, InvalidFileException e) {
+        void invalidFileTest(PresignedUrlCommand invalidFileRequest, InvalidFileException e) {
             assertThatCode(() -> presignedUrlGenerateAsyncService.generatePresignedUrl(invalidFileRequest))
                     .isInstanceOf(e.getClass())
                     .hasMessage(e.getMessage());

--- a/src/test/java/com/stumeet/server/file/application/service/PresignedUrlGenerateAsyncServiceTest.java
+++ b/src/test/java/com/stumeet/server/file/application/service/PresignedUrlGenerateAsyncServiceTest.java
@@ -1,0 +1,60 @@
+package com.stumeet.server.file.application.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+import com.stumeet.server.file.adapter.in.response.PresignedUrlResponse;
+import com.stumeet.server.file.application.port.dto.FileUrl;
+import com.stumeet.server.file.application.port.in.command.PresignedUrlCommand;
+import com.stumeet.server.file.application.port.out.PresignedUrlGeneratePort;
+import com.stumeet.server.file.domain.exception.InvalidFileException;
+import com.stumeet.server.stub.FileStub;
+import com.stumeet.server.template.UnitTest;
+
+class PresignedUrlGenerateAsyncServiceTest extends UnitTest {
+
+    @InjectMocks
+    private PresignedUrlGenerateAsyncService presignedUrlGenerateAsyncService;
+
+    @Mock
+    private PresignedUrlGeneratePort presignedUrlGeneratePort;
+
+    @Nested
+    @DisplayName("generatePresignedUrl 메소드는")
+    class GeneratePresignedUrl {
+
+        @Test
+        @DisplayName("[성공] Presigned URL을 생성한다.")
+        void successTest() throws ExecutionException, InterruptedException {
+            PresignedUrlCommand request = FileStub.getPresignedUrlCommand();
+            FileUrl want = FileStub.getPresignedUrl();
+
+            given(presignedUrlGeneratePort.generatePresignedUrl(request.path(), request.fileName()))
+                    .willReturn(want);
+
+            CompletableFuture<PresignedUrlResponse> got = presignedUrlGenerateAsyncService.generatePresignedUrl(request);
+
+            assertThat(got.get().url()).isEqualTo(want.url());
+        }
+
+        @ParameterizedTest
+        @MethodSource("com.stumeet.server.stub.FileStub#getInvalidFileTestArguments")
+        @DisplayName("[실패] 파일 이름이 유효하지 않은 경우 예외가 발생합니다.")
+        void invalidFileTest(String documentPath, PresignedUrlCommand invalidFileRequest, InvalidFileException e) {
+            assertThatCode(() -> presignedUrlGenerateAsyncService.generatePresignedUrl(invalidFileRequest))
+                    .isInstanceOf(e.getClass())
+                    .hasMessage(e.getMessage());
+        }
+    }
+}

--- a/src/test/java/com/stumeet/server/file/application/service/PresignedUrlGenerateServiceTest.java
+++ b/src/test/java/com/stumeet/server/file/application/service/PresignedUrlGenerateServiceTest.java
@@ -2,7 +2,7 @@ package com.stumeet.server.file.application.service;
 
 import com.stumeet.server.file.application.port.dto.FileUrl;
 import com.stumeet.server.file.application.port.in.command.PresignedUrlCommand;
-import com.stumeet.server.file.application.port.in.response.PresignedUrlResponse;
+import com.stumeet.server.file.adapter.in.response.PresignedUrlResponse;
 import com.stumeet.server.file.application.port.out.PresignedUrlGeneratePort;
 import com.stumeet.server.file.domain.exception.InvalidFileException;
 import com.stumeet.server.stub.FileStub;

--- a/src/test/java/com/stumeet/server/stub/FileStub.java
+++ b/src/test/java/com/stumeet/server/stub/FileStub.java
@@ -64,7 +64,6 @@ public class FileStub {
     public static Stream<Arguments> getInvalidFileTestArguments() {
         return Stream.of(
                 Arguments.of(
-                        "presigned-url-generate/fail/invalid-file-name",
                         PresignedUrlCommand.builder()
                                 .path(FileManagementPath.STUDY_ACTIVITY)
                                 .fileName("test")
@@ -72,11 +71,39 @@ public class FileStub {
                         new InvalidFileException(ErrorCode.INVALID_FILE_NAME_EXCEPTION)
                 ),
                 Arguments.of(
-                        "presigned-url-generate/fail/invalid-file-extension",
                         PresignedUrlCommand.builder()
                                 .path(FileManagementPath.STUDY_ACTIVITY)
                                 .fileName("test.pxp")
                                 .build(),
+                        new InvalidFileException(ErrorCode.INVALID_FILE_EXTENSION_EXCEPTION)
+                )
+        );
+    }
+
+    public static Stream<Arguments> getInvalidFilesTestArguments() {
+        return Stream.of(
+                Arguments.of(
+                        "presigned-urls-generate/fail/invalid-file-name",
+                        new PresignedUrlCommands(
+                                List.of(
+                                        PresignedUrlCommand.builder()
+                                                .path(FileManagementPath.STUDY_ACTIVITY)
+                                                .fileName("test")
+                                                .build()
+                                )
+                        ),
+                        new InvalidFileException(ErrorCode.INVALID_FILE_NAME_EXCEPTION)
+                ),
+                Arguments.of(
+                        "presigned-urls-generate/fail/invalid-file-extension",
+                        new PresignedUrlCommands(
+                                List.of(
+                                        PresignedUrlCommand.builder()
+                                                .path(FileManagementPath.STUDY_ACTIVITY)
+                                                .fileName("test.pxp")
+                                                .build()
+                                )
+                        ),
                         new InvalidFileException(ErrorCode.INVALID_FILE_EXTENSION_EXCEPTION)
                 )
         );

--- a/src/test/java/com/stumeet/server/stub/FileStub.java
+++ b/src/test/java/com/stumeet/server/stub/FileStub.java
@@ -1,12 +1,16 @@
 package com.stumeet.server.stub;
 
 import com.stumeet.server.common.response.ErrorCode;
+import com.stumeet.server.file.adapter.in.response.PresignedUrlResponse;
+import com.stumeet.server.file.adapter.in.response.PresignedUrlResponses;
 import com.stumeet.server.file.application.port.dto.FileUrl;
 import com.stumeet.server.file.application.port.in.command.PresignedUrlCommand;
+import com.stumeet.server.file.application.port.in.command.PresignedUrlCommands;
 import com.stumeet.server.file.domain.FileManagementPath;
 import com.stumeet.server.file.domain.exception.InvalidFileException;
 import org.junit.jupiter.params.provider.Arguments;
 
+import java.util.List;
 import java.util.stream.Stream;
 
 public class FileStub {
@@ -29,6 +33,32 @@ public class FileStub {
                 .path(FileManagementPath.STUDY_ACTIVITY)
                 .fileName("test.jpg")
                 .build();
+    }
+
+    public static PresignedUrlCommands getPresignedUrlCommands() {
+        return new PresignedUrlCommands(
+                List.of(
+                        getPresignedUrlCommand(),
+                        getPresignedUrlCommand(),
+                        getPresignedUrlCommand()
+                )
+        );
+    }
+
+    public static PresignedUrlResponse getPresignedUrlResponse() {
+        return PresignedUrlResponse.builder()
+                .url(getPresignedUrl().url())
+                .build();
+    }
+
+    public static PresignedUrlResponses getPresignedUrlResponses() {
+        return new PresignedUrlResponses(
+                List.of(
+                        getPresignedUrlResponse(),
+                        getPresignedUrlResponse(),
+                        getPresignedUrlResponse()
+                )
+        );
     }
 
     public static Stream<Arguments> getInvalidFileTestArguments() {


### PR DESCRIPTION
## 💁 해결 하려는 문제를 적어주세요 

스터디의 활동을 생성할 때 최대 5개의 presigned url이 필요합니다.

## 🤔 어떤 방식으로 해결했는지 적어주세요 

업로드할 이미지의 개수만큼 요청을 하기보다는 복수의 url을 한번의 요청으로 발급하는 것이 효율적이라고 생각하여, 

업로드할 복수의 이미지 정보 목록을 받고 병렬로 presigned url 목록을 요청하는 방식으로 구현했습니다.