### PR TITLE
✨ [STMT-296] 알림 토큰 갱신 API 구현 및 FCM 알림 전송 테스트 기능 구현

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -27,10 +27,10 @@ jobs:
       - name: Set environment variables
         run: |
           cd ./src/main/resources
-          touch ./application-secret.properties
           echo "${{ secrets.ENV }}" > ./application-secret.properties
+          mkdir -p ./firebase
+          echo "${{ secrets.FCM_ACCOUNT_SECRET }}" > ./firebase/"${{ secrets.FCM_ACCOUNT_SECRET_FILE_NAME }}"
 
-      # gradle caching - 빌드 시간 향상
       - name: Gradle Caching
         uses: actions/cache@v3
         with:
@@ -41,14 +41,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
 
-      # docker login
       - name: Login to Docker Hub
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      # build gradle
       - name: Build gradlew
         run: |
           chmod +x gradlew 
@@ -57,7 +55,6 @@ jobs:
           -Djib.from.auth.password=${{ secrets.DOCKER_PASSWORD }} \
           -Dspring.profiles.active=prod
 
-      ## deploy to production
       - name: Deploy to prod
         uses: appleboy/ssh-action@master
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
         run: |
           cd ./src/test/resources
           echo "${{ secrets.ENV }}" > ./application-secret.properties
+          mkdir -p ./firebase
           echo "${{ secrets.FCM_ACCOUNT_SECRET }}" > ./firebase/"${{ secrets.FCM_ACCOUNT_SECRET_FILE_NAME }}"
 
       - name: Gradle Caching

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
         run: |
           cd ./src/test/resources
           echo "${{ secrets.ENV }}" > ./application-secret.properties
+          echo "${{ secrets.FCM_ACCOUNT_SECRET }}" > ./firebase/"${{secrets.FCM_ACCOUNT_SECRET_FILE_NAME}}"
 
       - name: Gradle Caching
         uses: actions/cache@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
           echo "${{ secrets.ENV }}" > ./application-secret.properties
           mkdir -p ./firebase
           echo "${{ secrets.FCM_ACCOUNT_SECRET }}" > ./firebase/"${{ secrets.FCM_ACCOUNT_SECRET_FILE_NAME }}"
+          cat ./firebase/"${{ secrets.FCM_ACCOUNT_SECRET_FILE_NAME }}"
 
       - name: Gradle Caching
         uses: actions/cache@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         run: |
           cd ./src/test/resources
           echo "${{ secrets.ENV }}" > ./application-secret.properties
-          echo "${{ secrets.FCM_ACCOUNT_SECRET }}" > ./firebase/"${{secrets.FCM_ACCOUNT_SECRET_FILE_NAME}}"
+          echo "${{ secrets.FCM_ACCOUNT_SECRET }}" > ./firebase/"${{ secrets.FCM_ACCOUNT_SECRET_FILE_NAME }}"
 
       - name: Gradle Caching
         uses: actions/cache@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,6 @@ jobs:
           echo "${{ secrets.ENV }}" > ./application-secret.properties
           mkdir -p ./firebase
           echo "${{ secrets.FCM_ACCOUNT_SECRET }}" > ./firebase/"${{ secrets.FCM_ACCOUNT_SECRET_FILE_NAME }}"
-          cat ./firebase/"${{ secrets.FCM_ACCOUNT_SECRET_FILE_NAME }}"
 
       - name: Gradle Caching
         uses: actions/cache@v3

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ application-secret.properties
 src/main/resources/static/docs/**
 
 src/main/generated/**
+
+src/main/resources/firebase

--- a/build.gradle
+++ b/build.gradle
@@ -68,7 +68,8 @@ dependencies {
     testImplementation 'org.springframework.cloud:spring-cloud-contract-stub-runner'
     testImplementation 'org.testcontainers:localstack'
 
-
+    // fcm
+    implementation 'com.google.firebase:firebase-admin:9.3.0'
 }
 
 dependencyManagement {

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -899,6 +899,32 @@ include::{snippets}/delete-activity/fail/forbidden/response-fields.adoc[]
 include::{snippets}/delete-activity/fail/not-joined-member/response-body.adoc[]
 include::{snippets}/delete-activity/fail/not-joined-member/response-fields.adoc[]
 
+== 알림
+=== 알림 토큰 갱신
+
+알림 토큰을 갱신하는 API 입니다.
+
+==== POST /api/v1/notification-token/renew
+
+===== 요청
+include::{snippets}/renew-notification-token/success/http-request.adoc[]
+
+===== 헤더
+include::{snippets}/renew-notification-token/success/request-headers.adoc[]
+
+===== 요청 본문
+include::{snippets}/renew-notification-token/success/request-fields.adoc[]
+
+===== 응답 성공 (200)
+include::{snippets}/renew-notification-token/success/response-body.adoc[]
+include::{snippets}/renew-notification-token/success/response-fields.adoc[]
+
+===== 응답 실패 (400)
+.존재하지 않는 스터디 분야 ID를 요청한 경우
+include::{snippets}/renew-notification-token/fail/invalid-format/response-body.adoc[]
+include::{snippets}/renew-notification-token/fail/invalid-format/response-fields.adoc[]
+
+
 == 통합 API
 
 === 스터디 홈 화면 조회

--- a/src/main/java/com/stumeet/server/common/config/FirebaseAdminConfig.java
+++ b/src/main/java/com/stumeet/server/common/config/FirebaseAdminConfig.java
@@ -1,0 +1,30 @@
+package com.stumeet.server.common.config;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+
+@Configuration
+public class FirebaseAdminConfig {
+
+    @Value("${fcm.secret.path}")
+    private String serviceAccountFilePath;
+
+    @Bean
+    public FirebaseApp initializeFirebaseApp() throws IOException {
+        FileInputStream serviceAccount = new FileInputStream(serviceAccountFilePath);
+
+        FirebaseOptions options = FirebaseOptions.builder()
+                .setCredentials(GoogleCredentials.fromStream(serviceAccount))
+                .build();
+
+        return FirebaseApp.initializeApp(options);
+    }
+}

--- a/src/main/java/com/stumeet/server/common/config/FirebaseAdminConfig.java
+++ b/src/main/java/com/stumeet/server/common/config/FirebaseAdminConfig.java
@@ -1,11 +1,12 @@
 package com.stumeet.server.common.config;
 
-import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.Resource;
 
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.firebase.FirebaseApp;
@@ -15,16 +16,20 @@ import com.google.firebase.FirebaseOptions;
 public class FirebaseAdminConfig {
 
     @Value("${fcm.secret.path}")
-    private String serviceAccountFilePath;
+    private Resource serviceAccountResource;
 
     @Bean
     public FirebaseApp initializeFirebaseApp() throws IOException {
-        FileInputStream serviceAccount = new FileInputStream(serviceAccountFilePath);
+        if (FirebaseApp.getApps().isEmpty()) {
+            InputStream serviceAccount = serviceAccountResource.getInputStream();
 
-        FirebaseOptions options = FirebaseOptions.builder()
-                .setCredentials(GoogleCredentials.fromStream(serviceAccount))
-                .build();
+            FirebaseOptions options = FirebaseOptions.builder()
+                    .setCredentials(GoogleCredentials.fromStream(serviceAccount))
+                    .build();
 
-        return FirebaseApp.initializeApp(options);
+            return FirebaseApp.initializeApp(options);
+        } else {
+            return FirebaseApp.getInstance();
+        }
     }
 }

--- a/src/main/java/com/stumeet/server/common/response/ErrorCode.java
+++ b/src/main/java/com/stumeet/server/common/response/ErrorCode.java
@@ -69,6 +69,7 @@ public enum ErrorCode {
     ACTIVITY_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 활동 입니다."),
     ACTIVITY_STATUS_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 활동 상태 입니다."),
     ACTIVITY_PARTICIPANT_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 활동 참가자입니다."),
+    NOTIFICATION_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 알림 토큰입니다."),
 
     /*
         409 - CONFLICT

--- a/src/main/java/com/stumeet/server/notification/adapter/out/mapper/NotificationTokenPersistenceMapper.java
+++ b/src/main/java/com/stumeet/server/notification/adapter/out/mapper/NotificationTokenPersistenceMapper.java
@@ -1,0 +1,28 @@
+package com.stumeet.server.notification.adapter.out.mapper;
+
+import org.springframework.stereotype.Component;
+
+import com.stumeet.server.notification.adapter.out.persistence.NotificationTokenJpaEntity;
+import com.stumeet.server.notification.domain.NotificationToken;
+
+@Component
+public class NotificationTokenPersistenceMapper {
+
+    public NotificationToken toDomain(NotificationTokenJpaEntity entity) {
+        return NotificationToken.builder()
+                .id(entity.getId())
+                .memberId(entity.getMemberId())
+                .deviceId(entity.getDeviceId())
+                .token(entity.getToken())
+                .build();
+    }
+
+    public NotificationTokenJpaEntity toEntity(NotificationToken domain) {
+        return NotificationTokenJpaEntity.builder()
+                .id(domain.getId())
+                .memberId(domain.getMemberId())
+                .deviceId(domain.getDeviceId())
+                .token(domain.getToken())
+                .build();
+    }
+}

--- a/src/main/java/com/stumeet/server/notification/adapter/out/notification/FcmNotificationAdapter.java
+++ b/src/main/java/com/stumeet/server/notification/adapter/out/notification/FcmNotificationAdapter.java
@@ -1,0 +1,69 @@
+package com.stumeet.server.notification.adapter.out.notification;
+
+import org.springframework.stereotype.Component;
+
+import com.google.firebase.messaging.BatchResponse;
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.MulticastMessage;
+import com.google.firebase.messaging.Notification;
+import com.google.firebase.messaging.TopicManagementResponse;
+import com.stumeet.server.notification.application.port.out.ManageSubscriptionPort;
+import com.stumeet.server.notification.application.port.out.NotificationSendPort;
+import com.stumeet.server.notification.application.port.out.command.SendMessageCommand;
+import com.stumeet.server.notification.application.port.out.command.SubscribeCommand;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class FcmNotificationAdapter implements ManageSubscriptionPort, NotificationSendPort {
+
+    @Override
+    public void subscribe(SubscribeCommand command) throws FirebaseMessagingException {
+        TopicManagementResponse response = FirebaseMessaging.getInstance()
+                .subscribeToTopic(command.registrationTokens(), command.topic());
+
+        System.out.println(response.getSuccessCount() + " tokens were subscribed successfully");
+    }
+
+    @Override
+    public void sendTokenMulticastMessage(SendMessageCommand command) throws FirebaseMessagingException {
+        Notification notification = makeNotification(command.title(), command.body(), command.image());
+
+        MulticastMessage multicastMessage = MulticastMessage.builder()
+                .addAllTokens(command.registrationTokens())
+                .putAllData(command.data())
+                .setNotification(notification)
+                .build();
+
+        BatchResponse response = FirebaseMessaging.getInstance()
+                .sendEachForMulticast(multicastMessage);
+
+        System.out.println(response.getSuccessCount() + " messages were sent successfully");
+        System.out.println(response);
+    }
+
+    @Override
+    public void sendTopicMessage(SendMessageCommand command) throws FirebaseMessagingException {
+        Notification notification = makeNotification(command.title(), command.body(), command.image());
+
+        Message message = Message.builder()
+                .setTopic(command.topic())
+                .putAllData(command.data())
+                .setNotification(notification)
+                .build();
+
+        String response = FirebaseMessaging.getInstance().send(message);
+        System.out.println("Successfully sent message: " + response);
+    }
+
+    private Notification makeNotification(String title, String body, String image) {
+        return Notification.builder()
+                .setTitle(title)
+                .setBody(body)
+                .setImage(image)
+                .build();
+    }
+}

--- a/src/main/java/com/stumeet/server/notification/adapter/out/persistence/JpaNotificationTokenRepository.java
+++ b/src/main/java/com/stumeet/server/notification/adapter/out/persistence/JpaNotificationTokenRepository.java
@@ -1,0 +1,10 @@
+package com.stumeet.server.notification.adapter.out.persistence;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JpaNotificationTokenRepository extends JpaRepository<NotificationTokenJpaEntity, Long> {
+
+    Optional<NotificationTokenJpaEntity> findByMemberIdAndDeviceId(Long memberId, String deviceId);
+}

--- a/src/main/java/com/stumeet/server/notification/adapter/out/persistence/NotificationTokenJpaEntity.java
+++ b/src/main/java/com/stumeet/server/notification/adapter/out/persistence/NotificationTokenJpaEntity.java
@@ -1,0 +1,43 @@
+package com.stumeet.server.notification.adapter.out.persistence;
+
+import org.hibernate.annotations.Comment;
+
+import com.stumeet.server.common.model.BaseTimeEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "notification_token")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+@Getter
+public class NotificationTokenJpaEntity extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Comment("등록 토큰 ID")
+    private Long id;
+
+    @Column(name = "member_id")
+    @Comment("멤버 ID")
+    private Long memberId;
+
+    @Column(name = "device_id", unique = true, updatable = false)
+    @Comment("기기 식별자")
+    private String deviceId;
+
+    @Column(name = "token")
+    @Comment("알림 토큰")
+    private String token;
+}

--- a/src/main/java/com/stumeet/server/notification/adapter/out/persistence/NotificationTokenPersistenceAdapter.java
+++ b/src/main/java/com/stumeet/server/notification/adapter/out/persistence/NotificationTokenPersistenceAdapter.java
@@ -1,0 +1,33 @@
+package com.stumeet.server.notification.adapter.out.persistence;
+
+import com.stumeet.server.common.annotation.PersistenceAdapter;
+import com.stumeet.server.notification.adapter.out.mapper.NotificationTokenPersistenceMapper;
+import com.stumeet.server.notification.domain.exception.NotExistsNotificationTokenException;
+import com.stumeet.server.notification.application.port.out.NotificationTokenQueryPort;
+import com.stumeet.server.notification.application.port.out.SaveNotificationTokenPort;
+import com.stumeet.server.notification.domain.NotificationToken;
+
+import lombok.RequiredArgsConstructor;
+
+@PersistenceAdapter
+@RequiredArgsConstructor
+public class NotificationTokenPersistenceAdapter implements NotificationTokenQueryPort, SaveNotificationTokenPort {
+
+    private final JpaNotificationTokenRepository jpaNotificationTokenRepository;
+
+    private final NotificationTokenPersistenceMapper notificationTokenPersistenceMapper;
+
+    @Override
+    public NotificationToken findTokenForMember(Long memberId, String deviceId) {
+        NotificationTokenJpaEntity entity = jpaNotificationTokenRepository.findByMemberIdAndDeviceId(memberId, deviceId)
+                .orElseThrow(() -> new NotExistsNotificationTokenException(memberId));
+
+        return notificationTokenPersistenceMapper.toDomain(entity);
+    }
+
+    @Override
+    public void save(NotificationToken notificationToken) {
+        NotificationTokenJpaEntity entity = notificationTokenPersistenceMapper.toEntity(notificationToken);
+        jpaNotificationTokenRepository.save(entity);
+    }
+}

--- a/src/main/java/com/stumeet/server/notification/adapter/out/web/RenewNotificationTokenApi.java
+++ b/src/main/java/com/stumeet/server/notification/adapter/out/web/RenewNotificationTokenApi.java
@@ -37,7 +37,9 @@ public class RenewNotificationTokenApi {
 
         renewNotificationTokenUseCase.renewNotificationToken(command);
 
-        return ResponseEntity.ok(
-                ApiResponse.success(HttpStatus.OK.value(), "알림 토큰이 갱신되었습니다."));
+        return new ResponseEntity<>(
+                ApiResponse.success(HttpStatus.CREATED.value(), "알림 토큰이 갱신되었습니다."),
+                HttpStatus.CREATED
+        );
     }
 }

--- a/src/main/java/com/stumeet/server/notification/adapter/out/web/RenewNotificationTokenApi.java
+++ b/src/main/java/com/stumeet/server/notification/adapter/out/web/RenewNotificationTokenApi.java
@@ -1,0 +1,43 @@
+package com.stumeet.server.notification.adapter.out.web;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import com.stumeet.server.common.annotation.WebAdapter;
+import com.stumeet.server.common.auth.model.LoginMember;
+import com.stumeet.server.common.model.ApiResponse;
+import com.stumeet.server.notification.adapter.out.web.dto.RenewNotificationTokenRequest;
+import com.stumeet.server.notification.application.port.in.RenewNotificationTokenUseCase;
+import com.stumeet.server.notification.application.port.in.command.RenewNotificationTokenCommand;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@WebAdapter
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+public class RenewNotificationTokenApi {
+
+    private final RenewNotificationTokenUseCase renewNotificationTokenUseCase;
+
+    @PostMapping("/notification-token/renew")
+    public ResponseEntity<ApiResponse<Void>> renewRegistrationToken(
+            @AuthenticationPrincipal LoginMember member,
+            @RequestBody @Valid RenewNotificationTokenRequest request
+    ) {
+        RenewNotificationTokenCommand command = new RenewNotificationTokenCommand(
+                member.getId(),
+                request.deviceId(),
+                request.notificationToken()
+        );
+
+        renewNotificationTokenUseCase.renewNotificationToken(command);
+
+        return ResponseEntity.ok(
+                ApiResponse.success(HttpStatus.OK.value(), "알림 토큰이 갱신되었습니다."));
+    }
+}

--- a/src/main/java/com/stumeet/server/notification/adapter/out/web/dto/RenewNotificationTokenRequest.java
+++ b/src/main/java/com/stumeet/server/notification/adapter/out/web/dto/RenewNotificationTokenRequest.java
@@ -1,0 +1,12 @@
+package com.stumeet.server.notification.adapter.out.web.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record RenewNotificationTokenRequest(
+        @NotBlank(message = "디바이스 식별자는 공백일 수 없습니다.")
+        String deviceId,
+
+        @NotBlank(message = "알림 토큰은 공백일 수 없습니다.")
+        String notificationToken
+) {
+}

--- a/src/main/java/com/stumeet/server/notification/application/port/in/RenewNotificationTokenUseCase.java
+++ b/src/main/java/com/stumeet/server/notification/application/port/in/RenewNotificationTokenUseCase.java
@@ -1,0 +1,7 @@
+package com.stumeet.server.notification.application.port.in;
+
+import com.stumeet.server.notification.application.port.in.command.RenewNotificationTokenCommand;
+
+public interface RenewNotificationTokenUseCase {
+    void renewNotificationToken(RenewNotificationTokenCommand command);
+}

--- a/src/main/java/com/stumeet/server/notification/application/port/in/command/RenewNotificationTokenCommand.java
+++ b/src/main/java/com/stumeet/server/notification/application/port/in/command/RenewNotificationTokenCommand.java
@@ -1,0 +1,8 @@
+package com.stumeet.server.notification.application.port.in.command;
+
+public record RenewNotificationTokenCommand(
+        Long memberId,
+        String deviceId,
+        String notificationToken
+) {
+}

--- a/src/main/java/com/stumeet/server/notification/application/port/out/ManageSubscriptionPort.java
+++ b/src/main/java/com/stumeet/server/notification/application/port/out/ManageSubscriptionPort.java
@@ -1,0 +1,8 @@
+package com.stumeet.server.notification.application.port.out;
+
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.stumeet.server.notification.application.port.out.command.SubscribeCommand;
+
+public interface ManageSubscriptionPort {
+    void subscribe(SubscribeCommand command) throws FirebaseMessagingException;
+}

--- a/src/main/java/com/stumeet/server/notification/application/port/out/NotificationSendPort.java
+++ b/src/main/java/com/stumeet/server/notification/application/port/out/NotificationSendPort.java
@@ -1,0 +1,9 @@
+package com.stumeet.server.notification.application.port.out;
+
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.stumeet.server.notification.application.port.out.command.SendMessageCommand;
+
+public interface NotificationSendPort {
+    void sendTokenMulticastMessage(SendMessageCommand command) throws FirebaseMessagingException;
+    void sendTopicMessage(SendMessageCommand command) throws FirebaseMessagingException;
+}

--- a/src/main/java/com/stumeet/server/notification/application/port/out/NotificationTokenQueryPort.java
+++ b/src/main/java/com/stumeet/server/notification/application/port/out/NotificationTokenQueryPort.java
@@ -1,0 +1,7 @@
+package com.stumeet.server.notification.application.port.out;
+
+import com.stumeet.server.notification.domain.NotificationToken;
+
+public interface NotificationTokenQueryPort {
+    NotificationToken findTokenForMember(Long memberId, String deviceId);
+}

--- a/src/main/java/com/stumeet/server/notification/application/port/out/SaveNotificationTokenPort.java
+++ b/src/main/java/com/stumeet/server/notification/application/port/out/SaveNotificationTokenPort.java
@@ -1,0 +1,7 @@
+package com.stumeet.server.notification.application.port.out;
+
+import com.stumeet.server.notification.domain.NotificationToken;
+
+public interface SaveNotificationTokenPort {
+    void save(NotificationToken notificationToken);
+}

--- a/src/main/java/com/stumeet/server/notification/application/port/out/command/SendMessageCommand.java
+++ b/src/main/java/com/stumeet/server/notification/application/port/out/command/SendMessageCommand.java
@@ -1,0 +1,17 @@
+package com.stumeet.server.notification.application.port.out.command;
+
+import java.util.List;
+import java.util.Map;
+
+import lombok.Builder;
+
+@Builder
+public record SendMessageCommand(
+        List<String> registrationTokens,
+        String topic,
+        String title,
+        String body,
+        String image,
+        Map<String, String> data
+) {
+}

--- a/src/main/java/com/stumeet/server/notification/application/port/out/command/SubscribeCommand.java
+++ b/src/main/java/com/stumeet/server/notification/application/port/out/command/SubscribeCommand.java
@@ -1,0 +1,9 @@
+package com.stumeet.server.notification.application.port.out.command;
+
+import java.util.List;
+
+public record SubscribeCommand(
+        List<String> registrationTokens,
+        String topic
+) {
+}

--- a/src/main/java/com/stumeet/server/notification/application/service/RenewNotificationTokenService.java
+++ b/src/main/java/com/stumeet/server/notification/application/service/RenewNotificationTokenService.java
@@ -1,0 +1,37 @@
+package com.stumeet.server.notification.application.service;
+
+import com.stumeet.server.common.annotation.UseCase;
+import com.stumeet.server.notification.application.port.in.RenewNotificationTokenUseCase;
+import com.stumeet.server.notification.application.port.in.command.RenewNotificationTokenCommand;
+import com.stumeet.server.notification.application.port.out.NotificationTokenQueryPort;
+import com.stumeet.server.notification.application.port.out.SaveNotificationTokenPort;
+import com.stumeet.server.notification.domain.NotificationToken;
+import com.stumeet.server.notification.domain.exception.NotExistsNotificationTokenException;
+
+import lombok.RequiredArgsConstructor;
+
+@UseCase
+@RequiredArgsConstructor
+public class RenewNotificationTokenService implements RenewNotificationTokenUseCase {
+
+    private final NotificationTokenQueryPort notificationTokenQueryPort;
+    private final SaveNotificationTokenPort saveNotificationTokenPort;
+
+    @Override
+    public void renewNotificationToken(RenewNotificationTokenCommand command) {
+        NotificationToken token;
+        try {
+            token = notificationTokenQueryPort
+                    .findTokenForMember(command.memberId(), command.deviceId())
+                    .renewNotificationToken(command.notificationToken());
+        } catch (NotExistsNotificationTokenException exception) {
+            token = NotificationToken.builder()
+                    .memberId(command.memberId())
+                    .deviceId(command.deviceId())
+                    .token(command.notificationToken())
+                    .build();
+        }
+
+        saveNotificationTokenPort.save(token);
+    }
+}

--- a/src/main/java/com/stumeet/server/notification/domain/NotificationToken.java
+++ b/src/main/java/com/stumeet/server/notification/domain/NotificationToken.java
@@ -1,0 +1,25 @@
+package com.stumeet.server.notification.domain;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+@Getter
+public class NotificationToken {
+    private final Long id;
+    private final Long memberId;
+    private final String deviceId;
+    private final String token;
+
+    public NotificationToken renewNotificationToken(String token) {
+        return NotificationToken.builder()
+                .id(this.id)
+                .memberId(this.memberId)
+                .deviceId(this.deviceId)
+                .token(token)
+                .build();
+    }
+}

--- a/src/main/java/com/stumeet/server/notification/domain/exception/NotExistsNotificationTokenException.java
+++ b/src/main/java/com/stumeet/server/notification/domain/exception/NotExistsNotificationTokenException.java
@@ -1,0 +1,14 @@
+package com.stumeet.server.notification.domain.exception;
+
+import java.text.MessageFormat;
+
+import com.stumeet.server.common.exception.model.NotExistsException;
+import com.stumeet.server.common.response.ErrorCode;
+
+public class NotExistsNotificationTokenException extends NotExistsException {
+    public static final String MESSAGE = "존재하지 않는 등록 토큰입니다. 입력받은 멤버 ID : {0}";
+
+    public NotExistsNotificationTokenException(Long memberId) {
+        super(MessageFormat.format(MESSAGE, memberId), ErrorCode.NOTIFICATION_TOKEN_NOT_FOUND);
+    }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -53,6 +53,10 @@ presigned:
   url:
     expired-time: 3600
 
+fcm:
+  secret:
+    path: ${FCM_SECRET_LOCAL_PATH}
+
 #logging:
 #  level:
 #    root: debug

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -55,7 +55,7 @@ presigned:
 
 fcm:
   secret:
-    path: ${FCM_SECRET_LOCAL_PATH}
+    path: ${FCM_SECRET_PATH}
 
 #logging:
 #  level:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -58,4 +58,4 @@ presigned:
 
 fcm:
   secret:
-    path: ${FCM_SECRET_PROD_PATH}
+    path: ${FCM_SECRET_PATH}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -55,3 +55,7 @@ oauth:
 presigned:
   url:
     expired-time: 3600
+
+fcm:
+  secret:
+    path: ${FCM_SECRET_PROD_PATH}

--- a/src/main/resources/db/migration/V1.9__create_notification_token_table.sql
+++ b/src/main/resources/db/migration/V1.9__create_notification_token_table.sql
@@ -1,0 +1,15 @@
+CREATE TABLE IF NOT EXISTS `notification_token`
+(
+    `id`         BIGINT       NOT NULL AUTO_INCREMENT PRIMARY KEY COMMENT '알림 토큰 ID',
+    `member_id`  BIGINT       NOT NULL COMMENT '멤버 ID',
+    `device_id`  VARCHAR(100) NOT NULL COMMENT '디바이스 ID',
+    `token`      VARCHAR(100) COMMENT '토큰',
+    `created_at` DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '생성 시간',
+    `updated_at` DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '수정 시간',
+
+    CONSTRAINT `fk_registration_token_by_member_id` FOREIGN KEY (`member_id`)
+        REFERENCES `member` (`id`)
+        ON DELETE RESTRICT ON UPDATE CASCADE
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci;

--- a/src/test/java/com/stumeet/server/notification/adapter/out/web/RenewNotificationTokenApiTest.java
+++ b/src/test/java/com/stumeet/server/notification/adapter/out/web/RenewNotificationTokenApiTest.java
@@ -1,0 +1,85 @@
+package com.stumeet.server.notification.adapter.out.web;
+
+import static org.springframework.restdocs.headers.HeaderDocumentation.*;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+
+import com.stumeet.server.common.auth.model.AuthenticationHeader;
+import com.stumeet.server.helper.WithMockMember;
+import com.stumeet.server.notification.adapter.out.web.dto.RenewNotificationTokenRequest;
+import com.stumeet.server.stub.NotificationStub;
+import com.stumeet.server.stub.TokenStub;
+import com.stumeet.server.template.ApiTest;
+
+class RenewNotificationTokenApiTest extends ApiTest {
+
+    @Nested
+    @DisplayName("알림 토큰 갱신 API")
+    class RenewNotificationToken {
+        private final String path = "/api/v1/notification-token/renew";
+
+        @Test
+        @WithMockMember
+        @DisplayName("[성공] 알림 토큰 갱신에 성공한다.")
+        void success() throws Exception {
+            RenewNotificationTokenRequest request = NotificationStub.getRenewNotificationTokenRequest();
+
+            mockMvc.perform(post(path)
+                            .header(AuthenticationHeader.ACCESS_TOKEN.getName(), TokenStub.getMockAccessToken())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(toJson(request)))
+                    .andExpect(status().isCreated())
+                    .andDo(document("renew-notification-token/success",
+                            preprocessRequest(prettyPrint()),
+                            preprocessResponse(prettyPrint()),
+                            requestHeaders(
+                                    headerWithName(AuthenticationHeader.ACCESS_TOKEN.getName()).description("서버로부터 전달받은 액세스 토큰")
+                            ),
+                            requestFields(
+                                    fieldWithPath("deviceId").description("디바이스 식별자"),
+                                    fieldWithPath("notificationToken").description("알림 토큰")
+                            ),
+                            responseFields(
+                                    fieldWithPath("code").description("응답 상태"),
+                                    fieldWithPath("message").description("응답 메시지")
+                            )));
+        }
+
+        @Test
+        @WithMockMember
+        @DisplayName("[실패] 잘못된 형식으로 요청한 경우 알림 토큰 갱신에 실패한다.")
+        void fail_when_invalid_format() throws Exception {
+            RenewNotificationTokenRequest request = NotificationStub.getInvalidRenewNotificationTokenRequest();
+
+            mockMvc.perform(post(path)
+                            .header(AuthenticationHeader.ACCESS_TOKEN.getName(), TokenStub.getMockAccessToken())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(toJson(request)))
+                    .andExpect(status().isBadRequest())
+                    .andDo(document("renew-notification-token/fail/invalid-format",
+                            preprocessRequest(prettyPrint()),
+                            preprocessResponse(prettyPrint()),
+                            requestHeaders(
+                                    headerWithName(AuthenticationHeader.ACCESS_TOKEN.getName()).description("서버로부터 전달받은 액세스 토큰")
+                            ),
+                            requestFields(
+                                    fieldWithPath("deviceId").description("디바이스 식별자"),
+                                    fieldWithPath("notificationToken").description("알림 토큰")
+                            ),
+                            responseFields(
+                                    fieldWithPath("code").description("응답 상태"),
+                                    fieldWithPath("message").description("응답 메시지"),
+                                    fieldWithPath("data").description("에러 상세"),
+                                    fieldWithPath("data[].message").description("에러 상세 메시지")
+                            )));
+        }
+    }
+}

--- a/src/test/java/com/stumeet/server/stub/NotificationStub.java
+++ b/src/test/java/com/stumeet/server/stub/NotificationStub.java
@@ -1,0 +1,20 @@
+package com.stumeet.server.stub;
+
+import com.stumeet.server.notification.adapter.out.web.dto.RenewNotificationTokenRequest;
+
+public class NotificationStub {
+
+    public static RenewNotificationTokenRequest getRenewNotificationTokenRequest() {
+        return new RenewNotificationTokenRequest(
+                "9774d56d682e549c",
+                "eTwlLwiTPtM:APA91bH-0CjWQJ8p6DZHJ-LZiXkv2YKSCrGq9Z"
+        );
+    }
+
+    public static RenewNotificationTokenRequest getInvalidRenewNotificationTokenRequest() {
+        return new RenewNotificationTokenRequest(
+                "",
+                ""
+        );
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -48,4 +48,4 @@ presigned:
 
 fcm:
   secret:
-    path: ${FCM_SECRET_PROD_PATH}
+    path: ${FCM_SECRET_PATH}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -48,4 +48,4 @@ presigned:
 
 fcm:
   secret:
-    path: ${FCM_SECRET_LOCAL_PATH}
+    path: ${FCM_SECRET_PROD_PATH}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -45,3 +45,7 @@ oauth:
 presigned:
   url:
     expired-time: 3600
+
+fcm:
+  secret:
+    path: ${FCM_SECRET_LOCAL_PATH}


### PR DESCRIPTION
## 💁 해결 하려는 문제를 적어주세요 

- 특정 상황에서 사용자 디바이스에 알림을 전송해야 합니다.
  - 주별 칭찬 하지 않았을 경우
  - 리뷰 작성을 하지 않았을 경우
  - 주기적인 알림(캘린더 알림)
  - 공지활동 작성 시
## 🤔 어떤 방식으로 해결했는지 적어주세요 

- Google의 FCM 서비스를 활용하여 알림을 전송하는 기반 코드를 작성했습니다.
- 디바이스의 등록토큰을 저장할 테이블이 추가되었습니다.
- 등록토큰을 갱신하는 API를 구현했습니다.

## 🧑‍🏫 이해를 위해 필요한 자료가 있다면 첨부해주세요
![image](https://github.com/user-attachments/assets/38e42378-0f26-4e17-85b6-b6ff2f076b40)