### PR TITLE
✨ [STMT-290] 단일 스터디 멤버 조회 API 구현

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -309,7 +309,33 @@ include::{snippets}/update-study/fail/invalid-study-meeting-schedule/response-fi
 
 == 스터디 멤버 관리
 
-=== 스터디 멤버 조회
+=== 스터디 멤버 단일 상세 조회
+
+전달받은 스터디 ID의 단일 멤버 정보를 상세 조회하는 API입니다.
+
+==== GET /v1/api/studies/{studyId}/members/{memberId}
+
+===== 요청
+include::{snippets}/get-study-member-detail/success/http-request.adoc[]
+
+====== 헤더
+include::{snippets}/get-study-member-detail/success/request-headers.adoc[]
+
+====== 경로 변수
+include::{snippets}/get-study-member-detail/success/path-parameters.adoc[]
+
+===== 응답 실패 (403)
+.요청자가 스터디의 멤버가 아닌 경우
+include::{snippets}/get-study-member-detail/fail/is-not-study-member/response-body.adoc[]
+include::{snippets}/get-study-member-detail/fail/is-not-study-member/response-fields.adoc[]
+
+===== 응답 실패 (404)
+.요청한 스터디가 존재하지 않는 경우
+include::{snippets}/get-study-member-detail/fail/study-not-found/response-body.adoc[]
+include::{snippets}/get-study-member-detail/fail/study-not-found/response-fields.adoc[]
+
+
+=== 스터디 멤버 목록 조회
 
 전달받은 스터디 ID의 속한 멤버들을 조회하는 API입니다.
 

--- a/src/main/java/com/stumeet/server/activity/adapter/out/persistence/ActivityParticipantPersistenceAdapter.java
+++ b/src/main/java/com/stumeet/server/activity/adapter/out/persistence/ActivityParticipantPersistenceAdapter.java
@@ -44,6 +44,13 @@ public class ActivityParticipantPersistenceAdapter implements ActivityParticipan
     }
 
     @Override
+    public List<ActivityParticipant> findMemberParticipation(Long studyId, Long memberId) {
+        return jpaActivityParticipantRepository.findAllByActivityStudyIdAndMemberId(studyId, memberId).stream()
+                .map(activityParticipantPersistenceMapper::toDomain)
+                .toList();
+    }
+
+    @Override
     public void update(ActivityParticipant participant) {
         jpaActivityParticipantRepository.save(activityParticipantPersistenceMapper.toEntity(participant));
     }

--- a/src/main/java/com/stumeet/server/activity/adapter/out/persistence/JpaActivityParticipantRepository.java
+++ b/src/main/java/com/stumeet/server/activity/adapter/out/persistence/JpaActivityParticipantRepository.java
@@ -12,5 +12,7 @@ public interface JpaActivityParticipantRepository extends JpaRepository<Activity
 
     List<ActivityParticipantJpaEntity> findAllByActivityId(Long activityId);
 
+    List<ActivityParticipantJpaEntity> findAllByActivityStudyIdAndMemberId(Long studyId, Long memberId);
+
     void deleteAllByActivityId(Long activityId);
 }

--- a/src/main/java/com/stumeet/server/activity/application/port/in/EvaluateMemberAchievementUseCase.java
+++ b/src/main/java/com/stumeet/server/activity/application/port/in/EvaluateMemberAchievementUseCase.java
@@ -1,0 +1,6 @@
+package com.stumeet.server.activity.application.port.in;
+
+public interface EvaluateMemberAchievementUseCase {
+
+    Integer getMemberAchievement(Long studyId, Long memberId);
+}

--- a/src/main/java/com/stumeet/server/activity/application/port/out/ActivityParticipantQueryPort.java
+++ b/src/main/java/com/stumeet/server/activity/application/port/out/ActivityParticipantQueryPort.java
@@ -9,4 +9,6 @@ public interface ActivityParticipantQueryPort {
     ActivityParticipant findByActivityIdAndMemberIdAndId(Long activityId, Long memberId, Long id);
 
     List<ActivityParticipant> findAllByActivityId(Long activityId);
+
+    List<ActivityParticipant> findMemberParticipation(Long studyId, Long memberId);
 }

--- a/src/main/java/com/stumeet/server/activity/application/service/EvaluateMemberMemberParticipationService.java
+++ b/src/main/java/com/stumeet/server/activity/application/service/EvaluateMemberMemberParticipationService.java
@@ -1,0 +1,62 @@
+package com.stumeet.server.activity.application.service;
+
+import java.util.List;
+
+import org.springframework.transaction.annotation.Transactional;
+
+import com.stumeet.server.activity.application.port.in.EvaluateMemberAchievementUseCase;
+import com.stumeet.server.activity.application.port.out.ActivityParticipantQueryPort;
+import com.stumeet.server.activity.domain.model.ActivityCategory;
+import com.stumeet.server.activity.domain.model.ActivityParticipant;
+import com.stumeet.server.activity.domain.model.CommonStatus;
+import com.stumeet.server.common.annotation.UseCase;
+
+import lombok.RequiredArgsConstructor;
+
+@UseCase
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class EvaluateMemberMemberParticipationService implements EvaluateMemberAchievementUseCase {
+    private static final int PERCENTAGE_MULTIPLIER = 100;
+
+    private final ActivityParticipantQueryPort activityParticipantQueryPort;
+
+    @Override
+    public Integer getMemberAchievement(Long studyId, Long memberId) {
+        List<ActivityParticipant> activityParticipants =
+                activityParticipantQueryPort.findMemberParticipation(studyId, memberId);
+
+        return calculateParticipationPercentage(activityParticipants);
+    }
+
+    private Integer calculateParticipationPercentage(List<ActivityParticipant> participants) {
+        List<ActivityParticipant> joinedActivities = getValidJoinedActivities(participants);
+        long totalActivities = joinedActivities.size();
+
+        if (totalActivities == 0) {
+            return 0;
+        }
+
+        long achievedActivities = joinedActivities.stream()
+                .filter(ActivityParticipant::isAchieved)
+                .count();
+
+        double participation = (double)achievedActivities / totalActivities * PERCENTAGE_MULTIPLIER;
+        return (int)participation;
+    }
+
+    private List<ActivityParticipant> getValidJoinedActivities(List<ActivityParticipant> participants) {
+        return participants.stream()
+                .filter(participant -> isValidCategory(participant) && hasJoined(participant))
+                .toList();
+    }
+
+    private boolean isValidCategory(ActivityParticipant participant) {
+        return participant.getActivity().getCategory().equals(ActivityCategory.ASSIGNMENT)
+                || participant.getActivity().getCategory().equals(ActivityCategory.MEET);
+    }
+
+    private boolean hasJoined(ActivityParticipant participant) {
+        return !participant.getStatus().equals(CommonStatus.NOT_JOINED);
+    }
+}

--- a/src/main/java/com/stumeet/server/activity/domain/model/ActivityParticipant.java
+++ b/src/main/java/com/stumeet/server/activity/domain/model/ActivityParticipant.java
@@ -32,4 +32,8 @@ public class ActivityParticipant {
                 .status(status)
                 .build();
     }
+
+    public boolean isAchieved() {
+        return this.status.isSuccessfulStatus();
+    }
 }

--- a/src/main/java/com/stumeet/server/activity/domain/model/ActivityStatus.java
+++ b/src/main/java/com/stumeet/server/activity/domain/model/ActivityStatus.java
@@ -18,4 +18,6 @@ public interface ActivityStatus {
                 .findAny()
                 .orElseThrow(() -> new NotExistsActivityStatusException(status));
     }
+
+    boolean isSuccessfulStatus();
 }

--- a/src/main/java/com/stumeet/server/activity/domain/model/AssignmentStatus.java
+++ b/src/main/java/com/stumeet/server/activity/domain/model/AssignmentStatus.java
@@ -22,4 +22,9 @@ public enum AssignmentStatus implements ActivityStatus {
     public String getDescription() {
         return this.description;
     }
+
+    @Override
+    public boolean isSuccessfulStatus() {
+        return this.equals(PERFORMED);
+    }
 }

--- a/src/main/java/com/stumeet/server/activity/domain/model/CommonStatus.java
+++ b/src/main/java/com/stumeet/server/activity/domain/model/CommonStatus.java
@@ -17,4 +17,9 @@ public enum CommonStatus implements ActivityStatus {
     public String getDescription() {
         return this.description;
     }
+
+    @Override
+    public boolean isSuccessfulStatus() {
+        return false;
+    }
 }

--- a/src/main/java/com/stumeet/server/activity/domain/model/DefaultStatus.java
+++ b/src/main/java/com/stumeet/server/activity/domain/model/DefaultStatus.java
@@ -19,4 +19,9 @@ public enum DefaultStatus implements ActivityStatus {
     public String getDescription() {
         return this.description;
     }
+
+    @Override
+    public boolean isSuccessfulStatus() {
+        return false;
+    }
 }

--- a/src/main/java/com/stumeet/server/activity/domain/model/MeetStatus.java
+++ b/src/main/java/com/stumeet/server/activity/domain/model/MeetStatus.java
@@ -24,4 +24,9 @@ public enum MeetStatus implements ActivityStatus {
     public String getDescription() {
         return this.description;
     }
+
+    @Override
+    public boolean isSuccessfulStatus() {
+        return this.equals(ATTENDANCE) || this.equals(ACKNOWLEDGED_ABSENCE);
+    }
 }

--- a/src/main/java/com/stumeet/server/studymember/adapter/in/web/StudyMemberQueryApi.java
+++ b/src/main/java/com/stumeet/server/studymember/adapter/in/web/StudyMemberQueryApi.java
@@ -4,9 +4,11 @@ import com.stumeet.server.common.annotation.WebAdapter;
 import com.stumeet.server.common.auth.model.LoginMember;
 import com.stumeet.server.common.model.ApiResponse;
 import com.stumeet.server.common.response.SuccessCode;
+import com.stumeet.server.studymember.application.port.in.response.StudyMemberDetailResponse;
 import com.stumeet.server.studymember.application.port.in.response.StudyMemberResponses;
 import com.stumeet.server.studymember.application.port.in.StudyMemberQueryUseCase;
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -30,6 +32,19 @@ public class StudyMemberQueryApi {
         return new ResponseEntity<>(
                 ApiResponse.success(SuccessCode.GET_SUCCESS, responses),
                 HttpStatus.OK
+        );
+    }
+
+    @GetMapping("/studies/{studyId}/members/{memberId}")
+    public ResponseEntity<ApiResponse<StudyMemberDetailResponse>> getStudyMemberDetail(
+            @AuthenticationPrincipal LoginMember member,
+            @PathVariable Long studyId,
+            @PathVariable Long memberId
+    ) {
+        StudyMemberDetailResponse response = studyMemberQueryUseCase.getStudyMemberDetail(studyId, memberId, member.getId());
+
+        return ResponseEntity.ok(
+                ApiResponse.success(SuccessCode.GET_SUCCESS, response)
         );
     }
 }

--- a/src/main/java/com/stumeet/server/studymember/adapter/out/persistence/JpaStudyMemberRepositoryCustom.java
+++ b/src/main/java/com/stumeet/server/studymember/adapter/out/persistence/JpaStudyMemberRepositoryCustom.java
@@ -5,6 +5,9 @@ import com.stumeet.server.studymember.application.port.in.response.SimpleStudyMe
 import java.util.List;
 
 public interface JpaStudyMemberRepositoryCustom {
+
+    StudyMemberJpaEntity findStudyMemberByStudyIdAndMemberId(Long studyId, Long memberId);
+
     List<SimpleStudyMemberResponse> findStudyMembersByStudyId(Long studyId);
 
     boolean isStudyJoinMember(Long studyId, Long memberId);

--- a/src/main/java/com/stumeet/server/studymember/adapter/out/persistence/JpaStudyMemberRepositoryCustom.java
+++ b/src/main/java/com/stumeet/server/studymember/adapter/out/persistence/JpaStudyMemberRepositoryCustom.java
@@ -14,4 +14,5 @@ public interface JpaStudyMemberRepositoryCustom {
 
     boolean isAdmin(Long studyId, Long adminId);
 
+    boolean isSentGrape(Long studyId, Long memberId);
 }

--- a/src/main/java/com/stumeet/server/studymember/adapter/out/persistence/JpaStudyMemberRepositoryCustomImpl.java
+++ b/src/main/java/com/stumeet/server/studymember/adapter/out/persistence/JpaStudyMemberRepositoryCustomImpl.java
@@ -3,6 +3,7 @@ package com.stumeet.server.studymember.adapter.out.persistence;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.stumeet.server.studymember.application.port.in.response.QSimpleStudyMemberResponse;
 import com.stumeet.server.studymember.application.port.in.response.SimpleStudyMemberResponse;
+
 import lombok.RequiredArgsConstructor;
 
 import java.util.List;
@@ -14,6 +15,18 @@ public class JpaStudyMemberRepositoryCustomImpl implements JpaStudyMemberReposit
 
     private final JPAQueryFactory query;
 
+    @Override
+    public StudyMemberJpaEntity findStudyMemberByStudyIdAndMemberId(Long studyId, Long memberId) {
+        return query
+                .select(studyMemberJpaEntity)
+                .from(studyMemberJpaEntity)
+                .innerJoin(studyMemberJpaEntity.member)
+                .where(
+                        studyMemberJpaEntity.study.id.eq(studyId),
+                        studyMemberJpaEntity.member.id.eq(memberId)
+                )
+                .fetchOne();
+    }
 
     @Override
     public List<SimpleStudyMemberResponse> findStudyMembersByStudyId(Long studyId) {

--- a/src/main/java/com/stumeet/server/studymember/adapter/out/persistence/JpaStudyMemberRepositoryCustomImpl.java
+++ b/src/main/java/com/stumeet/server/studymember/adapter/out/persistence/JpaStudyMemberRepositoryCustomImpl.java
@@ -69,4 +69,17 @@ public class JpaStudyMemberRepositoryCustomImpl implements JpaStudyMemberReposit
                         ).fetchOne()
         );
     }
+
+    @Override
+    public boolean isSentGrape(Long studyId, Long memberId) {
+        return Boolean.TRUE.equals(
+                query
+                        .select(studyMemberJpaEntity.isSentGrape)
+                        .from(studyMemberJpaEntity)
+                        .where(
+                                studyMemberJpaEntity.study.id.eq(studyId),
+                                studyMemberJpaEntity.member.id.eq(memberId)
+                        ).fetchOne()
+        );
+    }
 }

--- a/src/main/java/com/stumeet/server/studymember/adapter/out/persistence/StudyMemberPersistenceAdapter.java
+++ b/src/main/java/com/stumeet/server/studymember/adapter/out/persistence/StudyMemberPersistenceAdapter.java
@@ -29,6 +29,13 @@ public class StudyMemberPersistenceAdapter implements StudyMemberJoinPort, Study
     }
 
     @Override
+    public StudyMember findStudyMember(Long studyId, Long memberId) {
+        StudyMemberJpaEntity entity = jpaStudyMemberRepository.findStudyMemberByStudyIdAndMemberId(studyId, memberId);
+
+        return studyMemberPersistenceMapper.toDomain(entity);
+    }
+
+    @Override
     public boolean isNotStudyJoinMember(Long studyId, Long memberId) {
         return !jpaStudyMemberRepository.isStudyJoinMember(studyId, memberId);
     }

--- a/src/main/java/com/stumeet/server/studymember/adapter/out/persistence/StudyMemberPersistenceAdapter.java
+++ b/src/main/java/com/stumeet/server/studymember/adapter/out/persistence/StudyMemberPersistenceAdapter.java
@@ -36,6 +36,11 @@ public class StudyMemberPersistenceAdapter implements StudyMemberJoinPort, Study
     }
 
     @Override
+    public boolean isSentGrape(Long studyId, Long memberId) {
+        return jpaStudyMemberRepository.isSentGrape(studyId, memberId);
+    }
+
+    @Override
     public boolean isNotStudyJoinMember(Long studyId, Long memberId) {
         return !jpaStudyMemberRepository.isStudyJoinMember(studyId, memberId);
     }

--- a/src/main/java/com/stumeet/server/studymember/application/port/in/StudyMemberQueryUseCase.java
+++ b/src/main/java/com/stumeet/server/studymember/application/port/in/StudyMemberQueryUseCase.java
@@ -1,7 +1,10 @@
 package com.stumeet.server.studymember.application.port.in;
 
+import com.stumeet.server.studymember.application.port.in.response.StudyMemberDetailResponse;
 import com.stumeet.server.studymember.application.port.in.response.StudyMemberResponses;
 
 public interface StudyMemberQueryUseCase {
-    StudyMemberResponses getStudyMembers(Long studyId, Long memberId);
+    StudyMemberResponses getStudyMembers(Long studyId, Long requesterId);
+
+    StudyMemberDetailResponse getStudyMemberDetail(Long studyId, Long targetMemberId, Long requesterId);
 }

--- a/src/main/java/com/stumeet/server/studymember/application/port/in/response/StudyMemberDetailResponse.java
+++ b/src/main/java/com/stumeet/server/studymember/application/port/in/response/StudyMemberDetailResponse.java
@@ -1,0 +1,12 @@
+package com.stumeet.server.studymember.application.port.in.response;
+
+public record StudyMemberDetailResponse(
+        Long id,
+        String name,
+        String image,
+        String region,
+        String profession,
+        boolean isSentGrape,
+        Integer achievement
+) {
+}

--- a/src/main/java/com/stumeet/server/studymember/application/port/in/response/StudyMemberDetailResponse.java
+++ b/src/main/java/com/stumeet/server/studymember/application/port/in/response/StudyMemberDetailResponse.java
@@ -6,7 +6,7 @@ public record StudyMemberDetailResponse(
         String image,
         String region,
         String profession,
-        boolean isSentGrape,
+        boolean canSendGrape,
         Integer achievement
 ) {
 }

--- a/src/main/java/com/stumeet/server/studymember/application/port/out/StudyMemberQueryPort.java
+++ b/src/main/java/com/stumeet/server/studymember/application/port/out/StudyMemberQueryPort.java
@@ -9,4 +9,6 @@ public interface StudyMemberQueryPort {
     List<SimpleStudyMemberResponse> findStudyMembers(Long studyId);
 
     StudyMember findStudyMember(Long studyId, Long memberId);
+
+    boolean isSentGrape(Long studyId, Long memberId);
 }

--- a/src/main/java/com/stumeet/server/studymember/application/port/out/StudyMemberQueryPort.java
+++ b/src/main/java/com/stumeet/server/studymember/application/port/out/StudyMemberQueryPort.java
@@ -1,9 +1,12 @@
 package com.stumeet.server.studymember.application.port.out;
 
 import com.stumeet.server.studymember.application.port.in.response.SimpleStudyMemberResponse;
+import com.stumeet.server.studymember.domain.StudyMember;
 
 import java.util.List;
 
 public interface StudyMemberQueryPort {
     List<SimpleStudyMemberResponse> findStudyMembers(Long studyId);
+
+    StudyMember findStudyMember(Long studyId, Long memberId);
 }

--- a/src/main/java/com/stumeet/server/studymember/application/service/StudyMemberQueryService.java
+++ b/src/main/java/com/stumeet/server/studymember/application/service/StudyMemberQueryService.java
@@ -43,7 +43,8 @@ public class StudyMemberQueryService implements StudyMemberQueryUseCase {
         studyMemberValidationUseCase.checkStudyJoinMember(studyId, requesterId);
 
         StudyMember studyMember = studyMemberQueryPort.findStudyMember(studyId, targetMemberId);
-        Integer achievement = evaluateMemberAchievementUseCase.getMemberAchievement(studyId, targetMemberId);
+        boolean canSendGrape = studyMemberQueryPort.isSentGrape(studyId, requesterId);
+        int achievement = evaluateMemberAchievementUseCase.getMemberAchievement(studyId, targetMemberId);
 
         return new StudyMemberDetailResponse(
                 studyMember.getMember().getId(),
@@ -51,7 +52,7 @@ public class StudyMemberQueryService implements StudyMemberQueryUseCase {
                 studyMember.getMember().getImage(),
                 studyMember.getMember().getRegion(),
                 studyMember.getMember().getProfession().getName(),
-                studyMember.isSentGrape(),
+                canSendGrape,
                 achievement
         );
     }

--- a/src/main/java/com/stumeet/server/studymember/application/service/StudyMemberQueryService.java
+++ b/src/main/java/com/stumeet/server/studymember/application/service/StudyMemberQueryService.java
@@ -1,13 +1,18 @@
 package com.stumeet.server.studymember.application.service;
 
+import com.stumeet.server.activity.application.port.in.EvaluateMemberAchievementUseCase;
 import com.stumeet.server.common.annotation.UseCase;
 import com.stumeet.server.study.application.port.in.StudyValidationUseCase;
 import com.stumeet.server.studymember.application.port.in.response.SimpleStudyMemberResponse;
+import com.stumeet.server.studymember.application.port.in.response.StudyMemberDetailResponse;
 import com.stumeet.server.studymember.application.port.in.response.StudyMemberResponses;
 import com.stumeet.server.studymember.application.port.in.StudyMemberQueryUseCase;
 import com.stumeet.server.studymember.application.port.in.StudyMemberValidationUseCase;
 import com.stumeet.server.studymember.application.port.out.StudyMemberQueryPort;
+import com.stumeet.server.studymember.domain.StudyMember;
+
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
@@ -19,14 +24,35 @@ public class StudyMemberQueryService implements StudyMemberQueryUseCase {
 
     private final StudyValidationUseCase studyValidationUseCase;
     private final StudyMemberValidationUseCase studyMemberValidationUseCase;
+    private final EvaluateMemberAchievementUseCase evaluateMemberAchievementUseCase;
+
     private final StudyMemberQueryPort studyMemberQueryPort;
 
     @Override
-    public StudyMemberResponses getStudyMembers(Long studyId, Long memberId) {
+    public StudyMemberResponses getStudyMembers(Long studyId, Long requesterId) {
         studyValidationUseCase.checkById(studyId);
-        studyMemberValidationUseCase.checkStudyJoinMember(studyId, memberId);
+        studyMemberValidationUseCase.checkStudyJoinMember(studyId, requesterId);
         List<SimpleStudyMemberResponse> response = studyMemberQueryPort.findStudyMembers(studyId);
 
         return new StudyMemberResponses(response);
+    }
+
+    @Override
+    public StudyMemberDetailResponse getStudyMemberDetail(Long studyId, Long targetMemberId, Long requesterId) {
+        studyValidationUseCase.checkById(studyId);
+        studyMemberValidationUseCase.checkStudyJoinMember(studyId, requesterId);
+
+        StudyMember studyMember = studyMemberQueryPort.findStudyMember(studyId, targetMemberId);
+        Integer achievement = evaluateMemberAchievementUseCase.getMemberAchievement(studyId, targetMemberId);
+
+        return new StudyMemberDetailResponse(
+                studyMember.getMember().getId(),
+                studyMember.getMember().getName(),
+                studyMember.getMember().getImage(),
+                studyMember.getMember().getRegion(),
+                studyMember.getMember().getProfession().getName(),
+                studyMember.isSentGrape(),
+                achievement
+        );
     }
 }

--- a/src/test/java/com/stumeet/server/studymember/adapter/in/web/StudyMemberQueryApiTest.java
+++ b/src/test/java/com/stumeet/server/studymember/adapter/in/web/StudyMemberQueryApiTest.java
@@ -2,6 +2,7 @@ package com.stumeet.server.studymember.adapter.in.web;
 
 import com.stumeet.server.common.auth.model.AuthenticationHeader;
 import com.stumeet.server.helper.WithMockMember;
+import com.stumeet.server.stub.MemberStub;
 import com.stumeet.server.stub.StudyStub;
 import com.stumeet.server.stub.TokenStub;
 import com.stumeet.server.template.ApiTest;
@@ -103,4 +104,41 @@ class StudyMemberQueryApiTest extends ApiTest {
         }
     }
 
+    @Nested
+    @DisplayName("단일 스터디 멤버 상세 조회")
+    class GetStudyMemberDetail {
+        private static final String PATH = "/api/v1/studies/{studyId}/members/{memberId}";
+
+        @Test
+        @WithMockMember
+        @DisplayName("[성공] 단일 스터디 멤버 상세 조회에 성공한다.")
+        void success() throws Exception {
+            Long studyId = StudyStub.getStudyId();
+            Long memberId = MemberStub.getMemberId();
+
+            mockMvc.perform(get(PATH, studyId, memberId)
+                    .header(AuthenticationHeader.ACCESS_TOKEN.getName(), TokenStub.getKakaoAccessToken()))
+                    .andExpect(status().isOk())
+                    .andDo(document("get-study-member-detail/success",
+                            preprocessRequest(prettyPrint()),
+                            preprocessResponse(prettyPrint()),
+                            pathParameters(
+                                    parameterWithName("studyId").description("스터디 ID"),
+                                    parameterWithName("memberId").description("조회할 멤버 ID")
+                            ),
+                            responseFields(
+                                    fieldWithPath("code").description("응답 코드"),
+                                    fieldWithPath("message").description("응답 메시지"),
+                                    fieldWithPath("data").description("스터디 멤버 상세 정보"),
+                                    fieldWithPath("data.id").description("멤버 ID"),
+                                    fieldWithPath("data.name").description("스터디 멤버 이름"),
+                                    fieldWithPath("data.image").description("스터디 멤버 프로필 이미지"),
+                                    fieldWithPath("data.region").description("스터디 멤버 지역"),
+                                    fieldWithPath("data.profession").description("스터디 멤버 분야"),
+                                    fieldWithPath("data.canSendGrape").description("포도알 발송 가능 여부"),
+                                    fieldWithPath("data.achievement").description("성취도")
+                            ))
+                    );
+        }
+    }
 }

--- a/src/test/java/com/stumeet/server/studymember/adapter/in/web/StudyMemberQueryApiTest.java
+++ b/src/test/java/com/stumeet/server/studymember/adapter/in/web/StudyMemberQueryApiTest.java
@@ -42,6 +42,9 @@ class StudyMemberQueryApiTest extends ApiTest {
                     .andDo(document("get-study-members/success",
                             preprocessRequest(prettyPrint()),
                             preprocessResponse(prettyPrint()),
+                            requestHeaders(
+                                    headerWithName(AuthenticationHeader.ACCESS_TOKEN.getName()).description("서버로부터 전달받은 액세스 토큰")
+                            ),
                             pathParameters(
                                     parameterWithName("studyId").description("스터디 ID")
                             ),
@@ -75,6 +78,9 @@ class StudyMemberQueryApiTest extends ApiTest {
                     .andDo(document("get-study-members/fail/not-joined-member",
                             preprocessRequest(prettyPrint()),
                             preprocessResponse(prettyPrint()),
+                            requestHeaders(
+                                    headerWithName(AuthenticationHeader.ACCESS_TOKEN.getName()).description("서버로부터 전달받은 액세스 토큰")
+                            ),
                             pathParameters(
                                     parameterWithName("studyId").description("스터디 ID")
                             ),
@@ -96,6 +102,9 @@ class StudyMemberQueryApiTest extends ApiTest {
                     .andDo(document("get-study-members/fail/not-exist-study",
                             preprocessRequest(prettyPrint()),
                             preprocessResponse(prettyPrint()),
+                            requestHeaders(
+                                    headerWithName(AuthenticationHeader.ACCESS_TOKEN.getName()).description("서버로부터 전달받은 액세스 토큰")
+                            ),
                             pathParameters(
                                     parameterWithName("studyId").description("스터디 ID")
                             ),
@@ -124,6 +133,9 @@ class StudyMemberQueryApiTest extends ApiTest {
                     .andDo(document("get-study-member-detail/success",
                             preprocessRequest(prettyPrint()),
                             preprocessResponse(prettyPrint()),
+                            requestHeaders(
+                                    headerWithName(AuthenticationHeader.ACCESS_TOKEN.getName()).description("서버로부터 전달받은 액세스 토큰")
+                            ),
                             pathParameters(
                                     parameterWithName("studyId").description("스터디 ID"),
                                     parameterWithName("memberId").description("조회할 멤버 ID")
@@ -156,6 +168,9 @@ class StudyMemberQueryApiTest extends ApiTest {
                     .andDo(document("get-study-member-detail/fail/study-not-found",
                             preprocessRequest(prettyPrint()),
                             preprocessResponse(prettyPrint()),
+                            requestHeaders(
+                                    headerWithName(AuthenticationHeader.ACCESS_TOKEN.getName()).description("서버로부터 전달받은 액세스 토큰")
+                            ),
                             pathParameters(
                                     parameterWithName("studyId").description("스터디 ID"),
                                     parameterWithName("memberId").description("조회할 멤버 ID")
@@ -180,6 +195,9 @@ class StudyMemberQueryApiTest extends ApiTest {
                     .andDo(document("get-study-member-detail/fail/is-not-study-member",
                             preprocessRequest(prettyPrint()),
                             preprocessResponse(prettyPrint()),
+                            requestHeaders(
+                                    headerWithName(AuthenticationHeader.ACCESS_TOKEN.getName()).description("서버로부터 전달받은 액세스 토큰")
+                            ),
                             pathParameters(
                                     parameterWithName("studyId").description("스터디 ID"),
                                     parameterWithName("memberId").description("조회할 멤버 ID")


### PR DESCRIPTION
## 💁 해결 하려는 문제를 적어주세요 

- 단일 스터디 멤버를 조회하는 API를 구현했습니다.

## 🤔 어떤 방식으로 해결했는지 적어주세요 

- 단일 스터디 멤버 조회 화면에서 참여한 활동 목록의 경우 멤버의 활동 리스트를 반환하는 API가 있으므로 멤버의 정보에 초점을 맞춰 구현했습니다.
- 응답 DTO
``` java
public record StudyMemberDetailResponse(
        Long id,
        String name,
        String image,
        String region,
        String profession,
        boolean canSendGrape,
        Integer achievement
) {
}
```

스터디 멤버 목록 조회와 유사하지만, 요청자가 해당 멤버에게 포도알을 보낼 수 있는지 여부와 성취도가 추가됐습니다.

- 성취도 계산 로직
기획에서 제공한 수식으로 구현했습니다.
``` 
성취한 활동 (출석, 수행 상태만) / 활동 개수(모임, 과제) * 100
```

모임(Meet)의 인정결석의 경우 기획에 문의 결과 성취한 활동 개수에 포함하는 것으로 전달받아 결론적으로 `모임`의 출석, 인정결석, `과제`의 제출을 성취한 활동으로 포함했습니다.

## 🧑‍🏫 이해를 위해 필요한 자료가 있다면 첨부해주세요
- 활동 수행상태
  - 공통
    - 미참여
- 자유
    - 없음
- 모임
    - 시작 전
    - 출석 ✅
    - 결석
    - 인정결석 ✅
    - 지각
- 과제
    - 시작 전
    - 미제출
    - 수행 ✅
    - 미수행
    
- 멤버 상세 조회 화면
<img width=300 src="https://github.com/user-attachments/assets/59014b4d-0b12-407b-91b3-00777fdcb136">
