### PR TITLE
:necktie: [STMT-300] 알림 토큰 갱신 시 멤버의 모든 토픽 구독 갱신

### DIFF
--- a/src/main/java/com/stumeet/server/notification/adapter/out/mapper/TopicSubscriptionPersistenceMapper.java
+++ b/src/main/java/com/stumeet/server/notification/adapter/out/mapper/TopicSubscriptionPersistenceMapper.java
@@ -1,9 +1,12 @@
 package com.stumeet.server.notification.adapter.out.mapper;
 
+import java.util.List;
+
 import org.springframework.stereotype.Component;
 
 import com.stumeet.server.notification.adapter.out.persistence.entity.TopicJpaEntity;
 import com.stumeet.server.notification.adapter.out.persistence.entity.TopicSubscriptionJpaEntity;
+import com.stumeet.server.notification.domain.Topic;
 import com.stumeet.server.notification.domain.TopicSubscription;
 
 @Component
@@ -17,5 +20,21 @@ public class TopicSubscriptionPersistenceMapper {
                 .build())
             .memberId(domain.getMemberId())
             .build();
+    }
+
+    public TopicSubscription toDomain(TopicSubscriptionJpaEntity entity) {
+        return TopicSubscription.builder()
+            .id(entity.getId())
+            .topic(Topic.builder()
+                .id(entity.getTopic().getId())
+                .build())
+            .memberId(entity.getMemberId())
+            .build();
+    }
+
+    public List<TopicSubscription> toDomains(List<TopicSubscriptionJpaEntity> entities) {
+        return entities.stream()
+            .map(this::toDomain)
+            .toList();
     }
 }

--- a/src/main/java/com/stumeet/server/notification/adapter/out/persistence/JpaTopicSubscriptionRepository.java
+++ b/src/main/java/com/stumeet/server/notification/adapter/out/persistence/JpaTopicSubscriptionRepository.java
@@ -1,10 +1,17 @@
 package com.stumeet.server.notification.adapter.out.persistence;
 
+import java.util.List;
+
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.stumeet.server.notification.adapter.out.persistence.entity.TopicSubscriptionJpaEntity;
 
 public interface JpaTopicSubscriptionRepository extends JpaRepository<TopicSubscriptionJpaEntity, Long> {
+
+    @EntityGraph(attributePaths = {"topic"})
+    List<TopicSubscriptionJpaEntity> findAllByMemberId(Long memberId);
+
     boolean existsByMemberIdAndTopicId(Long memberId, Long topicId);
 
     void deleteByMemberIdAndTopicId(Long memberId, Long topicId);

--- a/src/main/java/com/stumeet/server/notification/adapter/out/persistence/JpaTopicSubscriptionRepository.java
+++ b/src/main/java/com/stumeet/server/notification/adapter/out/persistence/JpaTopicSubscriptionRepository.java
@@ -5,5 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import com.stumeet.server.notification.adapter.out.persistence.entity.TopicSubscriptionJpaEntity;
 
 public interface JpaTopicSubscriptionRepository extends JpaRepository<TopicSubscriptionJpaEntity, Long> {
+    boolean existsByMemberIdAndTopicId(Long memberId, Long topicId);
+
     void deleteByMemberIdAndTopicId(Long memberId, Long topicId);
 }

--- a/src/main/java/com/stumeet/server/notification/adapter/out/persistence/TopicPersistenceAdapter.java
+++ b/src/main/java/com/stumeet/server/notification/adapter/out/persistence/TopicPersistenceAdapter.java
@@ -23,7 +23,7 @@ public class TopicPersistenceAdapter implements SaveTopicPort, TopicQueryPort, T
     private final TopicPersistenceMapper topicPersistenceMapper;
 
     @Override
-    public Topic findById(Long id) {
+    public Topic getById(Long id) {
         TopicJpaEntity entity = jpaTopicRepository.findById(id)
             .orElseThrow(() -> new NotExistsTopicException(id));
 
@@ -31,9 +31,9 @@ public class TopicPersistenceAdapter implements SaveTopicPort, TopicQueryPort, T
     }
 
     @Override
-    public Topic findStudyNoticeTopic(Long studyId) {
-        TopicJpaEntity entity = jpaTopicRepository.findByTypeAndReferId(TopicType.STUDY_NOTICE, studyId)
-            .orElseThrow(() -> new NotExistsStudyNoticeTopicException(studyId));
+    public Topic getByTypeAndReferId(TopicType type, Long referId) {
+        TopicJpaEntity entity = jpaTopicRepository.findByTypeAndReferId(type, referId)
+            .orElseThrow(() -> new NotExistsStudyNoticeTopicException(referId));
 
         return topicPersistenceMapper.toDomain(entity);
     }

--- a/src/main/java/com/stumeet/server/notification/adapter/out/persistence/TopicSubscriptionPersistenceAdapter.java
+++ b/src/main/java/com/stumeet/server/notification/adapter/out/persistence/TopicSubscriptionPersistenceAdapter.java
@@ -5,16 +5,23 @@ import com.stumeet.server.notification.adapter.out.mapper.TopicSubscriptionPersi
 import com.stumeet.server.notification.adapter.out.persistence.entity.TopicSubscriptionJpaEntity;
 import com.stumeet.server.notification.application.port.out.DeleteTopicSubscriptionPort;
 import com.stumeet.server.notification.application.port.out.SaveTopicSubscriptionPort;
+import com.stumeet.server.notification.application.port.out.TopicSubscriptionQueryPort;
 import com.stumeet.server.notification.domain.TopicSubscription;
 
 import lombok.RequiredArgsConstructor;
 
 @PersistenceAdapter
 @RequiredArgsConstructor
-public class TopicSubscriptionPersistenceAdapter implements SaveTopicSubscriptionPort, DeleteTopicSubscriptionPort {
+public class TopicSubscriptionPersistenceAdapter
+    implements TopicSubscriptionQueryPort, SaveTopicSubscriptionPort, DeleteTopicSubscriptionPort {
 
     private final JpaTopicSubscriptionRepository jpaTopicSubscriptionRepository;
     private final TopicSubscriptionPersistenceMapper topicSubscriptionPersistenceMapper;
+
+    @Override
+    public boolean isExists(Long memberId, Long topicId) {
+        return jpaTopicSubscriptionRepository.existsByMemberIdAndTopicId(memberId, topicId);
+    }
 
     @Override
     public void save(TopicSubscription topicSubscription) {

--- a/src/main/java/com/stumeet/server/notification/adapter/out/persistence/TopicSubscriptionPersistenceAdapter.java
+++ b/src/main/java/com/stumeet/server/notification/adapter/out/persistence/TopicSubscriptionPersistenceAdapter.java
@@ -1,5 +1,7 @@
 package com.stumeet.server.notification.adapter.out.persistence;
 
+import java.util.List;
+
 import com.stumeet.server.common.annotation.PersistenceAdapter;
 import com.stumeet.server.notification.adapter.out.mapper.TopicSubscriptionPersistenceMapper;
 import com.stumeet.server.notification.adapter.out.persistence.entity.TopicSubscriptionJpaEntity;
@@ -17,6 +19,13 @@ public class TopicSubscriptionPersistenceAdapter
 
     private final JpaTopicSubscriptionRepository jpaTopicSubscriptionRepository;
     private final TopicSubscriptionPersistenceMapper topicSubscriptionPersistenceMapper;
+
+    @Override
+    public List<TopicSubscription> getAllForMember(Long memberId) {
+        return topicSubscriptionPersistenceMapper.toDomains(
+            jpaTopicSubscriptionRepository.findAllByMemberId(memberId)
+        );
+    }
 
     @Override
     public boolean isExists(Long memberId, Long topicId) {

--- a/src/main/java/com/stumeet/server/notification/application/port/in/ManageSubscriptionUseCase.java
+++ b/src/main/java/com/stumeet/server/notification/application/port/in/ManageSubscriptionUseCase.java
@@ -1,8 +1,12 @@
 package com.stumeet.server.notification.application.port.in;
 
+import com.stumeet.server.notification.domain.Device;
+
 public interface ManageSubscriptionUseCase {
 
     void subscribeStudyNoticeTopic(Long memberId, Long studyId);
 
     void unsubscribeStudyNoticeTopic(Long memberId, Long studyId);
+
+    void renewSubscription(Device device);
 }

--- a/src/main/java/com/stumeet/server/notification/application/port/out/TopicQueryPort.java
+++ b/src/main/java/com/stumeet/server/notification/application/port/out/TopicQueryPort.java
@@ -1,10 +1,11 @@
 package com.stumeet.server.notification.application.port.out;
 
 import com.stumeet.server.notification.domain.Topic;
+import com.stumeet.server.notification.domain.TopicType;
 
 public interface TopicQueryPort {
 
-    Topic findById(Long id);
+    Topic getById(Long id);
 
-    Topic findStudyNoticeTopic(Long studyId);
+    Topic getByTypeAndReferId(TopicType type, Long referId);
 }

--- a/src/main/java/com/stumeet/server/notification/application/port/out/TopicSubscriptionQueryPort.java
+++ b/src/main/java/com/stumeet/server/notification/application/port/out/TopicSubscriptionQueryPort.java
@@ -1,5 +1,11 @@
 package com.stumeet.server.notification.application.port.out;
 
+import java.util.List;
+
+import com.stumeet.server.notification.domain.TopicSubscription;
+
 public interface TopicSubscriptionQueryPort {
+    List<TopicSubscription> getAllForMember(Long memberId);
+
     boolean isExists(Long memberId, Long topicId);
 }

--- a/src/main/java/com/stumeet/server/notification/application/port/out/TopicSubscriptionQueryPort.java
+++ b/src/main/java/com/stumeet/server/notification/application/port/out/TopicSubscriptionQueryPort.java
@@ -1,0 +1,5 @@
+package com.stumeet.server.notification.application.port.out;
+
+public interface TopicSubscriptionQueryPort {
+    boolean isExists(Long memberId, Long topicId);
+}

--- a/src/main/java/com/stumeet/server/notification/application/service/ManageTopicService.java
+++ b/src/main/java/com/stumeet/server/notification/application/service/ManageTopicService.java
@@ -63,4 +63,15 @@ public class ManageTopicService implements ManageSubscriptionUseCase {
         UnsubscribeCommand unsubscribeCommand = new UnsubscribeCommand(tokens, topic.getName());
         manageSubscriptionPort.unsubscribe(unsubscribeCommand);
     }
+
+    @Override
+    public void renewSubscription(Device device) {
+        List<TopicSubscription> subscriptions = topicSubscriptionQueryPort.getAllForMember(device.getMemberId());
+        List<String> tokens = List.of(device.getNotificationToken());
+
+        subscriptions.parallelStream()
+            .forEach(subscription -> manageSubscriptionPort.subscribe(
+                new SubscribeCommand(tokens, subscription.getTopic().getName())
+            ));
+    }
 }

--- a/src/main/java/com/stumeet/server/notification/application/service/ManageTopicService.java
+++ b/src/main/java/com/stumeet/server/notification/application/service/ManageTopicService.java
@@ -11,11 +11,13 @@ import com.stumeet.server.notification.application.port.out.ManageSubscriptionPo
 import com.stumeet.server.notification.application.port.out.DeviceQueryPort;
 import com.stumeet.server.notification.application.port.out.SaveTopicSubscriptionPort;
 import com.stumeet.server.notification.application.port.out.TopicQueryPort;
+import com.stumeet.server.notification.application.port.out.TopicSubscriptionQueryPort;
 import com.stumeet.server.notification.application.port.out.command.SubscribeCommand;
 import com.stumeet.server.notification.application.port.out.command.UnsubscribeCommand;
 import com.stumeet.server.notification.domain.Device;
 import com.stumeet.server.notification.domain.Topic;
 import com.stumeet.server.notification.domain.TopicSubscription;
+import com.stumeet.server.notification.domain.TopicType;
 
 import lombok.RequiredArgsConstructor;
 
@@ -25,6 +27,7 @@ import lombok.RequiredArgsConstructor;
 public class ManageTopicService implements ManageSubscriptionUseCase {
 
     private final TopicQueryPort topicQueryPort;
+    private final TopicSubscriptionQueryPort topicSubscriptionQueryPort;
     private final DeviceQueryPort deviceQueryPort;
 
     private final SaveTopicSubscriptionPort saveTopicSubscriptionPort;
@@ -33,9 +36,12 @@ public class ManageTopicService implements ManageSubscriptionUseCase {
 
     @Override
     public void subscribeStudyNoticeTopic(Long memberId, Long studyId) {
-        Topic topic = topicQueryPort.findStudyNoticeTopic(studyId);
-        TopicSubscription topicSubscription = TopicSubscription.create(topic, memberId);
-        saveTopicSubscriptionPort.save(topicSubscription);
+        Topic topic = topicQueryPort.getByTypeAndReferId(TopicType.STUDY_NOTICE, studyId);
+
+        if (!topicSubscriptionQueryPort.isExists(memberId, topic.getId())) {
+            TopicSubscription topicSubscription = TopicSubscription.create(topic, memberId);
+            saveTopicSubscriptionPort.save(topicSubscription);
+        }
 
         List<String> tokens = deviceQueryPort.findDevicesForMember(memberId)
             .stream().map(Device::getNotificationToken)
@@ -47,7 +53,7 @@ public class ManageTopicService implements ManageSubscriptionUseCase {
 
     @Override
     public void unsubscribeStudyNoticeTopic(Long memberId, Long studyId) {
-        Topic topic = topicQueryPort.findStudyNoticeTopic(studyId);
+        Topic topic = topicQueryPort.getByTypeAndReferId(TopicType.STUDY_NOTICE, studyId);
         deleteTopicSubscriptionPort.delete(memberId, topic.getId());
 
         List<String> tokens = deviceQueryPort.findDevicesForMember(memberId)

--- a/src/main/java/com/stumeet/server/notification/application/service/NotificationSendService.java
+++ b/src/main/java/com/stumeet/server/notification/application/service/NotificationSendService.java
@@ -10,6 +10,7 @@ import com.stumeet.server.notification.application.port.out.NotificationSendPort
 import com.stumeet.server.notification.application.port.out.TopicQueryPort;
 import com.stumeet.server.notification.application.port.out.command.SendMessageCommand;
 import com.stumeet.server.notification.domain.Topic;
+import com.stumeet.server.notification.domain.TopicType;
 import com.stumeet.server.study.application.port.in.StudyQueryUseCase;
 
 import lombok.RequiredArgsConstructor;
@@ -30,7 +31,7 @@ public class NotificationSendService implements StudyNoticeSendUseCase {
     @Override
     public void sendStudyNotice(Long studyId, Long activityId) {
         String studyName = studyQueryUseCase.getStudyName(studyId);
-        Topic topic = topicQueryPort.findStudyNoticeTopic(studyId);
+        Topic topic = topicQueryPort.getByTypeAndReferId(TopicType.STUDY_NOTICE, studyId);
 
         Map<String, String> data = Map.of(
             STUDY_ID, Long.toString(studyId),

--- a/src/main/java/com/stumeet/server/notification/application/service/RenewNotificationTokenService.java
+++ b/src/main/java/com/stumeet/server/notification/application/service/RenewNotificationTokenService.java
@@ -1,6 +1,7 @@
 package com.stumeet.server.notification.application.service;
 
 import com.stumeet.server.common.annotation.UseCase;
+import com.stumeet.server.notification.application.port.in.ManageSubscriptionUseCase;
 import com.stumeet.server.notification.application.port.in.RenewNotificationTokenUseCase;
 import com.stumeet.server.notification.application.port.in.command.RenewNotificationTokenCommand;
 import com.stumeet.server.notification.application.port.out.DeviceQueryPort;
@@ -13,6 +14,8 @@ import lombok.RequiredArgsConstructor;
 @UseCase
 @RequiredArgsConstructor
 public class RenewNotificationTokenService implements RenewNotificationTokenUseCase {
+
+    private final ManageSubscriptionUseCase manageSubscriptionUseCase;
 
     private final DeviceQueryPort deviceQueryPort;
     private final SaveDevicePort saveDevicePort;
@@ -31,7 +34,8 @@ public class RenewNotificationTokenService implements RenewNotificationTokenUseC
                     .notificationToken(command.notificationToken())
                     .build();
         }
-
         saveDevicePort.save(device);
+
+        manageSubscriptionUseCase.renewSubscription(device);
     }
 }

--- a/src/main/java/com/stumeet/server/notification/application/service/RenewNotificationTokenService.java
+++ b/src/main/java/com/stumeet/server/notification/application/service/RenewNotificationTokenService.java
@@ -33,9 +33,9 @@ public class RenewNotificationTokenService implements RenewNotificationTokenUseC
                     .deviceId(command.deviceId())
                     .notificationToken(command.notificationToken())
                     .build();
+
+            manageSubscriptionUseCase.renewSubscription(device);
         }
         saveDevicePort.save(device);
-
-        manageSubscriptionUseCase.renewSubscription(device);
     }
 }

--- a/src/main/java/com/stumeet/server/notification/domain/TopicSubscription.java
+++ b/src/main/java/com/stumeet/server/notification/domain/TopicSubscription.java
@@ -2,12 +2,13 @@ package com.stumeet.server.notification.domain;
 
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NonNull;
 
 @Getter
 public class TopicSubscription {
 
     private Long id;
-    private Topic topic;
+    @NonNull private Topic topic;
     private Long memberId;
 
     @Builder


### PR DESCRIPTION
## 💁 해결 하려는 문제를 적어주세요 

기존에는 특정 기능(스터디 가입, 탈퇴 등)을 수행할 때 저장된 토큰을 사용하여 토픽을 구독했으나, 토큰이 갱신되는 경우 FCM 구독 정보가 최신 상태로 유지되지 않는 문제가 발생했습니다.

## 🤔 어떤 방식으로 해결했는지 적어주세요 

토큰 갱신 API를 호출할 때 새로운 토큰으로 FCM의 토픽 구독을 요청하여 토픽 구독 정보를 갱신하는 로직을 추가했습니다.
