### PR TITLE
✨ [STMT-295]  관리자 여부, 포도알 전송 가능 여부 판단 API 분리 및 멤버 상세 화면 통합 API 구현

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -258,7 +258,7 @@ include::{snippets}/create-study/success/request-headers.adoc[]
 ===== 파트
 include::{snippets}/create-study/success/request-parts.adoc[]
 
-===== 요청 본문 매개변수
+===== 요청 파트 매개변수
 include::{snippets}/create-study/success/request-part-request-fields.adoc[]
 
 ===== 응답 성공 (200)
@@ -290,7 +290,7 @@ include::{snippets}/update-study/success/request-headers.adoc[]
 ===== 파트
 include::{snippets}/update-study/success/request-parts.adoc[]
 
-===== 요청 본문 매개변수
+===== 요청 파트 매개변수
 include::{snippets}/update-study/success/request-part-request-fields.adoc[]
 
 ===== 응답 성공 (200)

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -357,6 +357,10 @@ include::{snippets}/get-study-member-detail/success/request-headers.adoc[]
 ====== 경로 변수
 include::{snippets}/get-study-member-detail/success/path-parameters.adoc[]
 
+===== 응답 성공 (200)
+include::{snippets}/get-study-member-detail/success/response-body.adoc[]
+include::{snippets}/get-study-member-detail/success/response-fields.adoc[]
+
 ===== 응답 실패 (403)
 .요청자가 스터디의 멤버가 아닌 경우
 include::{snippets}/get-study-member-detail/fail/is-not-study-member/response-body.adoc[]

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -504,6 +504,55 @@ include::{snippets}/delegate-admin/fail/not-admin/response-fields.adoc[]
 include::{snippets}/delegate-admin/fail/member-not-joined/response-body.adoc[]
 include::{snippets}/delegate-admin/fail/member-not-joined/response-fields.adoc[]
 
+=== 관리자 여부 조회
+
+로그인 멤버가 스터디 관리자인지 조회하는 API입니다.
+
+==== GET /v1/api/studies/{studyId}/me/admin/check
+
+===== 요청
+include::{snippets}/get-study-member-is-admin/success/http-request.adoc[]
+
+====== 헤더
+include::{snippets}/get-study-member-is-admin/success/request-headers.adoc[]
+
+====== 경로 변수
+include::{snippets}/get-study-member-is-admin/success/path-parameters.adoc[]
+
+===== 응답 성공 (200)
+include::{snippets}/get-study-member-is-admin/success/response-body.adoc[]
+include::{snippets}/get-study-member-is-admin/success/response-fields.adoc[]
+
+===== 응답 실패 (404)
+.스터디가 존재하지 않을 경우
+include::{snippets}/get-study-member-is-admin/fail/study-not-found/response-body.adoc[]
+include::{snippets}/get-study-member-is-admin/fail/study-not-found/response-fields.adoc[]
+
+=== 포도알 전송 가능 여부 조회
+
+로그인 멤버의 포도알 전송 가능 여부를 조회하는 API입니다.
+
+==== GET /v1/api/studies/{studyId}/me/grapes/available
+
+===== 요청
+include::{snippets}/get-study-member-can-send-grape/success/http-request.adoc[]
+
+====== 헤더
+include::{snippets}/get-study-member-can-send-grape/success/request-headers.adoc[]
+
+====== 경로 변수
+include::{snippets}/get-study-member-can-send-grape/success/path-parameters.adoc[]
+
+===== 응답 성공 (200)
+include::{snippets}/get-study-member-can-send-grape/success/response-body.adoc[]
+include::{snippets}/get-study-member-can-send-grape/success/response-fields.adoc[]
+
+===== 응답 실패 (404)
+.스터디가 존재하지 않을 경우
+include::{snippets}/get-study-member-can-send-grape/fail/study-not-found/response-body.adoc[]
+include::{snippets}/get-study-member-can-send-grape/fail/study-not-found/response-fields.adoc[]
+
+
 == 파일 관리
 
 === Presigned URL 발급
@@ -512,7 +561,7 @@ include::{snippets}/delegate-admin/fail/member-not-joined/response-fields.adoc[]
 
 해당 API는 1시간동안 유효합니다.
 
-==== POST /api/v1/presigned-url
+==== POST /api/v1/presigned-urls
 
 ===== 요청
 
@@ -810,3 +859,58 @@ include::{snippets}/delete-activity/fail/forbidden/response-fields.adoc[]
 .스터디의 멤버가 아닌 경우
 include::{snippets}/delete-activity/fail/not-joined-member/response-body.adoc[]
 include::{snippets}/delete-activity/fail/not-joined-member/response-fields.adoc[]
+
+== 통합 API
+
+=== 스터디 홈 화면 조회
+
+스터디 홈 화면을 조회하는 API입니다.
+
+==== GET /api/external/v1/studies/{studyId}
+
+===== 요청
+include::{snippets}/get-study-home-full/success/http-request.adoc[]
+
+====== 헤더
+include::{snippets}/get-study-home-full/success/request-headers.adoc[]
+
+====== 경로 변수
+include::{snippets}/get-study-home-full/success/path-parameters.adoc[]
+
+===== 응답 성공 (200)
+include::{snippets}/get-study-home-full/success/response-body.adoc[]
+include::{snippets}/get-study-home-full/success/response-fields.adoc[]
+
+===== 응답 실패 (404)
+.스터디가 존재하지 않는 경우
+include::{snippets}/get-study-home-full/fail/study-not-found/response-body.adoc[]
+include::{snippets}/get-study-home-full/fail/study-not-found/response-fields.adoc[]
+
+=== 스터디 멤버 상세 화면 조회
+
+스터디 멤버 상세 화면을 조회하는 API입니다.
+
+==== GET /api/external/v1/studies/{studyId}/members/{memberId}
+
+===== 요청
+include::{snippets}/get-study-member-detail-full/success/http-request.adoc[]
+
+====== 헤더
+include::{snippets}/get-study-member-detail-full/success/request-headers.adoc[]
+
+====== 경로 변수
+include::{snippets}/get-study-member-detail-full/success/path-parameters.adoc[]
+
+===== 응답 성공 (200)
+include::{snippets}/get-study-member-detail-full/success/response-body.adoc[]
+include::{snippets}/get-study-member-detail-full/success/response-fields.adoc[]
+
+===== 응답 실패 (403)
+.해당 스터디에 가입한 멤버가 요청한 것이 아닌 경우
+include::{snippets}/get-study-member-detail-full/fail/is-not-study-member/response-body.adoc[]
+include::{snippets}/get-study-member-detail-full/fail/is-not-study-member/response-fields.adoc[]
+
+===== 응답 실패 (404)
+.스터디가 존재하지 않는 경우
+include::{snippets}/get-study-member-detail-full/fail/study-not-found/response-body.adoc[]
+include::{snippets}/get-study-member-detail-full/fail/study-not-found/response-fields.adoc[]

--- a/src/main/java/com/stumeet/server/activity/adapter/in/ActivityQueryApi.java
+++ b/src/main/java/com/stumeet/server/activity/adapter/in/ActivityQueryApi.java
@@ -74,6 +74,7 @@ public class ActivityQueryApi {
 			@RequestParam(required = false) @Min(value = 0) Integer page,
 			@RequestParam(required = false) Boolean isNotice,
 			@RequestParam(required = false) Long studyId,
+			@RequestParam(required = false) Long memberId,
 			@RequestParam(required = false) String category,
 			@RequestParam(required = false) LocalDateTime fromDate,
 			@RequestParam(required = false) LocalDateTime toDate
@@ -83,7 +84,7 @@ public class ActivityQueryApi {
 				.page(page)
 				.isNotice(isNotice)
 				.studyId(studyId)
-				.memberId(member.getId())
+				.memberId(memberId != null ? memberId : member.getId())
 				.categoryName(category)
 				.fromDate(fromDate)
 				.toDate(toDate)

--- a/src/main/java/com/stumeet/server/activity/adapter/in/response/ActivityDetailResponse.java
+++ b/src/main/java/com/stumeet/server/activity/adapter/in/response/ActivityDetailResponse.java
@@ -18,6 +18,7 @@ public record ActivityDetailResponse(
         LocalDateTime startDate,
         LocalDateTime endDate,
         String location,
+        String link,
         LocalDateTime createdAt,
         boolean isAuthor,
         boolean isAdmin

--- a/src/main/java/com/stumeet/server/activity/adapter/out/mapper/ActivityPersistenceMapper.java
+++ b/src/main/java/com/stumeet/server/activity/adapter/out/mapper/ActivityPersistenceMapper.java
@@ -32,6 +32,7 @@ public class ActivityPersistenceMapper {
                 .startDate(entity.getStartDate())
                 .endDate(entity.getEndDate())
                 .location(entity.getLocation())
+                .link(entity.getLink())
                 .createdAt(entity.getCreatedAt())
                 .location(entity.getLocation())
                 .build();
@@ -65,6 +66,7 @@ public class ActivityPersistenceMapper {
                 .startDate(domain.getStartDate())
                 .endDate(domain.getEndDate())
                 .location(domain instanceof Meet meet ? meet.getLocation() : null)
+                .link(domain.getLink())
                 .build();
     }
 }

--- a/src/main/java/com/stumeet/server/activity/adapter/out/model/ActivityJpaEntity.java
+++ b/src/main/java/com/stumeet/server/activity/adapter/out/model/ActivityJpaEntity.java
@@ -58,4 +58,8 @@ public class ActivityJpaEntity extends BaseTimeEntity {
     @Column(name = "location")
     @Comment("활동 장소")
     private String location;
+
+    @Column(name = "link")
+    @Comment("링크")
+    private String link;
 }

--- a/src/main/java/com/stumeet/server/activity/application/port/in/mapper/ActivityUseCaseMapper.java
+++ b/src/main/java/com/stumeet/server/activity/application/port/in/mapper/ActivityUseCaseMapper.java
@@ -85,6 +85,7 @@ public class ActivityUseCaseMapper {
                 .startDate(activity.getStartDate())
                 .endDate(activity.getEndDate())
                 .location(activity.getLocation())
+                .link(activity.getLink())
                 .createdAt(activity.getCreatedAt())
                 .isAuthor(isAuthor)
                 .isAdmin(isAdmin)

--- a/src/main/java/com/stumeet/server/bff/adapter/in/app/StudyHubApi.java
+++ b/src/main/java/com/stumeet/server/bff/adapter/in/app/StudyHubApi.java
@@ -1,0 +1,68 @@
+package com.stumeet.server.bff.adapter.in.app;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.stumeet.server.activity.adapter.in.response.ActivityListDetailedPageResponse;
+import com.stumeet.server.activity.application.port.in.ActivityQueryUseCase;
+import com.stumeet.server.activity.application.port.in.query.ActivityListDetailedQuery;
+import com.stumeet.server.bff.adapter.in.app.response.StudyDetailFullResponse;
+import com.stumeet.server.common.auth.model.LoginMember;
+import com.stumeet.server.common.model.ApiResponse;
+import com.stumeet.server.common.response.SuccessCode;
+import com.stumeet.server.study.adapter.in.web.response.StudyDetailResponse;
+import com.stumeet.server.study.application.port.in.StudyQueryUseCase;
+import com.stumeet.server.studymember.application.port.in.StudyMemberQueryUseCase;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/external/v1")
+@RequiredArgsConstructor
+public class StudyHubApi {
+
+    private final StudyQueryUseCase studyQueryUseCase;
+    private final StudyMemberQueryUseCase studyMemberQueryUseCase;
+    private final ActivityQueryUseCase activityQueryUseCase;
+
+    @GetMapping("/studies/{studyId}")
+    public ResponseEntity<ApiResponse<StudyDetailFullResponse>> getStudyDetailFull(
+            @AuthenticationPrincipal LoginMember member,
+            @PathVariable(name = "studyId") Long studyId
+    ) {
+        StudyDetailResponse studyDetailResponse = studyQueryUseCase.getStudyDetailById(studyId);
+
+        ActivityListDetailedQuery noticeQuery = getNoticeQuery(member.getId(), studyId);
+        ActivityListDetailedPageResponse activityNotice = activityQueryUseCase.getDetails(noticeQuery)
+                .items()
+                .getFirst();
+
+        boolean isAdmin = studyMemberQueryUseCase.isMemberAdmin(studyId, member.getId()).isAdmin();
+        boolean canSendGrape = studyMemberQueryUseCase.canStudyMemberSendGrape(studyId, member.getId()).canSendGrape();
+
+        StudyDetailFullResponse response = new StudyDetailFullResponse(
+                studyDetailResponse,
+                activityNotice,
+                isAdmin,
+                canSendGrape
+        );
+
+        return ResponseEntity.ok(
+                ApiResponse.success(SuccessCode.GET_SUCCESS, response)
+        );
+    }
+
+    private ActivityListDetailedQuery getNoticeQuery(Long memberId, Long studyId) {
+        return ActivityListDetailedQuery.builder()
+                .memberId(memberId)
+                .studyId(studyId)
+                .page(0)
+                .size(1)
+                .isNotice(true)
+                .build();
+    }
+}

--- a/src/main/java/com/stumeet/server/bff/adapter/in/app/StudyMemberHubApi.java
+++ b/src/main/java/com/stumeet/server/bff/adapter/in/app/StudyMemberHubApi.java
@@ -1,0 +1,46 @@
+package com.stumeet.server.bff.adapter.in.app;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.stumeet.server.bff.adapter.in.app.response.StudyMemberDetailFullResponse;
+import com.stumeet.server.common.auth.model.LoginMember;
+import com.stumeet.server.common.model.ApiResponse;
+import com.stumeet.server.common.response.SuccessCode;
+import com.stumeet.server.studymember.application.port.in.StudyMemberQueryUseCase;
+import com.stumeet.server.studymember.application.port.in.response.StudyMemberDetailResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/external/v1")
+@RequiredArgsConstructor
+public class StudyMemberHubApi {
+
+    private final StudyMemberQueryUseCase studyMemberQueryUseCase;
+
+    @GetMapping("/studies/{studyId}/members/{memberId}")
+    public ResponseEntity<ApiResponse<StudyMemberDetailFullResponse>> getStudyMemberDetailFull(
+            @AuthenticationPrincipal LoginMember member,
+            @PathVariable Long studyId,
+            @PathVariable Long memberId
+    ) {
+        StudyMemberDetailResponse studyMemberDetail = studyMemberQueryUseCase.getStudyMemberDetail(studyId, memberId, member.getId());
+        boolean isAdmin = studyMemberQueryUseCase.isMemberAdmin(studyId, memberId).isAdmin();
+        boolean canSendGrape = studyMemberQueryUseCase.canStudyMemberSendGrape(studyId, memberId).canSendGrape();
+
+        StudyMemberDetailFullResponse response = new StudyMemberDetailFullResponse(
+                studyMemberDetail,
+                isAdmin,
+                canSendGrape
+        );
+
+        return ResponseEntity.ok(
+                ApiResponse.success(SuccessCode.GET_SUCCESS, response)
+        );
+    }
+}

--- a/src/main/java/com/stumeet/server/bff/adapter/in/app/response/StudyDetailFullResponse.java
+++ b/src/main/java/com/stumeet/server/bff/adapter/in/app/response/StudyDetailFullResponse.java
@@ -1,0 +1,12 @@
+package com.stumeet.server.bff.adapter.in.app.response;
+
+import com.stumeet.server.activity.adapter.in.response.ActivityListDetailedPageResponse;
+import com.stumeet.server.study.adapter.in.web.response.StudyDetailResponse;
+
+public record StudyDetailFullResponse(
+        StudyDetailResponse studyDetail,
+        ActivityListDetailedPageResponse activityNotice,
+        Boolean isAdmin,
+        Boolean canSendGrape
+) {
+}

--- a/src/main/java/com/stumeet/server/bff/adapter/in/app/response/StudyMemberDetailFullResponse.java
+++ b/src/main/java/com/stumeet/server/bff/adapter/in/app/response/StudyMemberDetailFullResponse.java
@@ -1,0 +1,10 @@
+package com.stumeet.server.bff.adapter.in.app.response;
+
+import com.stumeet.server.studymember.application.port.in.response.StudyMemberDetailResponse;
+
+public record StudyMemberDetailFullResponse(
+        StudyMemberDetailResponse studyMemberDetailResponse,
+        Boolean isAdmin,
+        Boolean canSendGrape
+) {
+}

--- a/src/main/java/com/stumeet/server/study/application/service/StudyQueryService.java
+++ b/src/main/java/com/stumeet/server/study/application/service/StudyQueryService.java
@@ -41,6 +41,7 @@ public class StudyQueryService implements StudyQueryUseCase {
 				return studyUseCaseMapper.toMyStudiesResponse(activeJoinedStudies);
 			}
 
+			// TODO: 완료된 스터디 조회의 경우
 			// case FINISHED -> {
 			//
 			// }

--- a/src/main/java/com/stumeet/server/studymember/adapter/in/web/StudyMemberQueryApi.java
+++ b/src/main/java/com/stumeet/server/studymember/adapter/in/web/StudyMemberQueryApi.java
@@ -5,6 +5,7 @@ import com.stumeet.server.common.auth.model.LoginMember;
 import com.stumeet.server.common.model.ApiResponse;
 import com.stumeet.server.common.response.SuccessCode;
 import com.stumeet.server.studymember.application.port.in.response.StudyMemberDetailResponse;
+import com.stumeet.server.studymember.application.port.in.response.StudyMemberGrapeResponse;
 import com.stumeet.server.studymember.application.port.in.response.StudyMemberResponses;
 import com.stumeet.server.studymember.application.port.in.StudyMemberQueryUseCase;
 import lombok.RequiredArgsConstructor;
@@ -42,6 +43,18 @@ public class StudyMemberQueryApi {
             @PathVariable Long memberId
     ) {
         StudyMemberDetailResponse response = studyMemberQueryUseCase.getStudyMemberDetail(studyId, memberId, member.getId());
+
+        return ResponseEntity.ok(
+                ApiResponse.success(SuccessCode.GET_SUCCESS, response)
+        );
+    }
+
+    @GetMapping("/studies/{studyId}/me/grapes/available")
+    public ResponseEntity<ApiResponse<StudyMemberGrapeResponse>> canMemberSendGrape(
+            @AuthenticationPrincipal LoginMember member,
+            @PathVariable Long studyId
+    ) {
+        StudyMemberGrapeResponse response = studyMemberQueryUseCase.canStudyMemberSendGrape(studyId, member.getId());
 
         return ResponseEntity.ok(
                 ApiResponse.success(SuccessCode.GET_SUCCESS, response)

--- a/src/main/java/com/stumeet/server/studymember/adapter/in/web/StudyMemberQueryApi.java
+++ b/src/main/java/com/stumeet/server/studymember/adapter/in/web/StudyMemberQueryApi.java
@@ -4,6 +4,7 @@ import com.stumeet.server.common.annotation.WebAdapter;
 import com.stumeet.server.common.auth.model.LoginMember;
 import com.stumeet.server.common.model.ApiResponse;
 import com.stumeet.server.common.response.SuccessCode;
+import com.stumeet.server.studymember.application.port.in.response.StudyMemberAdminResponse;
 import com.stumeet.server.studymember.application.port.in.response.StudyMemberDetailResponse;
 import com.stumeet.server.studymember.application.port.in.response.StudyMemberGrapeResponse;
 import com.stumeet.server.studymember.application.port.in.response.StudyMemberResponses;
@@ -43,6 +44,18 @@ public class StudyMemberQueryApi {
             @PathVariable Long memberId
     ) {
         StudyMemberDetailResponse response = studyMemberQueryUseCase.getStudyMemberDetail(studyId, memberId, member.getId());
+
+        return ResponseEntity.ok(
+                ApiResponse.success(SuccessCode.GET_SUCCESS, response)
+        );
+    }
+
+    @GetMapping("/studies/{studyId}/me/admin/check")
+    public ResponseEntity<ApiResponse<StudyMemberAdminResponse>> isMemberAdmin(
+            @AuthenticationPrincipal LoginMember member,
+            @PathVariable Long studyId
+    ) {
+        StudyMemberAdminResponse response = studyMemberQueryUseCase.isMemberAdmin(studyId, member.getId());
 
         return ResponseEntity.ok(
                 ApiResponse.success(SuccessCode.GET_SUCCESS, response)

--- a/src/main/java/com/stumeet/server/studymember/application/port/in/StudyMemberQueryUseCase.java
+++ b/src/main/java/com/stumeet/server/studymember/application/port/in/StudyMemberQueryUseCase.java
@@ -1,5 +1,6 @@
 package com.stumeet.server.studymember.application.port.in;
 
+import com.stumeet.server.studymember.application.port.in.response.StudyMemberAdminResponse;
 import com.stumeet.server.studymember.application.port.in.response.StudyMemberDetailResponse;
 import com.stumeet.server.studymember.application.port.in.response.StudyMemberGrapeResponse;
 import com.stumeet.server.studymember.application.port.in.response.StudyMemberResponses;
@@ -8,6 +9,8 @@ public interface StudyMemberQueryUseCase {
     StudyMemberResponses getStudyMembers(Long studyId, Long requesterId);
 
     StudyMemberDetailResponse getStudyMemberDetail(Long studyId, Long targetMemberId, Long requesterId);
+
+    StudyMemberAdminResponse isMemberAdmin(Long studyId, Long memberId);
 
     StudyMemberGrapeResponse canStudyMemberSendGrape(Long studyId, Long memberId);
 }

--- a/src/main/java/com/stumeet/server/studymember/application/port/in/StudyMemberQueryUseCase.java
+++ b/src/main/java/com/stumeet/server/studymember/application/port/in/StudyMemberQueryUseCase.java
@@ -1,10 +1,13 @@
 package com.stumeet.server.studymember.application.port.in;
 
 import com.stumeet.server.studymember.application.port.in.response.StudyMemberDetailResponse;
+import com.stumeet.server.studymember.application.port.in.response.StudyMemberGrapeResponse;
 import com.stumeet.server.studymember.application.port.in.response.StudyMemberResponses;
 
 public interface StudyMemberQueryUseCase {
     StudyMemberResponses getStudyMembers(Long studyId, Long requesterId);
 
     StudyMemberDetailResponse getStudyMemberDetail(Long studyId, Long targetMemberId, Long requesterId);
+
+    StudyMemberGrapeResponse canStudyMemberSendGrape(Long studyId, Long memberId);
 }

--- a/src/main/java/com/stumeet/server/studymember/application/port/in/response/StudyMemberAdminResponse.java
+++ b/src/main/java/com/stumeet/server/studymember/application/port/in/response/StudyMemberAdminResponse.java
@@ -1,0 +1,6 @@
+package com.stumeet.server.studymember.application.port.in.response;
+
+public record StudyMemberAdminResponse(
+        Boolean isAdmin
+) {
+}

--- a/src/main/java/com/stumeet/server/studymember/application/port/in/response/StudyMemberDetailResponse.java
+++ b/src/main/java/com/stumeet/server/studymember/application/port/in/response/StudyMemberDetailResponse.java
@@ -6,7 +6,6 @@ public record StudyMemberDetailResponse(
         String image,
         String region,
         String profession,
-        boolean canSendGrape,
         Integer achievement
 ) {
 }

--- a/src/main/java/com/stumeet/server/studymember/application/port/in/response/StudyMemberGrapeResponse.java
+++ b/src/main/java/com/stumeet/server/studymember/application/port/in/response/StudyMemberGrapeResponse.java
@@ -1,0 +1,6 @@
+package com.stumeet.server.studymember.application.port.in.response;
+
+public record StudyMemberGrapeResponse(
+        Boolean canSendGrape
+) {
+}

--- a/src/main/java/com/stumeet/server/studymember/application/service/StudyMemberQueryService.java
+++ b/src/main/java/com/stumeet/server/studymember/application/service/StudyMemberQueryService.java
@@ -4,11 +4,14 @@ import com.stumeet.server.activity.application.port.in.EvaluateMemberAchievement
 import com.stumeet.server.common.annotation.UseCase;
 import com.stumeet.server.study.application.port.in.StudyValidationUseCase;
 import com.stumeet.server.studymember.application.port.in.response.SimpleStudyMemberResponse;
+import com.stumeet.server.studymember.application.port.in.response.StudyMemberAdminResponse;
 import com.stumeet.server.studymember.application.port.in.response.StudyMemberDetailResponse;
+import com.stumeet.server.studymember.application.port.in.response.StudyMemberGrapeResponse;
 import com.stumeet.server.studymember.application.port.in.response.StudyMemberResponses;
 import com.stumeet.server.studymember.application.port.in.StudyMemberQueryUseCase;
 import com.stumeet.server.studymember.application.port.in.StudyMemberValidationUseCase;
 import com.stumeet.server.studymember.application.port.out.StudyMemberQueryPort;
+import com.stumeet.server.studymember.application.port.out.StudyMemberValidationPort;
 import com.stumeet.server.studymember.domain.StudyMember;
 
 import lombok.RequiredArgsConstructor;
@@ -27,6 +30,7 @@ public class StudyMemberQueryService implements StudyMemberQueryUseCase {
     private final EvaluateMemberAchievementUseCase evaluateMemberAchievementUseCase;
 
     private final StudyMemberQueryPort studyMemberQueryPort;
+    private final StudyMemberValidationPort studyMemberValidationPort;
 
     @Override
     public StudyMemberResponses getStudyMembers(Long studyId, Long requesterId) {
@@ -43,7 +47,6 @@ public class StudyMemberQueryService implements StudyMemberQueryUseCase {
         studyMemberValidationUseCase.checkStudyJoinMember(studyId, requesterId);
 
         StudyMember studyMember = studyMemberQueryPort.findStudyMember(studyId, targetMemberId);
-        boolean canSendGrape = studyMemberQueryPort.isSentGrape(studyId, requesterId);
         int achievement = evaluateMemberAchievementUseCase.getMemberAchievement(studyId, targetMemberId);
 
         return new StudyMemberDetailResponse(
@@ -52,8 +55,14 @@ public class StudyMemberQueryService implements StudyMemberQueryUseCase {
                 studyMember.getMember().getImage(),
                 studyMember.getMember().getRegion(),
                 studyMember.getMember().getProfession().getName(),
-                canSendGrape,
                 achievement
+        );
+    }
+
+    @Override
+    public StudyMemberGrapeResponse canStudyMemberSendGrape(Long studyId, Long memberId) {
+        return new StudyMemberGrapeResponse(
+                !studyMemberQueryPort.isSentGrape(studyId, memberId)
         );
     }
 }

--- a/src/main/java/com/stumeet/server/studymember/application/service/StudyMemberQueryService.java
+++ b/src/main/java/com/stumeet/server/studymember/application/service/StudyMemberQueryService.java
@@ -60,6 +60,13 @@ public class StudyMemberQueryService implements StudyMemberQueryUseCase {
     }
 
     @Override
+    public StudyMemberAdminResponse isMemberAdmin(Long studyId, Long memberId) {
+        return new StudyMemberAdminResponse(
+                studyMemberValidationPort.isAdmin(studyId, memberId)
+        );
+    }
+
+    @Override
     public StudyMemberGrapeResponse canStudyMemberSendGrape(Long studyId, Long memberId) {
         return new StudyMemberGrapeResponse(
                 !studyMemberQueryPort.isSentGrape(studyId, memberId)

--- a/src/main/java/com/stumeet/server/studymember/application/service/StudyMemberQueryService.java
+++ b/src/main/java/com/stumeet/server/studymember/application/service/StudyMemberQueryService.java
@@ -61,6 +61,8 @@ public class StudyMemberQueryService implements StudyMemberQueryUseCase {
 
     @Override
     public StudyMemberAdminResponse isMemberAdmin(Long studyId, Long memberId) {
+        studyValidationUseCase.checkById(studyId);
+
         return new StudyMemberAdminResponse(
                 studyMemberValidationPort.isAdmin(studyId, memberId)
         );
@@ -68,6 +70,8 @@ public class StudyMemberQueryService implements StudyMemberQueryUseCase {
 
     @Override
     public StudyMemberGrapeResponse canStudyMemberSendGrape(Long studyId, Long memberId) {
+        studyValidationUseCase.checkById(studyId);
+
         return new StudyMemberGrapeResponse(
                 !studyMemberQueryPort.isSentGrape(studyId, memberId)
         );

--- a/src/test/java/com/stumeet/server/activity/adapter/in/ActivityCreateApiTest.java
+++ b/src/test/java/com/stumeet/server/activity/adapter/in/ActivityCreateApiTest.java
@@ -85,6 +85,7 @@ class ActivityCreateApiTest extends ApiTest {
                                     fieldWithPath("data.startDate").description("활동 시작일"),
                                     fieldWithPath("data.endDate").description("활동 종료일"),
                                     fieldWithPath("data.location").description("장소"),
+                                    fieldWithPath("data.link").description("링크"),
                                     fieldWithPath("data.createdAt").description("활동 생성일"),
                                     fieldWithPath("data.isAuthor").description("작성자 여부"),
                                     fieldWithPath("data.isAdmin").description("관리자 여부")

--- a/src/test/java/com/stumeet/server/activity/adapter/in/ActivityQueryApiTest.java
+++ b/src/test/java/com/stumeet/server/activity/adapter/in/ActivityQueryApiTest.java
@@ -76,6 +76,7 @@ class ActivityQueryApiTest extends ApiTest {
                                     fieldWithPath("data.startDate").description("활동 시작일"),
                                     fieldWithPath("data.endDate").description("활동 종료일"),
                                     fieldWithPath("data.location").description("장소"),
+                                    fieldWithPath("data.link").description("링크"),
                                     fieldWithPath("data.createdAt").description("활동 생성일"),
                                     fieldWithPath("data.isAuthor").description("작성자 여부"),
                                     fieldWithPath("data.isAdmin").description("관리자 여부")

--- a/src/test/java/com/stumeet/server/activity/adapter/in/ActivityQueryApiTest.java
+++ b/src/test/java/com/stumeet/server/activity/adapter/in/ActivityQueryApiTest.java
@@ -6,6 +6,7 @@ import com.stumeet.server.common.response.ErrorCode;
 import com.stumeet.server.common.response.SuccessCode;
 import com.stumeet.server.helper.WithMockMember;
 import com.stumeet.server.stub.ActivityStub;
+import com.stumeet.server.stub.MemberStub;
 import com.stumeet.server.stub.StudyStub;
 import com.stumeet.server.stub.TokenStub;
 import com.stumeet.server.template.ApiTest;
@@ -84,7 +85,7 @@ class ActivityQueryApiTest extends ApiTest {
 
         @Test
         @WithMockMember
-        @DisplayName("[실패] 스터디가 존재하지 않는 경우 예외가 발생한다.")
+        @DisplayName("[실패] 스터디가 존재하지 않는 경우 조회에 실패한다.")
         void studyNotFoundTest() throws Exception {
             Long studyId = StudyStub.getInvalidStudyId();
             Long activityId = ActivityStub.getActivityId();
@@ -113,7 +114,7 @@ class ActivityQueryApiTest extends ApiTest {
 
         @Test
         @WithMockMember(id = 3L)
-        @DisplayName("[실패] 스터디에 가입하지 않은 사용자인 경우 예외가 발생한다.")
+        @DisplayName("[실패] 스터디에 가입하지 않은 사용자인 경우 조회에 실패한다.")
         void notJoinedStudyTest() throws Exception {
             Long studyId = StudyStub.getStudyId();
             Long activityId = ActivityStub.getActivityId();
@@ -142,7 +143,7 @@ class ActivityQueryApiTest extends ApiTest {
 
         @Test
         @WithMockMember
-        @DisplayName("[실패] 활동이 존재하지 않는 경우 예외가 발생한다.")
+        @DisplayName("[실패] 활동이 존재하지 않는 경우 조회에 실패한다.")
         void notFoundActivityTest() throws Exception {
             Long studyId = StudyStub.getStudyId();
             Long activityId = ActivityStub.getInvalidActivityId();
@@ -227,7 +228,7 @@ class ActivityQueryApiTest extends ApiTest {
 
         @Test
         @WithMockMember
-        @DisplayName("[실패] 존재하지 않는 스터디 id로 요청하는 경우 활동 상세 조회에 실패한다.")
+        @DisplayName("[실패] 존재하지 않는 스터디 id로 요청하는 경우 조회에 실패한다.")
         void fail_when_study_id_not_found() throws Exception {
             mockMvc.perform(get(PATH)
                             .param("size", "2")
@@ -258,7 +259,7 @@ class ActivityQueryApiTest extends ApiTest {
 
         @Test
         @WithMockMember
-        @DisplayName("[실패] 유효하지 않은 활동 유형으로 요청하는 경우 활동 상세 조회에 실패한다.")
+        @DisplayName("[실패] 유효하지 않은 활동 유형으로 요청하는 경우 조회에 실패한다.")
         void fail_when_activity_category_not_found() throws Exception {
             mockMvc.perform(get(PATH)
                             .param("size", "2")
@@ -303,6 +304,7 @@ class ActivityQueryApiTest extends ApiTest {
                             .param("isNotice", "true")
                             .param("category", ActivityCategory.MEET.name())
                             .param("studyId", StudyStub.getStudyId().toString())
+                            .param("memberId", MemberStub.getMemberId().toString())
                             .param("fromDate", "2024-04-01T00:00:00")
                             .param("toDate", "2024-04-30T00:00:00")
                             .header(AuthenticationHeader.ACCESS_TOKEN.getName(), TokenStub.getMockAccessToken()))
@@ -319,6 +321,7 @@ class ActivityQueryApiTest extends ApiTest {
                                     parameterWithName("page").description("조회할 페이지 번호").optional(),
                                     parameterWithName("isNotice").description("공지사항 여부 (true/false)").optional(),
                                     parameterWithName("studyId").description("특정 스터디 ID").optional(),
+                                    parameterWithName("memberId").description("멤버 ID (생략 시 로그인 멤버 id로 조회)").optional(),
                                     parameterWithName("category").description("활동 유형 (DEFAULT/MEET/ASSIGNMENT)").optional(),
                                     parameterWithName("fromDate").description("YYYY-MM-DDThh:mm:ss").optional(),
                                     parameterWithName("toDate").description("YYYY-MM-DDThh:mm:ss").optional()
@@ -346,7 +349,7 @@ class ActivityQueryApiTest extends ApiTest {
 
         @Test
         @WithMockMember
-        @DisplayName("[실패] 불완전한 페이지네이션 요청변수로 요청하는 경우 활동 상세 조회에 실패한다.")
+        @DisplayName("[실패] 불완전한 페이지네이션 요청변수로 요청하는 경우 조회에 실패한다.")
         void fail_when_pagination_parameters_is_incomplete() throws Exception {
             mockMvc.perform(get(PATH)
                             .param("size", "5")
@@ -364,6 +367,7 @@ class ActivityQueryApiTest extends ApiTest {
                                     parameterWithName("page").description("조회할 페이지 번호").optional(),
                                     parameterWithName("isNotice").description("공지사항 여부 (true/false)").optional(),
                                     parameterWithName("studyId").description("특정 스터디 ID").optional(),
+                                    parameterWithName("memberId").description("멤버 ID (생략 시 로그인 멤버 id로 조회)").optional(),
                                     parameterWithName("category").description("활동 유형 (DEFAULT/MEET/ASSIGNMENT)").optional(),
                                     parameterWithName("fromDate").description("YYYY-MM-DDThh:mm:ss").optional(),
                                     parameterWithName("toDate").description("YYYY-MM-DDThh:mm:ss").optional()
@@ -377,7 +381,7 @@ class ActivityQueryApiTest extends ApiTest {
 
         @Test
         @WithMockMember
-        @DisplayName("[실패] 0보다 작은 페이지네이션 요청변수로 요청하는 경우 활동 상세 조회에 실패한다.")
+        @DisplayName("[실패] 0보다 작은 페이지네이션 요청변수로 요청하는 경우 조회에 실패한다.")
         void fail_when_pagination_parameters_is_smaller_than_zero() throws Exception {
             mockMvc.perform(get(PATH)
                             .param("size", "-1")
@@ -396,6 +400,7 @@ class ActivityQueryApiTest extends ApiTest {
                                     parameterWithName("page").description("조회할 페이지 번호").optional(),
                                     parameterWithName("isNotice").description("공지사항 여부 (true/false)").optional(),
                                     parameterWithName("studyId").description("특정 스터디 ID").optional(),
+                                    parameterWithName("memberId").description("멤버 ID (생략 시 로그인 멤버 id로 조회)").optional(),
                                     parameterWithName("category").description("활동 유형 (DEFAULT/MEET/ASSIGNMENT)").optional(),
                                     parameterWithName("fromDate").description("YYYY-MM-DDThh:mm:ss").optional(),
                                     parameterWithName("toDate").description("YYYY-MM-DDThh:mm:ss").optional()
@@ -409,7 +414,7 @@ class ActivityQueryApiTest extends ApiTest {
 
         @Test
         @WithMockMember
-        @DisplayName("[실패] 존재하지 않는 스터디 id로 요청하는 경우 활동 상세 조회에 실패한다.")
+        @DisplayName("[실패] 존재하지 않는 스터디 id로 요청하는 경우 조회에 실패한다.")
         void fail_when_study_id_not_found() throws Exception {
             mockMvc.perform(get(PATH)
                             .param("studyId", StudyStub.getInvalidStudyId().toString())
@@ -427,6 +432,7 @@ class ActivityQueryApiTest extends ApiTest {
                                     parameterWithName("page").description("조회할 페이지 번호").optional(),
                                     parameterWithName("isNotice").description("공지사항 여부 (true/false)").optional(),
                                     parameterWithName("studyId").description("특정 스터디 ID").optional(),
+                                    parameterWithName("memberId").description("멤버 ID (생략 시 로그인 멤버 id로 조회)").optional(),
                                     parameterWithName("category").description("활동 유형 (DEFAULT/MEET/ASSIGNMENT)").optional(),
                                     parameterWithName("fromDate").description("YYYY-MM-DDThh:mm:ss").optional(),
                                     parameterWithName("toDate").description("YYYY-MM-DDThh:mm:ss").optional()
@@ -440,7 +446,7 @@ class ActivityQueryApiTest extends ApiTest {
 
         @Test
         @WithMockMember
-        @DisplayName("[실패] 유효하지 않은 활동 유형으로 요청하는 경우 활동 상세 조회에 실패한다.")
+        @DisplayName("[실패] 유효하지 않은 활동 유형으로 요청하는 경우 조회에 실패한다.")
         void fail_when_activity_category_not_found() throws Exception {
             mockMvc.perform(get(PATH)
                             .param("category", ActivityStub.getInvalidActivityCategoryName())
@@ -458,6 +464,7 @@ class ActivityQueryApiTest extends ApiTest {
                                     parameterWithName("page").description("조회할 페이지 번호").optional(),
                                     parameterWithName("isNotice").description("공지사항 여부 (true/false)").optional(),
                                     parameterWithName("studyId").description("특정 스터디 ID").optional(),
+                                    parameterWithName("memberId").description("멤버 ID (생략 시 로그인 멤버 id로 조회)").optional(),
                                     parameterWithName("category").description("활동 유형 (DEFAULT/MEET/ASSIGNMENT)").optional(),
                                     parameterWithName("fromDate").description("YYYY-MM-DDThh:mm:ss").optional(),
                                     parameterWithName("toDate").description("YYYY-MM-DDThh:mm:ss").optional()
@@ -471,7 +478,7 @@ class ActivityQueryApiTest extends ApiTest {
 
         @Test
         @WithMockMember
-        @DisplayName("[실패] 시작기준일이 종료기준일보다 이후인 경우 활동 상세 조회에 실패한다.")
+        @DisplayName("[실패] 시작기준일이 종료기준일보다 이후인 경우 조회에 실패한다.")
         void fail_when_fromDate_is_after_toDate() throws Exception {
             mockMvc.perform(get(PATH)
                             .param("fromDate", "2024-06-01T00:00:00")
@@ -490,6 +497,7 @@ class ActivityQueryApiTest extends ApiTest {
                                     parameterWithName("page").description("조회할 페이지 번호").optional(),
                                     parameterWithName("isNotice").description("공지사항 여부 (true/false)").optional(),
                                     parameterWithName("studyId").description("특정 스터디 ID").optional(),
+                                    parameterWithName("memberId").description("멤버 ID (생략 시 로그인 멤버 id로 조회)").optional(),
                                     parameterWithName("category").description("활동 유형 (DEFAULT/MEET/ASSIGNMENT)").optional(),
                                     parameterWithName("fromDate").description("YYYY-MM-DDThh:mm:ss").optional(),
                                     parameterWithName("toDate").description("YYYY-MM-DDThh:mm:ss").optional()

--- a/src/test/java/com/stumeet/server/bff/adapter/in/app/StudyHubApiTest.java
+++ b/src/test/java/com/stumeet/server/bff/adapter/in/app/StudyHubApiTest.java
@@ -1,0 +1,115 @@
+package com.stumeet.server.bff.adapter.in.app;
+
+import static org.springframework.restdocs.headers.HeaderDocumentation.*;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import com.stumeet.server.common.auth.model.AuthenticationHeader;
+import com.stumeet.server.helper.WithMockMember;
+import com.stumeet.server.stub.MemberStub;
+import com.stumeet.server.stub.StudyStub;
+import com.stumeet.server.stub.TokenStub;
+import com.stumeet.server.template.ApiTest;
+
+class StudyHubApiTest extends ApiTest {
+    
+    @Nested
+    @DisplayName("스터디 홈 화면 조회")
+    class StudyMemberDetailFull {
+        private static final String PATH = "/api/external/v1/studies/{studyId}";
+
+        @Test
+        @WithMockMember
+        @DisplayName("[성공] 스터디 홈 화면 조회에 성공한다.")
+        void success() throws Exception {
+            Long studyId = StudyStub.getStudyId();
+
+            mockMvc.perform(get(PATH, studyId)
+                            .header(AuthenticationHeader.ACCESS_TOKEN.getName(), TokenStub.getKakaoAccessToken()))
+                    .andExpect(status().isOk())
+                    .andDo(document("get-study-home-full/success",
+                            preprocessRequest(prettyPrint()),
+                            preprocessResponse(prettyPrint()),
+                            requestHeaders(
+                                    headerWithName(AuthenticationHeader.ACCESS_TOKEN.getName()).description("서버로부터 전달받은 액세스 토큰")
+                            ),
+                            pathParameters(
+                                    parameterWithName("studyId").description("스터디 ID")
+                            ),
+                            responseFields(
+                                    fieldWithPath("code").description("응답 코드"),
+                                    fieldWithPath("message").description("응답 메시지"),
+                                    fieldWithPath("data").description("스터디 홈 정보"),
+                                    fieldWithPath("data.studyDetail").description("스터디 상세 정보"),
+                                    fieldWithPath("data.studyDetail.id").description("스터디 ID"),
+                                    fieldWithPath("data.studyDetail.field").description("분야"),
+                                    fieldWithPath("data.studyDetail.name").description("스터디 이름"),
+                                    fieldWithPath("data.studyDetail.tags").description("태그 리스트"),
+                                    fieldWithPath("data.studyDetail.intro").description("소개"),
+                                    fieldWithPath("data.studyDetail.region").description("지역"),
+                                    fieldWithPath("data.studyDetail.rule").description("규칙"),
+                                    fieldWithPath("data.studyDetail.image").description("이미지 URL"),
+                                    fieldWithPath("data.studyDetail.headcount").description("참여 인원 수"),
+                                    fieldWithPath("data.studyDetail.startDate").description("시작 날짜"),
+                                    fieldWithPath("data.studyDetail.endDate").description("종료 날짜"),
+                                    fieldWithPath("data.studyDetail.meetingTime").description("정기모임 시간"),
+                                    fieldWithPath("data.studyDetail.meetingRepetitionType")
+                                            .description("정기모임 반복 유형 / `매일`, `매주`, `매달`"),
+                                    fieldWithPath("data.studyDetail.meetingRepetitionDates")
+                                            .description("정기모임 반복일 / 매주: 요일, 매달: 날짜"),
+                                    fieldWithPath("data.studyDetail.isFinished").description("종료 여부"),
+                                    fieldWithPath("data.studyDetail.isDeleted").description("삭제 여부"),
+                                    fieldWithPath("data.activityNotice").description("최근 공지 활동"),
+                                    fieldWithPath("data.activityNotice.id").description("활동 ID"),
+                                    fieldWithPath("data.activityNotice.category").description("활동 유형"),
+                                    fieldWithPath("data.activityNotice.title").description("활동 제목"),
+                                    fieldWithPath("data.activityNotice.content").description("활동 내용"),
+                                    fieldWithPath("data.activityNotice.startDate").description("활동 시작일"),
+                                    fieldWithPath("data.activityNotice.endDate").description("활동 종료일"),
+                                    fieldWithPath("data.activityNotice.location").description("장소"),
+                                    fieldWithPath("data.activityNotice.author.memberId").description("활동 작성자 ID"),
+                                    fieldWithPath("data.activityNotice.author.name").description("활동 작성자 이름"),
+                                    fieldWithPath("data.activityNotice.author.profileImageUrl").description("활동 작성자 프로필 이미지 URL"),
+                                    fieldWithPath("data.activityNotice.createdAt").description("활동 생성일"),
+                                    fieldWithPath("data.isAdmin").description("로그인 멤버 관리자 여부"),
+                                    fieldWithPath("data.canSendGrape").description("로그인 멤버 포도알 전송 가능 여부")
+                            ))
+                    );
+        }
+
+        @Test
+        @WithMockMember
+        @DisplayName("[실패] 스터디가 존재하지 않으면 예외가 발생한다.")
+        void fail_when_study_not_found() throws Exception {
+            Long notExistStudyId = StudyStub.getInvalidStudyId();
+            Long memberId = MemberStub.getMemberId();
+
+            mockMvc.perform(get(PATH, notExistStudyId, memberId)
+                            .header(AuthenticationHeader.ACCESS_TOKEN.getName(), TokenStub.getKakaoAccessToken()))
+                    .andExpect(status().isNotFound())
+                    .andDo(document("get-study-home-full/fail/study-not-found",
+                            preprocessRequest(prettyPrint()),
+                            preprocessResponse(prettyPrint()),
+                            requestHeaders(
+                                    headerWithName(AuthenticationHeader.ACCESS_TOKEN.getName()).description(
+                                            "서버로부터 전달받은 액세스 토큰")
+                            ),
+                            pathParameters(
+                                    parameterWithName("studyId").description("스터디 ID")
+                            ),
+                            responseFields(
+                                    fieldWithPath("code").description("응답 코드"),
+                                    fieldWithPath("message").description("응답 메시지")
+                            ))
+                    );
+        }
+    }
+}

--- a/src/test/java/com/stumeet/server/bff/adapter/in/app/StudyMemberHubApiTest.java
+++ b/src/test/java/com/stumeet/server/bff/adapter/in/app/StudyMemberHubApiTest.java
@@ -1,0 +1,121 @@
+package com.stumeet.server.bff.adapter.in.app;
+
+import static org.springframework.restdocs.headers.HeaderDocumentation.*;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import com.stumeet.server.common.auth.model.AuthenticationHeader;
+import com.stumeet.server.helper.WithMockMember;
+import com.stumeet.server.stub.MemberStub;
+import com.stumeet.server.stub.StudyStub;
+import com.stumeet.server.stub.TokenStub;
+import com.stumeet.server.template.ApiTest;
+
+class StudyMemberHubApiTest extends ApiTest {
+
+    @Nested
+    @DisplayName("스터디 멤버 상세 화면 조회")
+    class StudyMemberDetailFull {
+        private static final String PATH = "/api/external/v1/studies/{studyId}/members/{memberId}";
+
+        @Test
+        @WithMockMember
+        @DisplayName("[성공] 스터디 멤버 상세 화면 조회에 성공한다.")
+        void success() throws Exception {
+            Long studyId = StudyStub.getStudyId();
+            Long memberId = MemberStub.getMemberId();
+
+            mockMvc.perform(get(PATH, studyId, memberId)
+                            .header(AuthenticationHeader.ACCESS_TOKEN.getName(), TokenStub.getKakaoAccessToken()))
+                    .andExpect(status().isOk())
+                    .andDo(document("get-study-member-detail-full/success",
+                            preprocessRequest(prettyPrint()),
+                            preprocessResponse(prettyPrint()),
+                            requestHeaders(
+                                    headerWithName(AuthenticationHeader.ACCESS_TOKEN.getName()).description("서버로부터 전달받은 액세스 토큰")
+                            ),
+                            pathParameters(
+                                    parameterWithName("studyId").description("스터디 ID"),
+                                    parameterWithName("memberId").description("조회할 멤버 ID")
+                            ),
+                            responseFields(
+                                    fieldWithPath("code").description("응답 코드"),
+                                    fieldWithPath("message").description("응답 메시지"),
+                                    fieldWithPath("data").description("스터디 멤버 상세 정보"),
+                                    fieldWithPath("data.studyMemberDetailResponse.id").description("멤버 ID"),
+                                    fieldWithPath("data.studyMemberDetailResponse.name").description("스터디 멤버 이름"),
+                                    fieldWithPath("data.studyMemberDetailResponse.image").description("스터디 멤버 프로필 이미지"),
+                                    fieldWithPath("data.studyMemberDetailResponse.region").description("스터디 멤버 지역"),
+                                    fieldWithPath("data.studyMemberDetailResponse.profession").description("스터디 멤버 분야"),
+                                    fieldWithPath("data.studyMemberDetailResponse.achievement").description("성취도"),
+                                    fieldWithPath("data.isAdmin").description("로그인 멤버 관리자 여부"),
+                                    fieldWithPath("data.canSendGrape").description("로그인 멤버 포도알 전송 가능 여부")
+                            ))
+                    );
+        }
+
+        @Test
+        @WithMockMember
+        @DisplayName("[실패] 스터디가 존재하지 않으면 예외가 발생한다.")
+        void fail_when_study_not_found() throws Exception {
+            Long notExistStudyId = StudyStub.getInvalidStudyId();
+            Long memberId = MemberStub.getMemberId();
+
+            mockMvc.perform(get(PATH, notExistStudyId, memberId)
+                            .header(AuthenticationHeader.ACCESS_TOKEN.getName(), TokenStub.getKakaoAccessToken()))
+                    .andExpect(status().isNotFound())
+                    .andDo(document("get-study-member-detail-full/fail/study-not-found",
+                            preprocessRequest(prettyPrint()),
+                            preprocessResponse(prettyPrint()),
+                            requestHeaders(
+                                    headerWithName(AuthenticationHeader.ACCESS_TOKEN.getName()).description(
+                                            "서버로부터 전달받은 액세스 토큰")
+                            ),
+                            pathParameters(
+                                    parameterWithName("studyId").description("스터디 ID"),
+                                    parameterWithName("memberId").description("조회할 멤버 ID")
+                            ),
+                            responseFields(
+                                    fieldWithPath("code").description("응답 코드"),
+                                    fieldWithPath("message").description("응답 메시지")
+                            ))
+                    );
+        }
+
+        @Test
+        @WithMockMember(id = 0L)
+        @DisplayName("[실패] 해당 스터디에 가입한 멤버가 요청한 것이 아니라면 예외가 발생한다.")
+        void fail_when_is_not_study_member() throws Exception {
+            Long studyId = StudyStub.getStudyId();
+            Long memberId = MemberStub.getMemberId();
+
+            mockMvc.perform(get(PATH, studyId, memberId)
+                            .header(AuthenticationHeader.ACCESS_TOKEN.getName(), TokenStub.getKakaoAccessToken()))
+                    .andExpect(status().isForbidden())
+                    .andDo(document("get-study-member-detail-full/fail/is-not-study-member",
+                            preprocessRequest(prettyPrint()),
+                            preprocessResponse(prettyPrint()),
+                            requestHeaders(
+                                    headerWithName(AuthenticationHeader.ACCESS_TOKEN.getName()).description(
+                                            "서버로부터 전달받은 액세스 토큰")
+                            ),
+                            pathParameters(
+                                    parameterWithName("studyId").description("스터디 ID"),
+                                    parameterWithName("memberId").description("조회할 멤버 ID")
+                            ),
+                            responseFields(
+                                    fieldWithPath("code").description("응답 코드"),
+                                    fieldWithPath("message").description("응답 메시지")
+                            ))
+                    );
+        }
+    }
+}

--- a/src/test/java/com/stumeet/server/studymember/adapter/in/web/StudyMemberQueryApiTest.java
+++ b/src/test/java/com/stumeet/server/studymember/adapter/in/web/StudyMemberQueryApiTest.java
@@ -257,7 +257,7 @@ class StudyMemberQueryApiTest extends ApiTest {
             mockMvc.perform(get(PATH, studyId)
                             .header(AuthenticationHeader.ACCESS_TOKEN.getName(), TokenStub.getKakaoAccessToken()))
                     .andExpect(status().isNotFound())
-                    .andDo(document("get-study-member-is-admin/success",
+                    .andDo(document("get-study-member-is-admin/fail/study-not-found",
                             preprocessRequest(prettyPrint()),
                             preprocessResponse(prettyPrint()),
                             requestHeaders(
@@ -317,7 +317,7 @@ class StudyMemberQueryApiTest extends ApiTest {
             mockMvc.perform(get(PATH, studyId)
                             .header(AuthenticationHeader.ACCESS_TOKEN.getName(), TokenStub.getKakaoAccessToken()))
                     .andExpect(status().isNotFound())
-                    .andDo(document("get-study-member-can-send-grape/success",
+                    .andDo(document("get-study-member-can-send-grape/fail/study-not-found",
                             preprocessRequest(prettyPrint()),
                             preprocessResponse(prettyPrint()),
                             requestHeaders(

--- a/src/test/java/com/stumeet/server/studymember/adapter/in/web/StudyMemberQueryApiTest.java
+++ b/src/test/java/com/stumeet/server/studymember/adapter/in/web/StudyMemberQueryApiTest.java
@@ -274,4 +274,64 @@ class StudyMemberQueryApiTest extends ApiTest {
                     );
         }
     }
+
+    @Nested
+    @DisplayName("스터디 멤버 포도알 전송 가능 여부 조회")
+    class CanMemberSendGrape {
+        private static final String PATH = "/api/v1/studies/{studyId}/me/grapes/available";
+
+        @Test
+        @WithMockMember
+        @DisplayName("[성공] 스터디 멤버의 포도알 전송 가능 여부 조회에 성공한다.")
+        void success() throws Exception {
+            Long studyId = StudyStub.getStudyId();
+
+            mockMvc.perform(get(PATH, studyId)
+                            .header(AuthenticationHeader.ACCESS_TOKEN.getName(), TokenStub.getKakaoAccessToken()))
+                    .andExpect(status().isOk())
+                    .andDo(document("get-study-member-can-send-grape/success",
+                            preprocessRequest(prettyPrint()),
+                            preprocessResponse(prettyPrint()),
+                            requestHeaders(
+                                    headerWithName(AuthenticationHeader.ACCESS_TOKEN.getName()).description(
+                                            "서버로부터 전달받은 액세스 토큰")
+                            ),
+                            pathParameters(
+                                    parameterWithName("studyId").description("스터디 ID")
+                            ),
+                            responseFields(
+                                    fieldWithPath("code").description("응답 코드"),
+                                    fieldWithPath("message").description("응답 메시지"),
+                                    fieldWithPath("data").description("스터디 멤버 포도알 전송 가능 여부"),
+                                    fieldWithPath("data.canSendGrape").description("포도알 전송 가능 여부")
+                            ))
+                    );
+        }
+
+        @Test
+        @WithMockMember
+        @DisplayName("[실패] 스터디가 존재하지 않을 경우 스터디 멤버의 포도알 전송 가능 여부 조회에 실패한다.")
+        void fail_when_study_not_exist() throws Exception {
+            Long studyId = StudyStub.getInvalidStudyId();
+
+            mockMvc.perform(get(PATH, studyId)
+                            .header(AuthenticationHeader.ACCESS_TOKEN.getName(), TokenStub.getKakaoAccessToken()))
+                    .andExpect(status().isNotFound())
+                    .andDo(document("get-study-member-can-send-grape/success",
+                            preprocessRequest(prettyPrint()),
+                            preprocessResponse(prettyPrint()),
+                            requestHeaders(
+                                    headerWithName(AuthenticationHeader.ACCESS_TOKEN.getName()).description(
+                                            "서버로부터 전달받은 액세스 토큰")
+                            ),
+                            pathParameters(
+                                    parameterWithName("studyId").description("스터디 ID")
+                            ),
+                            responseFields(
+                                    fieldWithPath("code").description("응답 코드"),
+                                    fieldWithPath("message").description("응답 메시지")
+                            ))
+                    );
+        }
+    }
 }

--- a/src/test/java/com/stumeet/server/studymember/adapter/in/web/StudyMemberQueryApiTest.java
+++ b/src/test/java/com/stumeet/server/studymember/adapter/in/web/StudyMemberQueryApiTest.java
@@ -43,7 +43,8 @@ class StudyMemberQueryApiTest extends ApiTest {
                             preprocessRequest(prettyPrint()),
                             preprocessResponse(prettyPrint()),
                             requestHeaders(
-                                    headerWithName(AuthenticationHeader.ACCESS_TOKEN.getName()).description("서버로부터 전달받은 액세스 토큰")
+                                    headerWithName(AuthenticationHeader.ACCESS_TOKEN.getName()).description(
+                                            "서버로부터 전달받은 액세스 토큰")
                             ),
                             pathParameters(
                                     parameterWithName("studyId").description("스터디 ID")
@@ -79,7 +80,8 @@ class StudyMemberQueryApiTest extends ApiTest {
                             preprocessRequest(prettyPrint()),
                             preprocessResponse(prettyPrint()),
                             requestHeaders(
-                                    headerWithName(AuthenticationHeader.ACCESS_TOKEN.getName()).description("서버로부터 전달받은 액세스 토큰")
+                                    headerWithName(AuthenticationHeader.ACCESS_TOKEN.getName()).description(
+                                            "서버로부터 전달받은 액세스 토큰")
                             ),
                             pathParameters(
                                     parameterWithName("studyId").description("스터디 ID")
@@ -103,7 +105,8 @@ class StudyMemberQueryApiTest extends ApiTest {
                             preprocessRequest(prettyPrint()),
                             preprocessResponse(prettyPrint()),
                             requestHeaders(
-                                    headerWithName(AuthenticationHeader.ACCESS_TOKEN.getName()).description("서버로부터 전달받은 액세스 토큰")
+                                    headerWithName(AuthenticationHeader.ACCESS_TOKEN.getName()).description(
+                                            "서버로부터 전달받은 액세스 토큰")
                             ),
                             pathParameters(
                                     parameterWithName("studyId").description("스터디 ID")
@@ -134,7 +137,8 @@ class StudyMemberQueryApiTest extends ApiTest {
                             preprocessRequest(prettyPrint()),
                             preprocessResponse(prettyPrint()),
                             requestHeaders(
-                                    headerWithName(AuthenticationHeader.ACCESS_TOKEN.getName()).description("서버로부터 전달받은 액세스 토큰")
+                                    headerWithName(AuthenticationHeader.ACCESS_TOKEN.getName()).description(
+                                            "서버로부터 전달받은 액세스 토큰")
                             ),
                             pathParameters(
                                     parameterWithName("studyId").description("스터디 ID"),
@@ -149,7 +153,6 @@ class StudyMemberQueryApiTest extends ApiTest {
                                     fieldWithPath("data.image").description("스터디 멤버 프로필 이미지"),
                                     fieldWithPath("data.region").description("스터디 멤버 지역"),
                                     fieldWithPath("data.profession").description("스터디 멤버 분야"),
-                                    fieldWithPath("data.canSendGrape").description("포도알 발송 가능 여부"),
                                     fieldWithPath("data.achievement").description("성취도")
                             ))
                     );
@@ -169,7 +172,8 @@ class StudyMemberQueryApiTest extends ApiTest {
                             preprocessRequest(prettyPrint()),
                             preprocessResponse(prettyPrint()),
                             requestHeaders(
-                                    headerWithName(AuthenticationHeader.ACCESS_TOKEN.getName()).description("서버로부터 전달받은 액세스 토큰")
+                                    headerWithName(AuthenticationHeader.ACCESS_TOKEN.getName()).description(
+                                            "서버로부터 전달받은 액세스 토큰")
                             ),
                             pathParameters(
                                     parameterWithName("studyId").description("스터디 ID"),
@@ -196,11 +200,72 @@ class StudyMemberQueryApiTest extends ApiTest {
                             preprocessRequest(prettyPrint()),
                             preprocessResponse(prettyPrint()),
                             requestHeaders(
-                                    headerWithName(AuthenticationHeader.ACCESS_TOKEN.getName()).description("서버로부터 전달받은 액세스 토큰")
+                                    headerWithName(AuthenticationHeader.ACCESS_TOKEN.getName()).description(
+                                            "서버로부터 전달받은 액세스 토큰")
                             ),
                             pathParameters(
                                     parameterWithName("studyId").description("스터디 ID"),
                                     parameterWithName("memberId").description("조회할 멤버 ID")
+                            ),
+                            responseFields(
+                                    fieldWithPath("code").description("응답 코드"),
+                                    fieldWithPath("message").description("응답 메시지")
+                            ))
+                    );
+        }
+    }
+
+    @Nested
+    @DisplayName("스터디 멤버 관리자 여부 조회")
+    class CheckMemberAdmin {
+        private static final String PATH = "/api/v1/studies/{studyId}/me/admin/check";
+
+        @Test
+        @WithMockMember
+        @DisplayName("[성공] 스터디 멤버의 관리자 여부 조회에 성공한다.")
+        void success() throws Exception {
+            Long studyId = StudyStub.getStudyId();
+
+            mockMvc.perform(get(PATH, studyId)
+                            .header(AuthenticationHeader.ACCESS_TOKEN.getName(), TokenStub.getKakaoAccessToken()))
+                    .andExpect(status().isOk())
+                    .andDo(document("get-study-member-is-admin/success",
+                            preprocessRequest(prettyPrint()),
+                            preprocessResponse(prettyPrint()),
+                            requestHeaders(
+                                    headerWithName(AuthenticationHeader.ACCESS_TOKEN.getName()).description(
+                                            "서버로부터 전달받은 액세스 토큰")
+                            ),
+                            pathParameters(
+                                    parameterWithName("studyId").description("스터디 ID")
+                            ),
+                            responseFields(
+                                    fieldWithPath("code").description("응답 코드"),
+                                    fieldWithPath("message").description("응답 메시지"),
+                                    fieldWithPath("data").description("스터디 멤버 관리자 여부"),
+                                    fieldWithPath("data.isAdmin").description("관리자 여부")
+                            ))
+                    );
+        }
+
+        @Test
+        @WithMockMember
+        @DisplayName("[성공] 스터디가 존재하지 않을 경우 스터디 멤버의 관리자 여부 조회에 실패한다.")
+        void fail_when_study_not_exist() throws Exception {
+            Long studyId = StudyStub.getInvalidStudyId();
+
+            mockMvc.perform(get(PATH, studyId)
+                            .header(AuthenticationHeader.ACCESS_TOKEN.getName(), TokenStub.getKakaoAccessToken()))
+                    .andExpect(status().isNotFound())
+                    .andDo(document("get-study-member-is-admin/success",
+                            preprocessRequest(prettyPrint()),
+                            preprocessResponse(prettyPrint()),
+                            requestHeaders(
+                                    headerWithName(AuthenticationHeader.ACCESS_TOKEN.getName()).description(
+                                            "서버로부터 전달받은 액세스 토큰")
+                            ),
+                            pathParameters(
+                                    parameterWithName("studyId").description("스터디 ID")
                             ),
                             responseFields(
                                     fieldWithPath("code").description("응답 코드"),

--- a/src/test/resources/db/setup.sql
+++ b/src/test/resources/db/setup.sql
@@ -42,10 +42,11 @@ VALUES (4, 'test4', 'http://localhost:4572/user/1/profile/2024030416531039839905
         '서울', 1, 'MEMBER', 'OAUTH', 'SEED', 0.0, false, null);
 INSERT INTO study_member (member_id, study_id, is_admin, is_sent_grape) VALUES (4, 1, false, false);
 
+
 -- [TABLE: activity]
 -- 스터디 1 (공지) 기본 활동
-INSERT INTO activity(id, study_id, author_id, category, title, content, is_notice,location)
-VALUES (1, 1, 4, 'DEFAULT', 'title', 'content', true, null);
+INSERT INTO activity(id, study_id, author_id, category, title, content, is_notice, location, link)
+VALUES (1, 1, 4, 'DEFAULT', 'title', 'content', true, null, 'https://www.naver.com');
 
 INSERT INTO activity_image (activity_id, image) VALUES (1, 'https://example.com/images/image1.png');
 INSERT INTO activity_image (activity_id, image) VALUES (1, 'https://example.com/images/image2.png');


### PR DESCRIPTION
## 💁 해결 하려는 문제를 적어주세요 

UI에서 관리자만 보이는 옵션이 존재하여, 모든 API에 관리자 여부를 포함시키는 대신 이를 재사용 가능한 하나의 API로 통합했습니다.

하지만 이 방식은 멤버 또는 스터디 상세 화면에서 4~5개의 API 호출이 필요하게 되어, 통신 비용이 증가하고 효율성이 떨어지는 문제가 발생했습니다.

## 🤔 어떤 방식으로 해결했는지 적어주세요 

따라서 클라이언트의 환경에 따라 필요한 정보만을 뽑아주는 BFF(Backend For Frontend) 패턴을 차용하여 기존의 API는 그대로 두고, 화면에 필요한 정보를 통합으로 모아 응답하는 개념적으로 외부 API를 구현했습니다.

## 🧑‍🏫 이해를 위해 필요한 자료가 있다면 첨부해주세요
<div style="display: flex; justify-content: center; align-items: center; gap: 20px; width: 100%;">
  <img src="https://github.com/user-attachments/assets/2f4d9f34-cb88-42db-a671-23c4ed0ad6f7" width="200" alt="스터디 상세 화면">
  <img src="https://github.com/user-attachments/assets/b6c33f94-4ebf-4e45-a0eb-61cbf5ac915e" width="200" alt="스터디 멤버 상세 화면">
</div>










