### PR TITLE
:necktie: [STMT-264] 멤버 활동 상태 변경 API의 요청에서 조회 API에서 제공하지 않는 memberId 제거

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -865,10 +865,6 @@ include::{snippets}/update-activity-participant-status/fail/activity-is-default/
 include::{snippets}/update-activity-participant-status/fail/member-is-not-admin/response-body.adoc[]
 include::{snippets}/update-activity-participant-status/fail/member-is-not-admin/response-fields.adoc[]
 
-.상태 변경되는 멤버가 스터디의 멤버가 아닌 경우
-include::{snippets}/update-activity-participant-status/fail/member-is-not-joined-member/response-body.adoc[]
-include::{snippets}/update-activity-participant-status/fail/member-is-not-joined-member/response-fields.adoc[]
-
 ===== 응답 실패 (404)
 .요청한 스터디가 존재하지 않는 경우
 include::{snippets}/update-activity-participant-status/fail/study-not-found/response-body.adoc[]

--- a/src/main/java/com/stumeet/server/activity/adapter/in/ParticipantStatusUpdateApi.java
+++ b/src/main/java/com/stumeet/server/activity/adapter/in/ParticipantStatusUpdateApi.java
@@ -26,11 +26,10 @@ public class ParticipantStatusUpdateApi {
 
     private final ParticipantStatusUpdateUseCase participantStatusUpdateUseCase;
 
-    @PatchMapping("/studies/{studyId}/members/{memberId}/activities/{activityId}/status")
+    @PatchMapping("/studies/{studyId}/activities/{activityId}/status")
     public ResponseEntity<ApiResponse<Void>> updateStatus(
             @AuthenticationPrincipal LoginMember loginMember,
             @PathVariable Long studyId,
-            @PathVariable Long memberId,
             @PathVariable Long activityId,
             @RequestBody @Valid ParticipantStatusUpdateRequest request
     ) {
@@ -38,7 +37,6 @@ public class ParticipantStatusUpdateApi {
                 .adminId(loginMember.getId())
                 .studyId(studyId)
                 .activityId(activityId)
-                .memberId(memberId)
                 .participantId(request.participantId())
                 .status(request.status())
                 .build();

--- a/src/main/java/com/stumeet/server/activity/adapter/out/persistence/ActivityParticipantPersistenceAdapter.java
+++ b/src/main/java/com/stumeet/server/activity/adapter/out/persistence/ActivityParticipantPersistenceAdapter.java
@@ -28,9 +28,9 @@ public class ActivityParticipantPersistenceAdapter implements ActivityParticipan
     }
 
     @Override
-    public ActivityParticipant findByActivityIdAndMemberIdAndId(Long activityId, Long memberId, Long participantId) {
+    public ActivityParticipant findByIdAndActivityId(Long participantId, Long activityId) {
         ActivityParticipantJpaEntity participant =
-                jpaActivityParticipantRepository.findByActivityIdAndMemberIdAndId(activityId, memberId, participantId)
+                jpaActivityParticipantRepository.findByActivityIdAndMemberIdAndId(activityId, participantId)
                         .orElseThrow(() -> new NotExistsActivityParticipantException(participantId));
 
         return activityParticipantPersistenceMapper.toDomain(participant);

--- a/src/main/java/com/stumeet/server/activity/adapter/out/persistence/ActivityParticipantPersistenceAdapter.java
+++ b/src/main/java/com/stumeet/server/activity/adapter/out/persistence/ActivityParticipantPersistenceAdapter.java
@@ -30,7 +30,7 @@ public class ActivityParticipantPersistenceAdapter implements ActivityParticipan
     @Override
     public ActivityParticipant findByIdAndActivityId(Long participantId, Long activityId) {
         ActivityParticipantJpaEntity participant =
-                jpaActivityParticipantRepository.findByActivityIdAndMemberIdAndId(activityId, participantId)
+                jpaActivityParticipantRepository.findByIdAndActivityId(participantId, activityId)
                         .orElseThrow(() -> new NotExistsActivityParticipantException(participantId));
 
         return activityParticipantPersistenceMapper.toDomain(participant);

--- a/src/main/java/com/stumeet/server/activity/adapter/out/persistence/JpaActivityParticipantRepository.java
+++ b/src/main/java/com/stumeet/server/activity/adapter/out/persistence/JpaActivityParticipantRepository.java
@@ -8,7 +8,7 @@ import java.util.Optional;
 
 public interface JpaActivityParticipantRepository extends JpaRepository<ActivityParticipantJpaEntity, Long> {
 
-    Optional<ActivityParticipantJpaEntity> findByActivityIdAndMemberIdAndId(Long activityId, Long memberId, Long id);
+    Optional<ActivityParticipantJpaEntity> findByIdAndActivityId(Long id, Long activityId);
 
     List<ActivityParticipantJpaEntity> findAllByActivityId(Long activityId);
 

--- a/src/main/java/com/stumeet/server/activity/application/port/in/command/ParticipantStatusUpdateCommand.java
+++ b/src/main/java/com/stumeet/server/activity/application/port/in/command/ParticipantStatusUpdateCommand.java
@@ -8,13 +8,12 @@ public record ParticipantStatusUpdateCommand(
         Long adminId,
         Long studyId,
         Long activityId,
-        Long memberId,
         Long participantId,
         ActivityStatus status
 ) {
 
     @Builder
-    public ParticipantStatusUpdateCommand(Long adminId, Long studyId, Long activityId, Long memberId, Long participantId, String status) {
-        this(adminId, studyId, activityId, memberId, participantId, ActivityStatus.findByStatus(status));
+    public ParticipantStatusUpdateCommand(Long adminId, Long studyId, Long activityId, Long participantId, String status) {
+        this(adminId, studyId, activityId, participantId, ActivityStatus.findByStatus(status));
     }
 }

--- a/src/main/java/com/stumeet/server/activity/application/port/out/ActivityParticipantQueryPort.java
+++ b/src/main/java/com/stumeet/server/activity/application/port/out/ActivityParticipantQueryPort.java
@@ -6,7 +6,7 @@ import java.util.List;
 
 public interface ActivityParticipantQueryPort {
 
-    ActivityParticipant findByActivityIdAndMemberIdAndId(Long activityId, Long memberId, Long id);
+    ActivityParticipant findByIdAndActivityId(Long id, Long activityId);
 
     List<ActivityParticipant> findAllByActivityId(Long activityId);
 

--- a/src/main/java/com/stumeet/server/activity/application/service/ParticipantStatusUpdateService.java
+++ b/src/main/java/com/stumeet/server/activity/application/service/ParticipantStatusUpdateService.java
@@ -34,15 +34,15 @@ public class ParticipantStatusUpdateService implements ParticipantStatusUpdateUs
     public void updateStatus(ParticipantStatusUpdateCommand command) {
         studyValidationUseCase.checkById(command.studyId());
         studyMemberValidationUseCase.checkAdmin(command.studyId(), command.adminId());
-        studyMemberValidationUseCase.checkStudyJoinMember(command.studyId(), command.memberId());
 
         Activity activity = activityQueryPort.getByStudyIdAndId(command.studyId(), command.activityId());
         validateActivityCategory(activity);
         activity.getCategory().validateStatus(command.status());
 
-        ActivityParticipant participant = activityParticipantQueryPort.findByActivityIdAndMemberIdAndId(command.activityId(), command.memberId(), command.participantId());
-        ActivityParticipant updated = participant.update(command.status());
+        ActivityParticipant participant = activityParticipantQueryPort.findByIdAndActivityId(command.participantId(), command.activityId());
+        studyMemberValidationUseCase.checkStudyJoinMember(command.studyId(), participant.getMember().getId());
 
+        ActivityParticipant updated = participant.update(command.status());
         activityParticipantCommandPort.update(updated);
     }
 

--- a/src/main/java/com/stumeet/server/activity/application/service/ParticipantStatusUpdateService.java
+++ b/src/main/java/com/stumeet/server/activity/application/service/ParticipantStatusUpdateService.java
@@ -40,8 +40,6 @@ public class ParticipantStatusUpdateService implements ParticipantStatusUpdateUs
         activity.getCategory().validateStatus(command.status());
 
         ActivityParticipant participant = activityParticipantQueryPort.findByIdAndActivityId(command.participantId(), command.activityId());
-        studyMemberValidationUseCase.checkStudyJoinMember(command.studyId(), participant.getMember().getId());
-
         ActivityParticipant updated = participant.update(command.status());
         activityParticipantCommandPort.update(updated);
     }

--- a/src/test/java/com/stumeet/server/activity/adapter/in/ParticipantStatusUpdateApiTest.java
+++ b/src/test/java/com/stumeet/server/activity/adapter/in/ParticipantStatusUpdateApiTest.java
@@ -25,10 +25,10 @@ import com.stumeet.server.template.ApiTest;
 class ParticipantStatusUpdateApiTest extends ApiTest {
 
     @Nested
-    @DisplayName("활동 수정 API")
+    @DisplayName("멤버 활동 상태 수정 API")
     class UpdateActivity {
 
-        private final String path = "/api/v1/studies/{studyId}/members/{memberId}/activities/{activityId}/status";
+        private final String path = "/api/v1/studies/{studyId}/activities/{activityId}/status";
 
         @Test
         @WithMockMember
@@ -36,7 +36,7 @@ class ParticipantStatusUpdateApiTest extends ApiTest {
         void success() throws Exception {
             ParticipantStatusUpdateRequest request = ActivityParticipantStub.getParticipantStatusUpdateRequest();
 
-            mockMvc.perform(patch(path, StudyStub.getStudyId(), 2L, ActivityStub.getMeetActivityId())
+            mockMvc.perform(patch(path, StudyStub.getStudyId(), ActivityStub.getMeetActivityId())
                             .header(AuthenticationHeader.ACCESS_TOKEN.getName(), TokenStub.getMockAccessToken())
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(toJson(request)))
@@ -50,7 +50,6 @@ class ParticipantStatusUpdateApiTest extends ApiTest {
                             ),
                             pathParameters(
                                     parameterWithName("studyId").description("스터디 ID"),
-                                    parameterWithName("memberId").description("멤버 ID"),
                                     parameterWithName("activityId").description("활동 ID")
                             ),
                             requestFields(
@@ -72,7 +71,7 @@ class ParticipantStatusUpdateApiTest extends ApiTest {
                     .status("HELLO")
                     .build();
 
-            mockMvc.perform(patch(path, StudyStub.getStudyId(), 2L, ActivityStub.getMeetActivityId())
+            mockMvc.perform(patch(path, StudyStub.getStudyId(), ActivityStub.getMeetActivityId())
                             .header(AuthenticationHeader.ACCESS_TOKEN.getName(), TokenStub.getMockAccessToken())
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(toJson(request)))
@@ -86,7 +85,6 @@ class ParticipantStatusUpdateApiTest extends ApiTest {
                             ),
                             pathParameters(
                                     parameterWithName("studyId").description("스터디 ID"),
-                                    parameterWithName("memberId").description("멤버 ID"),
                                     parameterWithName("activityId").description("활동 ID")
                             ),
                             requestFields(
@@ -105,7 +103,7 @@ class ParticipantStatusUpdateApiTest extends ApiTest {
         void fail_when_study_not_found() throws Exception {
             ParticipantStatusUpdateRequest request = ActivityParticipantStub.getParticipantStatusUpdateRequest();
 
-            mockMvc.perform(patch(path, StudyStub.getInvalidStudyId(), 2L, ActivityStub.getMeetActivityId())
+            mockMvc.perform(patch(path, StudyStub.getInvalidStudyId(), ActivityStub.getMeetActivityId())
                             .header(AuthenticationHeader.ACCESS_TOKEN.getName(), TokenStub.getMockAccessToken())
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(toJson(request)))
@@ -119,7 +117,6 @@ class ParticipantStatusUpdateApiTest extends ApiTest {
                             ),
                             pathParameters(
                                     parameterWithName("studyId").description("스터디 ID"),
-                                    parameterWithName("memberId").description("멤버 ID"),
                                     parameterWithName("activityId").description("활동 ID")
                             ),
                             requestFields(
@@ -138,7 +135,7 @@ class ParticipantStatusUpdateApiTest extends ApiTest {
         void fail_when_member_is_not_admin() throws Exception {
             ParticipantStatusUpdateRequest request = ActivityParticipantStub.getParticipantStatusUpdateRequest();
 
-            mockMvc.perform(patch(path, StudyStub.getStudyId(), 2L, ActivityStub.getMeetActivityId())
+            mockMvc.perform(patch(path, StudyStub.getStudyId(), ActivityStub.getMeetActivityId())
                             .header(AuthenticationHeader.ACCESS_TOKEN.getName(), TokenStub.getMockAccessToken())
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(toJson(request)))
@@ -152,40 +149,6 @@ class ParticipantStatusUpdateApiTest extends ApiTest {
                             ),
                             pathParameters(
                                     parameterWithName("studyId").description("스터디 ID"),
-                                    parameterWithName("memberId").description("멤버 ID"),
-                                    parameterWithName("activityId").description("활동 ID")
-                            ),
-                            requestFields(
-                                    fieldWithPath("participantId").description("참가자 ID"),
-                                    fieldWithPath("status").description("활동 멤버 상태")
-                            ),
-                            responseFields(
-                                    fieldWithPath("code").description("응답 상태"),
-                                    fieldWithPath("message").description("응답 메시지")
-                            )));
-        }
-
-        @Test
-        @WithMockMember
-        @DisplayName("[실패] 상태 변경되는 멤버가 스터디의 멤버가 아닌 경우 멤버의 활동 상태 수정에 실패한다.")
-        void fail_when_member_is_not_joined_member() throws Exception {
-            ParticipantStatusUpdateRequest request = ActivityParticipantStub.getParticipantStatusUpdateRequest();
-
-            mockMvc.perform(patch(path, StudyStub.getStudyId(), 3L, ActivityStub.getMeetActivityId())
-                            .header(AuthenticationHeader.ACCESS_TOKEN.getName(), TokenStub.getMockAccessToken())
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content(toJson(request)))
-                    .andExpect(status().isForbidden())
-                    .andDo(document("update-activity-participant-status/fail/member-is-not-joined-member",
-                            preprocessRequest(prettyPrint()),
-                            preprocessResponse(prettyPrint()),
-                            requestHeaders(
-                                    headerWithName(AuthenticationHeader.ACCESS_TOKEN.getName())
-                                            .description("서버로부터 전달받은 액세스 토큰")
-                            ),
-                            pathParameters(
-                                    parameterWithName("studyId").description("스터디 ID"),
-                                    parameterWithName("memberId").description("멤버 ID"),
                                     parameterWithName("activityId").description("활동 ID")
                             ),
                             requestFields(
@@ -204,7 +167,7 @@ class ParticipantStatusUpdateApiTest extends ApiTest {
         void fail_when_activity_category_default() throws Exception {
             ParticipantStatusUpdateRequest request = ActivityParticipantStub.getParticipantStatusUpdateRequest();
 
-            mockMvc.perform(patch(path, StudyStub.getStudyId(), 2L, ActivityStub.getDefaultActivity())
+            mockMvc.perform(patch(path, StudyStub.getStudyId(), ActivityStub.getDefaultActivity())
                             .header(AuthenticationHeader.ACCESS_TOKEN.getName(), TokenStub.getMockAccessToken())
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(toJson(request)))
@@ -218,7 +181,6 @@ class ParticipantStatusUpdateApiTest extends ApiTest {
                             ),
                             pathParameters(
                                     parameterWithName("studyId").description("스터디 ID"),
-                                    parameterWithName("memberId").description("멤버 ID"),
                                     parameterWithName("activityId").description("활동 ID")
                             ),
                             requestFields(


### PR DESCRIPTION
## 💁 해결 하려는 문제를 적어주세요 

- 멤버 활동 상태 변경 API에서 활동 멤버 조회 API에서 제공하지 않는 memberId를 사용하고 있었습니다.

## 🤔 어떤 방식으로 해결했는지 적어주세요 

- 클라이언트에서 요청을 원활하게 하도록 memberId를 요청에서 제거했습니다.