### PR TITLE
✨ [STMT-173] 포도알 칭찬 전송, 목록 조회 API 구현

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -975,7 +975,7 @@ include::{snippets}/register-review/success/request-fields.adoc[]
 | PINPOINT_TEACHER   | 쪽집게 강사
 |===
 
-===== 응답 성공 (200)
+===== 응답 성공 (201)
 include::{snippets}/register-review/success/response-body.adoc[]
 include::{snippets}/register-review/success/response-fields.adoc[]
 
@@ -1064,7 +1064,7 @@ include::{snippets}/send-grape-praise/success/request-headers.adoc[]
 ====== 요청 본문
 include::{snippets}/send-grape-praise/success/request-fields.adoc[]
 
-===== 응답 성공 (200)
+===== 응답 성공 (201)
 include::{snippets}/send-grape-praise/success/response-body.adoc[]
 include::{snippets}/send-grape-praise/success/response-fields.adoc[]
 
@@ -1086,6 +1086,24 @@ include::{snippets}/send-grape-praise/fail/sender_is_not_the_study_member/respon
 .전송자가 해당 스터디의 이미 이번주 포도알을 전송한 경우
 include::{snippets}/send-grape-praise/fail/sender_already_sent_grape/response-body.adoc[]
 include::{snippets}/send-grape-praise/fail/sender_already_sent_grape/response-fields.adoc[]
+
+=== 포도알 칭찬 목록 조회
+
+받은 포도알 칭찬 목록을 조회하는 API입니다.
+
+==== GET /api/v1/reviews/grapes
+===== 요청
+include::{snippets}/get-member-grapes/success/http-request.adoc[]
+
+====== 헤더
+include::{snippets}/get-member-grapes/success/request-headers.adoc[]
+
+====== 요청 매개 변수
+include::{snippets}/get-member-grapes/success/query-parameters.adoc[]
+
+===== 응답 성공 (200)
+include::{snippets}/get-member-grapes/success/response-body.adoc[]
+include::{snippets}/get-member-grapes/success/response-fields.adoc[]
 
 
 == 파일 관리

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -1050,6 +1050,43 @@ include::{snippets}/get-member-review-tags-stats/success/request-headers.adoc[]
 include::{snippets}/get-member-review-tags-stats/success/response-body.adoc[]
 include::{snippets}/get-member-review-tags-stats/success/response-fields.adoc[]
 
+=== 포도알 칭찬 전송
+
+같은 스터디원에게 포도알 칭찬을 전송하는 API입니다.
+
+==== GET /api/v1/reviews/grapes
+===== 요청
+include::{snippets}/send-grape-praise/success/http-request.adoc[]
+
+====== 헤더
+include::{snippets}/send-grape-praise/success/request-headers.adoc[]
+
+====== 요청 본문
+include::{snippets}/send-grape-praise/success/request-fields.adoc[]
+
+===== 응답 성공 (200)
+include::{snippets}/send-grape-praise/success/response-body.adoc[]
+include::{snippets}/send-grape-praise/success/response-fields.adoc[]
+
+===== 응답 실패 (400)
+.유효하지 않은 칭찬 타입으로 요청한 경우
+include::{snippets}/send-grape-praise/fail/invalid-compliment-type/response-body.adoc[]
+include::{snippets}/send-grape-praise/fail/invalid-compliment-type/response-fields.adoc[]
+
+===== 응답 실패 (404)
+.존재하지 않는 스터디 멤버 ID로 요청한 경우
+include::{snippets}/send-grape-praise/fail/study-member-not-found/response-body.adoc[]
+include::{snippets}/send-grape-praise/fail/study-member-not-found/response-fields.adoc[]
+
+.전송자가 해당 스터디의 스터디원이 아닌 경우
+include::{snippets}/send-grape-praise/fail/sender_is_not_the_study_member/response-body.adoc[]
+include::{snippets}/send-grape-praise/fail/sender_is_not_the_study_member/response-fields.adoc[]
+
+===== 응답 실패 (409)
+.전송자가 해당 스터디의 이미 이번주 포도알을 전송한 경우
+include::{snippets}/send-grape-praise/fail/sender_already_sent_grape/response-body.adoc[]
+include::{snippets}/send-grape-praise/fail/sender_already_sent_grape/response-fields.adoc[]
+
 
 == 파일 관리
 

--- a/src/main/java/com/stumeet/server/activity/adapter/out/event/handler/StudyNoticeNotificationHandler.java
+++ b/src/main/java/com/stumeet/server/activity/adapter/out/event/handler/StudyNoticeNotificationHandler.java
@@ -5,7 +5,7 @@ import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 
 import com.stumeet.server.activity.adapter.out.event.model.StudyNoticeNotificationEvent;
-import com.stumeet.server.notification.application.port.in.StudyNoticeSendUseCase;
+import com.stumeet.server.notification.application.port.in.SendStudyNoticeUseCase;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
@@ -15,12 +15,12 @@ import lombok.extern.log4j.Log4j2;
 @RequiredArgsConstructor
 public class StudyNoticeNotificationHandler {
 
-    private final StudyNoticeSendUseCase studyNoticeSendUseCase;
+    private final SendStudyNoticeUseCase sendStudyNoticeUseCase;
 
     @Async
     @EventListener(StudyNoticeNotificationEvent.class)
     public void sendNotification(StudyNoticeNotificationEvent event) {
         log.info(event.getMessage());
-        studyNoticeSendUseCase.sendStudyNotice(event.getStudyId(), event.getActivityId());
+        sendStudyNoticeUseCase.sendStudyNotice(event.getStudyId(), event.getActivityId());
     }
 }

--- a/src/main/java/com/stumeet/server/bff/adapter/in/app/StudyHubApi.java
+++ b/src/main/java/com/stumeet/server/bff/adapter/in/app/StudyHubApi.java
@@ -42,7 +42,7 @@ public class StudyHubApi {
                 .getFirst();
 
         boolean isAdmin = studyMemberQueryUseCase.isMemberAdmin(studyId, member.getId()).isAdmin();
-        boolean canSendGrape = studyMemberQueryUseCase.canStudyMemberSendGrape(studyId, member.getId()).canSendGrape();
+        boolean canSendGrape = studyMemberQueryUseCase.canSendGrape(studyId, member.getId());
 
         StudyDetailFullResponse response = new StudyDetailFullResponse(
                 studyDetailResponse,

--- a/src/main/java/com/stumeet/server/bff/adapter/in/app/StudyMemberHubApi.java
+++ b/src/main/java/com/stumeet/server/bff/adapter/in/app/StudyMemberHubApi.java
@@ -31,7 +31,7 @@ public class StudyMemberHubApi {
     ) {
         StudyMemberDetailResponse studyMemberDetail = studyMemberQueryUseCase.getStudyMemberDetail(studyId, memberId, member.getId());
         boolean isAdmin = studyMemberQueryUseCase.isMemberAdmin(studyId, memberId).isAdmin();
-        boolean canSendGrape = studyMemberQueryUseCase.canStudyMemberSendGrape(studyId, memberId).canSendGrape();
+        boolean canSendGrape = studyMemberQueryUseCase.canSendGrape(studyId, memberId);
 
         StudyMemberDetailFullResponse response = new StudyMemberDetailFullResponse(
                 studyMemberDetail,

--- a/src/main/java/com/stumeet/server/common/exception/model/EnumValidationException.java
+++ b/src/main/java/com/stumeet/server/common/exception/model/EnumValidationException.java
@@ -1,0 +1,11 @@
+package com.stumeet.server.common.exception.model;
+
+import com.stumeet.server.common.response.ErrorCode;
+
+public class EnumValidationException extends BusinessException {
+    private static final String MESSAGE_TEMPLATE = "enum %s 검증 실패, 입력값: %s";
+
+    public <E extends Enum<E>> EnumValidationException(ErrorCode errorCode, Class<E> enumClass, String invalidValue) {
+        super(String.format(MESSAGE_TEMPLATE, enumClass.getSimpleName(), invalidValue), errorCode);
+    }
+}

--- a/src/main/java/com/stumeet/server/common/response/ErrorCode.java
+++ b/src/main/java/com/stumeet/server/common/response/ErrorCode.java
@@ -3,6 +3,7 @@ package com.stumeet.server.common.response;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+
 import org.springframework.http.HttpStatus;
 
 @Getter
@@ -10,8 +11,8 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
 
     /*
-      400 - BAD REQUEST
-  */
+        400 - BAD REQUEST
+    */
     VALIDATION_REQUEST_EXCEPTION(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
     BIND_EXCEPTION(HttpStatus.BAD_REQUEST, "요청 값을 바인딩하는 과정에서 오류가 발생하였습니다."),
     METHOD_ARGUMENT_NOT_VALID_EXCEPTION(HttpStatus.BAD_REQUEST, "요청 값이 검증되지 않은 값 입니다."),
@@ -19,7 +20,8 @@ public enum ErrorCode {
     INVALID_FORMAT_EXCEPTION(HttpStatus.BAD_REQUEST, "요청 값이 유효하지 않은 데이터입니다."),
     NOT_EXIST_EXCEPTION(HttpStatus.BAD_REQUEST, "요청으로 전달한 값이 존재하지 않습니다."),
     FILE_SIZE_LIMIT_EXCEEDED_EXCEPTION(HttpStatus.BAD_REQUEST, "첨부파일은 최대 5MB 까지 가능합니다."),
-    INVALID_PAGINATION_PARAMETERS_EXCEPTION(HttpStatus.BAD_REQUEST, "제공된 페이지네이션 매개변수가 유효하지 않습니다. 'page'와 'size' 매개변수를 함께 포함하거나 함께 생략해야 합니다."),
+    INVALID_PAGINATION_PARAMETERS_EXCEPTION(HttpStatus.BAD_REQUEST,
+        "제공된 페이지네이션 매개변수가 유효하지 않습니다. 'page'와 'size' 매개변수를 함께 포함하거나 함께 생략해야 합니다."),
 
     DUPLICATE_NICKNAME_EXCEPTION(HttpStatus.BAD_REQUEST, "닉네임이 중복되었습니다."),
     NOT_MATCHED_TOKEN_EXCEPTION(HttpStatus.BAD_REQUEST, "요청으로 전달한 토큰과 매칭되는 토큰이 없습니다."),
@@ -33,13 +35,14 @@ public enum ErrorCode {
 
     INVALID_PERIOD_EXCEPTION(HttpStatus.BAD_REQUEST, "종료일이 시작일보다 빠릅니다."),
     ACTIVITY_PERIOD_REQUIRED_EXCEPTION(HttpStatus.BAD_REQUEST, "모임, 과제 활동 생성 시 종료일과 시작일 값이 필수입니다."),
-    INVALID_ACTIVITY_CATEGORY_EXCEPTION(HttpStatus.BAD_REQUEST, "유효하지 않은 활동 카테고리입니다."),
     START_DATE_NOT_YET_EXCEPTION(HttpStatus.BAD_REQUEST, "시작일 전에 스터디를 완료할 수 없습니다."),
     LOCATION_REQUIRED_FOR_MEET_EXCEPTION(HttpStatus.BAD_REQUEST, "모임 활동 생성 시 장소 값이 필수입니다."),
     DEFAULT_ACTIVITY_STATUS_IMMUTABLE_EXCEPTION(HttpStatus.BAD_REQUEST, "자유 활동의 경우 참여자 상태를 수정할 수 없습니다."),
     INVALID_STATUS_FOR_ACTIVITY_CATEGORY(HttpStatus.BAD_REQUEST, "해당 활동 카테고리에 유효하지 않은 활동 상태입니다."),
     INVALID_REVIEW_TAG_COUNT_EXCEPTION(HttpStatus.BAD_REQUEST, "리뷰 태그 개수는 3개를 초과할 수 없습니다."),
 
+    INVALID_ACTIVITY_CATEGORY_EXCEPTION(HttpStatus.BAD_REQUEST, "유효하지 않은 활동 카테고리입니다."),
+    INVALID_COMPLIMENT_TYPE_EXCEPTION(HttpStatus.BAD_REQUEST, "유효하지 않은 칭찬 타입입니다."),
 
     /*
         401 - UNAUTHORIZED
@@ -49,22 +52,22 @@ public enum ErrorCode {
     JWT_TOKEN_PARSING_EXCEPTION(HttpStatus.UNAUTHORIZED, "JWT 토큰 파싱에 실패했습니다."),
     NOT_EXIST_OAUTH_PROVIDER(HttpStatus.UNAUTHORIZED, "존재하지 않는 OAuth 제공자입니다."),
 
-
     /*
-      403 - FORBIDDEN
+        403 - FORBIDDEN
     */
     ACCESS_DENIED_EXCEPTION(HttpStatus.FORBIDDEN, "유효하지 않은 요청입니다."),
     STUDY_MEMBER_NOT_JOINED_EXCEPTION(HttpStatus.FORBIDDEN, "스터디에 가입한 멤버가 아닙니다."),
     NOT_STUDY_ADMIN_EXCEPTION(HttpStatus.FORBIDDEN, "스터디 관리자가 아닙니다."),
     ALREADY_STUDY_JOIN_MEMBER_EXCEPTION(HttpStatus.FORBIDDEN, "스터디에 이미 가입한 사용자입니다."),
     ACTIVITY_MANAGEMENT_ACCESS_DENIED_EXCEPTION(HttpStatus.FORBIDDEN, "활동 관리 권한이 없습니다."),
-
+    SELF_GRAPE_PRAISE_FORBIDDEN_EXCEPTION(HttpStatus.FORBIDDEN, "자기 자신에게 포도알 칭찬을 할 수 없습니다."),
 
     /*
         404 - NOT FOUND
     */
     STUDY_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 스터디 입니다."),
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 멤버 입니다."),
+    STUDY_MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 스터디 멤버 입니다."),
     STUDY_FIELD_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 스터디 분야 입니다."),
     STUDY_STATUS_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 스터디 상태 입니다."),
     ACTIVITY_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 활동 입니다."),
@@ -76,7 +79,6 @@ public enum ErrorCode {
     TOPIC_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 토픽입니다."),
     STUDY_NOTICE_TOPIC_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 스터디의 공지 토픽이 존재하지 않습니다."),
 
-  
     /*
         409 - CONFLICT
      */
@@ -84,8 +86,8 @@ public enum ErrorCode {
     NOT_YET_FINISHED_STUDY(HttpStatus.CONFLICT, "완료되지 않은 스터디 입니다."),
     ALREADY_TOPIC_EXISTS(HttpStatus.CONFLICT, "요청한 알림 토픽이 이미 존재합니다."),
     ALREADY_STUDY_MEMBER_REVIEW_EXISTS(HttpStatus.CONFLICT, "이미 해당 유저에 대한 스터디 리뷰를 작성했습니다."),
+    ALREADY_SENT_GRAPE_ERROR(HttpStatus.CONFLICT, "이미 이번 주 포도알을 전송했습니다."),
 
-  
     /*
         500 - INTERNAL SERVER ERROR
     */
@@ -96,12 +98,10 @@ public enum ErrorCode {
 
     ASYNC_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "비동기 작업 중 에러가 발생했습니다."),
 
-  
     /*
         503 - SERVICE UNAVAILABLE
     */
-    EXTERNAL_SERVICE_UNAVAILABLE_ERROR(HttpStatus.SERVICE_UNAVAILABLE, "외부 서비스가 일시적으로 사용 불가능합니다. 잠시 후 다시 시도해 주세요.")
-    ;
+    EXTERNAL_SERVICE_UNAVAILABLE_ERROR(HttpStatus.SERVICE_UNAVAILABLE, "외부 서비스가 일시적으로 사용 불가능합니다. 잠시 후 다시 시도해 주세요.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/stumeet/server/notification/application/port/in/DeviceQueryUseCase.java
+++ b/src/main/java/com/stumeet/server/notification/application/port/in/DeviceQueryUseCase.java
@@ -1,0 +1,10 @@
+package com.stumeet.server.notification.application.port.in;
+
+import java.util.List;
+
+import com.stumeet.server.notification.domain.Device;
+
+public interface DeviceQueryUseCase {
+
+    List<Device> getMemberDevices(Long memberId);
+}

--- a/src/main/java/com/stumeet/server/notification/application/port/in/SendGrapePraiseAlertUseCase.java
+++ b/src/main/java/com/stumeet/server/notification/application/port/in/SendGrapePraiseAlertUseCase.java
@@ -1,0 +1,6 @@
+package com.stumeet.server.notification.application.port.in;
+
+public interface SendGrapePraiseAlertUseCase {
+
+    void sendGrapeAlert(Long studyId, Long memberId);
+}

--- a/src/main/java/com/stumeet/server/notification/application/port/in/SendStudyNoticeUseCase.java
+++ b/src/main/java/com/stumeet/server/notification/application/port/in/SendStudyNoticeUseCase.java
@@ -1,6 +1,6 @@
 package com.stumeet.server.notification.application.port.in;
 
-public interface StudyNoticeSendUseCase {
+public interface SendStudyNoticeUseCase {
 
     void sendStudyNotice(Long studyId, Long activityId);
 }

--- a/src/main/java/com/stumeet/server/notification/application/service/MemberDeviceQueryService.java
+++ b/src/main/java/com/stumeet/server/notification/application/service/MemberDeviceQueryService.java
@@ -1,0 +1,24 @@
+package com.stumeet.server.notification.application.service;
+
+import java.util.List;
+
+import org.springframework.transaction.annotation.Transactional;
+
+import com.stumeet.server.common.annotation.UseCase;
+import com.stumeet.server.notification.application.port.in.DeviceQueryUseCase;
+import com.stumeet.server.notification.application.port.out.DeviceQueryPort;
+import com.stumeet.server.notification.domain.Device;
+
+import lombok.RequiredArgsConstructor;
+
+@UseCase
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class MemberDeviceQueryService implements DeviceQueryUseCase {
+    private final DeviceQueryPort deviceQueryPort;
+
+    @Override
+    public List<Device> getMemberDevices(Long memberId) {
+        return deviceQueryPort.findDevicesForMember(memberId);
+    }
+}

--- a/src/main/java/com/stumeet/server/notification/application/service/SendNotificationService.java
+++ b/src/main/java/com/stumeet/server/notification/application/service/SendNotificationService.java
@@ -1,14 +1,18 @@
 package com.stumeet.server.notification.application.service;
 
+import java.util.List;
 import java.util.Map;
 
 import org.springframework.transaction.annotation.Transactional;
 
 import com.stumeet.server.common.annotation.UseCase;
-import com.stumeet.server.notification.application.port.in.StudyNoticeSendUseCase;
+import com.stumeet.server.notification.application.port.in.DeviceQueryUseCase;
+import com.stumeet.server.notification.application.port.in.SendGrapePraiseAlertUseCase;
+import com.stumeet.server.notification.application.port.in.SendStudyNoticeUseCase;
 import com.stumeet.server.notification.application.port.out.NotificationSendPort;
 import com.stumeet.server.notification.application.port.out.TopicQueryPort;
 import com.stumeet.server.notification.application.port.out.command.SendMessageCommand;
+import com.stumeet.server.notification.domain.Device;
 import com.stumeet.server.notification.domain.Topic;
 import com.stumeet.server.notification.domain.TopicType;
 import com.stumeet.server.study.application.port.in.StudyQueryUseCase;
@@ -18,12 +22,17 @@ import lombok.RequiredArgsConstructor;
 @UseCase
 @Transactional
 @RequiredArgsConstructor
-public class NotificationSendService implements StudyNoticeSendUseCase {
+public class SendNotificationService implements SendStudyNoticeUseCase, SendGrapePraiseAlertUseCase {
+    // template
     private static final String STUDY_NOTICE_BODY_TEMPLATE = "\"%s\" 에 새로운 공지가 올라왔어요!";
+    private static final String GRAPE_ALERT_BODY_TEMPLATE = "포도알 칭찬을 받았어요!";
+
+    // data key
     private static final String STUDY_ID = "studyId";
     private static final String ACTIVITY_ID = "activityId";
 
     private final StudyQueryUseCase studyQueryUseCase;
+    private final DeviceQueryUseCase deviceQueryUseCase;
 
     private final TopicQueryPort topicQueryPort;
     private final NotificationSendPort notificationSendPort;
@@ -47,5 +56,22 @@ public class NotificationSendService implements StudyNoticeSendUseCase {
             .build();
 
         notificationSendPort.sendTopicMessage(command);
+    }
+
+    @Override
+    public void sendGrapeAlert(Long studyId, Long memberId) {
+        String studyName = studyQueryUseCase.getStudyName(studyId);
+        List<String> tokens = deviceQueryUseCase.getMemberDevices(memberId).stream()
+            .map(Device::getNotificationToken)
+            .toList();
+
+        SendMessageCommand command = SendMessageCommand.builder()
+            .registrationTokens(tokens)
+            .title(studyName)
+            .body(GRAPE_ALERT_BODY_TEMPLATE)
+            .image(null)
+            .build();
+
+        notificationSendPort.sendTokenMulticastMessage(command);
     }
 }

--- a/src/main/java/com/stumeet/server/review/adapter/out/persistence/entity/ReviewJpaEntity.java
+++ b/src/main/java/com/stumeet/server/review/adapter/out/persistence/entity/ReviewJpaEntity.java
@@ -1,6 +1,5 @@
 package com.stumeet.server.review.adapter.out.persistence.entity;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
 import com.stumeet.server.common.model.BaseTimeEntity;

--- a/src/main/java/com/stumeet/server/review/application/port/out/GrapeQueryPort.java
+++ b/src/main/java/com/stumeet/server/review/application/port/out/GrapeQueryPort.java
@@ -1,0 +1,10 @@
+package com.stumeet.server.review.application.port.out;
+
+import org.springframework.data.domain.Page;
+
+import com.stumeet.server.studymember.domain.Grape;
+
+public interface GrapeQueryPort {
+
+    Page<Grape> findPageByMemberId(Long memberId, int page, int size);
+}

--- a/src/main/java/com/stumeet/server/review/application/port/out/GrapeSavePort.java
+++ b/src/main/java/com/stumeet/server/review/application/port/out/GrapeSavePort.java
@@ -1,0 +1,8 @@
+package com.stumeet.server.review.application.port.out;
+
+import com.stumeet.server.studymember.domain.Grape;
+
+public interface GrapeSavePort {
+
+    void save(Grape grape);
+}

--- a/src/main/java/com/stumeet/server/studymember/adapter/in/web/GrapePraiseSendApi.java
+++ b/src/main/java/com/stumeet/server/studymember/adapter/in/web/GrapePraiseSendApi.java
@@ -1,0 +1,43 @@
+package com.stumeet.server.studymember.adapter.in.web;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import com.stumeet.server.common.annotation.WebAdapter;
+import com.stumeet.server.common.auth.model.LoginMember;
+import com.stumeet.server.common.model.ApiResponse;
+import com.stumeet.server.common.response.SuccessCode;
+import com.stumeet.server.studymember.adapter.in.web.dto.GrapeSendRequest;
+import com.stumeet.server.studymember.application.port.in.GrapePraiseSendUseCase;
+import com.stumeet.server.studymember.application.port.in.command.GrapeSendCommand;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@WebAdapter
+@RequestMapping("/api/v1/reviews")
+@RequiredArgsConstructor
+public class GrapePraiseSendApi {
+    private final GrapePraiseSendUseCase grapePraiseSendUseCase;
+
+    @PostMapping("/grape")
+    public ResponseEntity<ApiResponse<Void>> sendGrape(
+        @AuthenticationPrincipal LoginMember member,
+        @RequestBody @Valid GrapeSendRequest request
+    ) {
+        GrapeSendCommand command = GrapeSendCommand.builder()
+            .senderMemberId(member.getId())
+            .studyMemberId(request.studyMemberId())
+            .complimentTypeName(request.complimentType())
+            .build();
+        grapePraiseSendUseCase.sendGrape(command);
+
+        return new ResponseEntity<>(
+            ApiResponse.success(SuccessCode.REVIEW_CREATE_SUCCESS),
+            HttpStatus.CREATED);
+    }
+}

--- a/src/main/java/com/stumeet/server/studymember/adapter/in/web/GrapeQueryApi.java
+++ b/src/main/java/com/stumeet/server/studymember/adapter/in/web/GrapeQueryApi.java
@@ -1,0 +1,41 @@
+package com.stumeet.server.studymember.adapter.in.web;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import com.stumeet.server.common.annotation.WebAdapter;
+import com.stumeet.server.common.auth.model.LoginMember;
+import com.stumeet.server.common.model.ApiResponse;
+import com.stumeet.server.common.response.SuccessCode;
+import com.stumeet.server.studymember.adapter.in.web.dto.GrapeResponses;
+import com.stumeet.server.studymember.application.port.in.MemberGrapeQueryUseCase;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.RequiredArgsConstructor;
+
+@WebAdapter
+@RequestMapping("/api/v1/reviews")
+@RequiredArgsConstructor
+@Validated
+public class GrapeQueryApi {
+    private final MemberGrapeQueryUseCase memberGrapeQueryUseCase;
+
+    @GetMapping("/grapes")
+    public ResponseEntity<ApiResponse<GrapeResponses>> getMemberGrapes(
+        @AuthenticationPrincipal LoginMember member,
+        @NotNull @RequestParam(defaultValue = "5") int size,
+        @NotNull @RequestParam(defaultValue = "0") int page
+    ) {
+        GrapeResponses response = memberGrapeQueryUseCase.findMemberGrapes(member.getId(), page, size);
+
+        return new ResponseEntity<>(
+            ApiResponse.success(SuccessCode.GET_SUCCESS, response),
+            HttpStatus.OK
+        );
+    }
+}

--- a/src/main/java/com/stumeet/server/studymember/adapter/in/web/StudyMemberQueryApi.java
+++ b/src/main/java/com/stumeet/server/studymember/adapter/in/web/StudyMemberQueryApi.java
@@ -67,7 +67,8 @@ public class StudyMemberQueryApi {
             @AuthenticationPrincipal LoginMember member,
             @PathVariable Long studyId
     ) {
-        StudyMemberGrapeResponse response = studyMemberQueryUseCase.canStudyMemberSendGrape(studyId, member.getId());
+        boolean canSendGrape = studyMemberQueryUseCase.canSendGrape(studyId, member.getId());
+        StudyMemberGrapeResponse response = new StudyMemberGrapeResponse(canSendGrape);
 
         return ResponseEntity.ok(
                 ApiResponse.success(SuccessCode.GET_SUCCESS, response)

--- a/src/main/java/com/stumeet/server/studymember/adapter/in/web/dto/GrapeResponse.java
+++ b/src/main/java/com/stumeet/server/studymember/adapter/in/web/dto/GrapeResponse.java
@@ -1,0 +1,14 @@
+package com.stumeet.server.studymember.adapter.in.web.dto;
+
+import java.time.LocalDateTime;
+
+import lombok.Builder;
+
+@Builder
+public record GrapeResponse(
+    Long id,
+    String studyName,
+    String compliment,
+    LocalDateTime createdAt
+) {
+}

--- a/src/main/java/com/stumeet/server/studymember/adapter/in/web/dto/GrapeResponses.java
+++ b/src/main/java/com/stumeet/server/studymember/adapter/in/web/dto/GrapeResponses.java
@@ -1,0 +1,14 @@
+package com.stumeet.server.studymember.adapter.in.web.dto;
+
+import java.util.List;
+
+import com.stumeet.server.common.model.PageInfoResponse;
+
+import lombok.Builder;
+
+@Builder
+public record GrapeResponses(
+    List<GrapeResponse> grapes,
+    PageInfoResponse pageInfo
+) {
+}

--- a/src/main/java/com/stumeet/server/studymember/adapter/in/web/dto/GrapeSendRequest.java
+++ b/src/main/java/com/stumeet/server/studymember/adapter/in/web/dto/GrapeSendRequest.java
@@ -1,0 +1,15 @@
+package com.stumeet.server.studymember.adapter.in.web.dto;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+
+@Builder
+public record GrapeSendRequest(
+    @NotNull
+    Long studyMemberId,
+
+    @NotEmpty
+    String complimentType
+) {
+}

--- a/src/main/java/com/stumeet/server/studymember/adapter/out/event/handler/GrapePraiseAlertHandler.java
+++ b/src/main/java/com/stumeet/server/studymember/adapter/out/event/handler/GrapePraiseAlertHandler.java
@@ -1,0 +1,26 @@
+package com.stumeet.server.studymember.adapter.out.event.handler;
+
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+import com.stumeet.server.notification.application.port.in.SendGrapePraiseAlertUseCase;
+import com.stumeet.server.studymember.adapter.out.event.model.GrapePraiseAlertEvent;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+
+@Log4j2
+@RequiredArgsConstructor
+@Component
+public class GrapePraiseAlertHandler {
+
+    private final SendGrapePraiseAlertUseCase sendGrapePraiseAlertUseCase;
+
+    @Async
+    @EventListener(GrapePraiseAlertEvent.class)
+    public void deleteActivityImage(GrapePraiseAlertEvent event) {
+        log.info(event.getMessage());
+        sendGrapePraiseAlertUseCase.sendGrapeAlert(event.getStudyId(), event.getMemberId());
+    }
+}

--- a/src/main/java/com/stumeet/server/studymember/adapter/out/event/model/GrapePraiseAlertEvent.java
+++ b/src/main/java/com/stumeet/server/studymember/adapter/out/event/model/GrapePraiseAlertEvent.java
@@ -1,0 +1,18 @@
+package com.stumeet.server.studymember.adapter.out.event.model;
+
+import com.stumeet.server.common.event.model.Event;
+
+import lombok.Getter;
+
+@Getter
+public class GrapePraiseAlertEvent extends Event {
+
+    private final Long studyId;
+    private final Long memberId;
+
+    public GrapePraiseAlertEvent(Object source, Long studyId, Long memberId) {
+        super(source, String.format("[포도알 칭찬 알림 발송] studyId: %d, memberId: %d", studyId, memberId));
+        this.studyId = studyId;
+        this.memberId = memberId;
+    }
+}

--- a/src/main/java/com/stumeet/server/studymember/adapter/out/persistence/AdminManagementAdapter.java
+++ b/src/main/java/com/stumeet/server/studymember/adapter/out/persistence/AdminManagementAdapter.java
@@ -1,6 +1,7 @@
 package com.stumeet.server.studymember.adapter.out.persistence;
 
 import com.stumeet.server.common.annotation.PersistenceAdapter;
+import com.stumeet.server.studymember.adapter.out.persistence.repository.JpaStudyMemberRepository;
 import com.stumeet.server.studymember.application.port.out.AdminManagementPort;
 
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/stumeet/server/studymember/adapter/out/persistence/GrapePersistenceAdapter.java
+++ b/src/main/java/com/stumeet/server/studymember/adapter/out/persistence/GrapePersistenceAdapter.java
@@ -1,6 +1,10 @@
 package com.stumeet.server.studymember.adapter.out.persistence;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+
 import com.stumeet.server.common.annotation.PersistenceAdapter;
+import com.stumeet.server.review.application.port.out.GrapeQueryPort;
 import com.stumeet.server.studymember.adapter.out.persistence.entity.GrapeJpaEntity;
 import com.stumeet.server.studymember.adapter.out.persistence.mapper.GrapePersistenceMapper;
 import com.stumeet.server.review.application.port.out.GrapeSavePort;
@@ -11,9 +15,15 @@ import lombok.RequiredArgsConstructor;
 
 @PersistenceAdapter
 @RequiredArgsConstructor
-public class GrapePersistenceAdapter implements GrapeSavePort {
+public class GrapePersistenceAdapter implements GrapeQueryPort, GrapeSavePort {
     private final JpaGrapeRepository jpaGrapeRepository;
     private final GrapePersistenceMapper grapePersistenceMapper;
+
+    @Override
+    public Page<Grape> findPageByMemberId(Long memberId, int page, int size) {
+        Page<GrapeJpaEntity> entities = jpaGrapeRepository.findAllByMemberIdOrderByCreatedAtDesc(memberId, PageRequest.of(page, size));
+        return grapePersistenceMapper.toDomains(entities);
+    }
 
     @Override
     public void save(Grape grape) {

--- a/src/main/java/com/stumeet/server/studymember/adapter/out/persistence/GrapePersistenceAdapter.java
+++ b/src/main/java/com/stumeet/server/studymember/adapter/out/persistence/GrapePersistenceAdapter.java
@@ -1,0 +1,23 @@
+package com.stumeet.server.studymember.adapter.out.persistence;
+
+import com.stumeet.server.common.annotation.PersistenceAdapter;
+import com.stumeet.server.studymember.adapter.out.persistence.entity.GrapeJpaEntity;
+import com.stumeet.server.studymember.adapter.out.persistence.mapper.GrapePersistenceMapper;
+import com.stumeet.server.review.application.port.out.GrapeSavePort;
+import com.stumeet.server.studymember.adapter.out.persistence.repository.JpaGrapeRepository;
+import com.stumeet.server.studymember.domain.Grape;
+
+import lombok.RequiredArgsConstructor;
+
+@PersistenceAdapter
+@RequiredArgsConstructor
+public class GrapePersistenceAdapter implements GrapeSavePort {
+    private final JpaGrapeRepository jpaGrapeRepository;
+    private final GrapePersistenceMapper grapePersistenceMapper;
+
+    @Override
+    public void save(Grape grape) {
+        GrapeJpaEntity entity = grapePersistenceMapper.toEntity(grape);
+        jpaGrapeRepository.save(entity);
+    }
+}

--- a/src/main/java/com/stumeet/server/studymember/adapter/out/persistence/StudyMemberLeavePersistenceAdapter.java
+++ b/src/main/java/com/stumeet/server/studymember/adapter/out/persistence/StudyMemberLeavePersistenceAdapter.java
@@ -1,6 +1,7 @@
 package com.stumeet.server.studymember.adapter.out.persistence;
 
 import com.stumeet.server.common.annotation.PersistenceAdapter;
+import com.stumeet.server.studymember.adapter.out.persistence.repository.JpaStudyMemberRepository;
 import com.stumeet.server.studymember.application.port.out.StudyMemberLeavePort;
 import lombok.RequiredArgsConstructor;
 

--- a/src/main/java/com/stumeet/server/studymember/adapter/out/persistence/StudyMemberPersistenceAdapter.java
+++ b/src/main/java/com/stumeet/server/studymember/adapter/out/persistence/StudyMemberPersistenceAdapter.java
@@ -1,21 +1,26 @@
 package com.stumeet.server.studymember.adapter.out.persistence;
 
 import com.stumeet.server.common.annotation.PersistenceAdapter;
+import com.stumeet.server.studymember.adapter.out.persistence.entity.StudyMemberJpaEntity;
 import com.stumeet.server.studymember.adapter.out.persistence.mapper.StudyMemberPersistenceMapper;
+import com.stumeet.server.studymember.adapter.out.persistence.repository.JpaStudyMemberRepository;
 import com.stumeet.server.studymember.application.port.in.response.SimpleStudyMemberResponse;
 import com.stumeet.server.studymember.application.port.out.StudyMemberJoinPort;
 import com.stumeet.server.studymember.application.port.out.StudyMemberQueryPort;
 import com.stumeet.server.studymember.application.port.out.StudyMemberUpdatePort;
 import com.stumeet.server.studymember.application.port.out.StudyMemberValidationPort;
 import com.stumeet.server.studymember.domain.StudyMember;
+import com.stumeet.server.studymember.domain.exception.StudyMemberNotExistException;
+
 import lombok.RequiredArgsConstructor;
 
 import java.util.List;
 
 @PersistenceAdapter
 @RequiredArgsConstructor
-public class StudyMemberPersistenceAdapter implements StudyMemberJoinPort, StudyMemberQueryPort, StudyMemberValidationPort,
-        StudyMemberUpdatePort {
+public class StudyMemberPersistenceAdapter
+    implements StudyMemberJoinPort, StudyMemberQueryPort, StudyMemberValidationPort,
+    StudyMemberUpdatePort {
 
     private final JpaStudyMemberRepository jpaStudyMemberRepository;
     private final StudyMemberPersistenceMapper studyMemberPersistenceMapper;
@@ -27,7 +32,16 @@ public class StudyMemberPersistenceAdapter implements StudyMemberJoinPort, Study
 
     @Override
     public StudyMember findStudyMember(Long studyId, Long memberId) {
-        StudyMemberJpaEntity entity = jpaStudyMemberRepository.findStudyMemberByStudyIdAndMemberId(studyId, memberId);
+        StudyMemberJpaEntity entity = jpaStudyMemberRepository.findStudyMemberByStudyIdAndMemberId(studyId, memberId)
+            .orElseThrow(() -> new StudyMemberNotExistException(memberId));
+
+        return studyMemberPersistenceMapper.toDomain(entity);
+    }
+
+    @Override
+    public StudyMember findStudyMember(Long studyMemberId) {
+        StudyMemberJpaEntity entity = jpaStudyMemberRepository.findById(studyMemberId)
+            .orElseThrow(() -> new StudyMemberNotExistException(studyMemberId));
 
         return studyMemberPersistenceMapper.toDomain(entity);
     }
@@ -46,6 +60,11 @@ public class StudyMemberPersistenceAdapter implements StudyMemberJoinPort, Study
     @Override
     public boolean isSentGrape(Long studyId, Long memberId) {
         return jpaStudyMemberRepository.isSentGrape(studyId, memberId);
+    }
+
+    @Override
+    public boolean isExist(Long id) {
+        return jpaStudyMemberRepository.existsById(id);
     }
 
     @Override

--- a/src/main/java/com/stumeet/server/studymember/adapter/out/persistence/entity/GrapeJpaEntity.java
+++ b/src/main/java/com/stumeet/server/studymember/adapter/out/persistence/entity/GrapeJpaEntity.java
@@ -1,0 +1,41 @@
+package com.stumeet.server.studymember.adapter.out.persistence.entity;
+
+import com.stumeet.server.common.model.BaseTimeEntity;
+import com.stumeet.server.studymember.domain.ComplimentType;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+@Getter
+@Table(name = "grape")
+public class GrapeJpaEntity extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long memberId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "studyId")
+    private LinkedStudyJpaEntity linkedStudy;
+
+    @Enumerated(EnumType.STRING)
+    private ComplimentType complimentType;
+}

--- a/src/main/java/com/stumeet/server/studymember/adapter/out/persistence/entity/JoinMemberJpaEntity.java
+++ b/src/main/java/com/stumeet/server/studymember/adapter/out/persistence/entity/JoinMemberJpaEntity.java
@@ -1,4 +1,4 @@
-package com.stumeet.server.studymember.adapter.out.persistence;
+package com.stumeet.server.studymember.adapter.out.persistence.entity;
 
 import jakarta.persistence.*;
 import lombok.*;

--- a/src/main/java/com/stumeet/server/studymember/adapter/out/persistence/entity/JoinMemberProfessionJpaEntity.java
+++ b/src/main/java/com/stumeet/server/studymember/adapter/out/persistence/entity/JoinMemberProfessionJpaEntity.java
@@ -1,20 +1,24 @@
-package com.stumeet.server.studymember.adapter.out.persistence;
+package com.stumeet.server.studymember.adapter.out.persistence.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.Comment;
 
 @Entity
-@Table(name = "study")
+@Table(name = "profession")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder
 @Getter
-public class JoinStudyJpaEntity {
+public class JoinMemberProfessionJpaEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Comment("참여 스터디 ID")
+    @Comment("스터디 참여 멤버의 분야 ID")
     private Long id;
+
+    @Column(name = "name", length = 20, nullable = false)
+    @Comment("이름")
+    private String name;
 
 }

--- a/src/main/java/com/stumeet/server/studymember/adapter/out/persistence/entity/JoinStudyJpaEntity.java
+++ b/src/main/java/com/stumeet/server/studymember/adapter/out/persistence/entity/JoinStudyJpaEntity.java
@@ -1,24 +1,20 @@
-package com.stumeet.server.studymember.adapter.out.persistence;
+package com.stumeet.server.studymember.adapter.out.persistence.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.Comment;
 
 @Entity
-@Table(name = "profession")
+@Table(name = "study")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder
 @Getter
-public class JoinMemberProfessionJpaEntity {
+public class JoinStudyJpaEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Comment("스터디 참여 멤버의 분야 ID")
+    @Comment("참여 스터디 ID")
     private Long id;
-
-    @Column(name = "name", length = 20, nullable = false)
-    @Comment("이름")
-    private String name;
 
 }

--- a/src/main/java/com/stumeet/server/studymember/adapter/out/persistence/entity/LinkedStudyJpaEntity.java
+++ b/src/main/java/com/stumeet/server/studymember/adapter/out/persistence/entity/LinkedStudyJpaEntity.java
@@ -1,0 +1,28 @@
+package com.stumeet.server.studymember.adapter.out.persistence.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+@Getter
+@Table(name = "study")
+public class LinkedStudyJpaEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "name")
+    private String name;
+}

--- a/src/main/java/com/stumeet/server/studymember/adapter/out/persistence/entity/StudyMemberJpaEntity.java
+++ b/src/main/java/com/stumeet/server/studymember/adapter/out/persistence/entity/StudyMemberJpaEntity.java
@@ -1,4 +1,4 @@
-package com.stumeet.server.studymember.adapter.out.persistence;
+package com.stumeet.server.studymember.adapter.out.persistence.entity;
 
 import com.stumeet.server.common.model.BaseTimeEntity;
 import jakarta.persistence.*;

--- a/src/main/java/com/stumeet/server/studymember/adapter/out/persistence/mapper/GrapePersistenceMapper.java
+++ b/src/main/java/com/stumeet/server/studymember/adapter/out/persistence/mapper/GrapePersistenceMapper.java
@@ -1,0 +1,23 @@
+package com.stumeet.server.studymember.adapter.out.persistence.mapper;
+
+import org.springframework.stereotype.Component;
+
+import com.stumeet.server.studymember.adapter.out.persistence.entity.GrapeJpaEntity;
+import com.stumeet.server.studymember.adapter.out.persistence.entity.LinkedStudyJpaEntity;
+import com.stumeet.server.studymember.domain.Grape;
+
+@Component
+public class GrapePersistenceMapper {
+
+    public GrapeJpaEntity toEntity(Grape grape) {
+        return GrapeJpaEntity.builder()
+            .id(grape.getId())
+            .memberId(grape.getMemberId())
+            .linkedStudy(LinkedStudyJpaEntity.builder()
+                .id(grape.getStudyId())
+                .name(grape.getStudyName())
+                .build())
+            .complimentType(grape.getComplimentType())
+            .build();
+    }
+}

--- a/src/main/java/com/stumeet/server/studymember/adapter/out/persistence/mapper/GrapePersistenceMapper.java
+++ b/src/main/java/com/stumeet/server/studymember/adapter/out/persistence/mapper/GrapePersistenceMapper.java
@@ -1,5 +1,6 @@
 package com.stumeet.server.studymember.adapter.out.persistence.mapper;
 
+import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Component;
 
 import com.stumeet.server.studymember.adapter.out.persistence.entity.GrapeJpaEntity;
@@ -9,15 +10,30 @@ import com.stumeet.server.studymember.domain.Grape;
 @Component
 public class GrapePersistenceMapper {
 
-    public GrapeJpaEntity toEntity(Grape grape) {
+    public GrapeJpaEntity toEntity(Grape domain) {
         return GrapeJpaEntity.builder()
-            .id(grape.getId())
-            .memberId(grape.getMemberId())
+            .id(domain.getId())
+            .memberId(domain.getMemberId())
             .linkedStudy(LinkedStudyJpaEntity.builder()
-                .id(grape.getStudyId())
-                .name(grape.getStudyName())
+                .id(domain.getStudyId())
+                .name(domain.getStudyName())
                 .build())
-            .complimentType(grape.getComplimentType())
+            .complimentType(domain.getComplimentType())
             .build();
+    }
+
+    public Grape toDomain(GrapeJpaEntity entity) {
+        return Grape.builder()
+            .id(entity.getId())
+            .memberId(entity.getMemberId())
+            .studyId(entity.getLinkedStudy().getId())
+            .studyName(entity.getLinkedStudy().getName())
+            .complimentType(entity.getComplimentType())
+            .createdAt(entity.getCreatedAt())
+            .build();
+    }
+
+    public Page<Grape> toDomains(Page<GrapeJpaEntity> entities) {
+        return entities.map(this::toDomain);
     }
 }

--- a/src/main/java/com/stumeet/server/studymember/adapter/out/persistence/mapper/JoinMemberPersistenceMapper.java
+++ b/src/main/java/com/stumeet/server/studymember/adapter/out/persistence/mapper/JoinMemberPersistenceMapper.java
@@ -1,6 +1,6 @@
 package com.stumeet.server.studymember.adapter.out.persistence.mapper;
 
-import com.stumeet.server.studymember.adapter.out.persistence.JoinMemberJpaEntity;
+import com.stumeet.server.studymember.adapter.out.persistence.entity.JoinMemberJpaEntity;
 import com.stumeet.server.studymember.domain.JoinMember;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;

--- a/src/main/java/com/stumeet/server/studymember/adapter/out/persistence/mapper/JoinMemberProfessionPersistenceMapper.java
+++ b/src/main/java/com/stumeet/server/studymember/adapter/out/persistence/mapper/JoinMemberProfessionPersistenceMapper.java
@@ -1,6 +1,6 @@
 package com.stumeet.server.studymember.adapter.out.persistence.mapper;
 
-import com.stumeet.server.studymember.adapter.out.persistence.JoinMemberProfessionJpaEntity;
+import com.stumeet.server.studymember.adapter.out.persistence.entity.JoinMemberProfessionJpaEntity;
 import com.stumeet.server.studymember.domain.JoinMemberProfession;
 import org.springframework.stereotype.Component;
 

--- a/src/main/java/com/stumeet/server/studymember/adapter/out/persistence/mapper/JoinStudyPersistenceMapper.java
+++ b/src/main/java/com/stumeet/server/studymember/adapter/out/persistence/mapper/JoinStudyPersistenceMapper.java
@@ -1,6 +1,6 @@
 package com.stumeet.server.studymember.adapter.out.persistence.mapper;
 
-import com.stumeet.server.studymember.adapter.out.persistence.JoinStudyJpaEntity;
+import com.stumeet.server.studymember.adapter.out.persistence.entity.JoinStudyJpaEntity;
 import com.stumeet.server.studymember.domain.JoinStudy;
 import org.springframework.stereotype.Component;
 

--- a/src/main/java/com/stumeet/server/studymember/adapter/out/persistence/mapper/StudyMemberPersistenceMapper.java
+++ b/src/main/java/com/stumeet/server/studymember/adapter/out/persistence/mapper/StudyMemberPersistenceMapper.java
@@ -1,6 +1,6 @@
 package com.stumeet.server.studymember.adapter.out.persistence.mapper;
 
-import com.stumeet.server.studymember.adapter.out.persistence.StudyMemberJpaEntity;
+import com.stumeet.server.studymember.adapter.out.persistence.entity.StudyMemberJpaEntity;
 import com.stumeet.server.studymember.domain.StudyMember;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;

--- a/src/main/java/com/stumeet/server/studymember/adapter/out/persistence/repository/JpaGrapeRepository.java
+++ b/src/main/java/com/stumeet/server/studymember/adapter/out/persistence/repository/JpaGrapeRepository.java
@@ -1,8 +1,12 @@
 package com.stumeet.server.studymember.adapter.out.persistence.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.stumeet.server.studymember.adapter.out.persistence.entity.GrapeJpaEntity;
 
 public interface JpaGrapeRepository extends JpaRepository<GrapeJpaEntity, Long> {
+
+    Page<GrapeJpaEntity> findAllByMemberIdOrderByCreatedAtDesc(Long memberId, Pageable pageable);
 }

--- a/src/main/java/com/stumeet/server/studymember/adapter/out/persistence/repository/JpaGrapeRepository.java
+++ b/src/main/java/com/stumeet/server/studymember/adapter/out/persistence/repository/JpaGrapeRepository.java
@@ -1,0 +1,8 @@
+package com.stumeet.server.studymember.adapter.out.persistence.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.stumeet.server.studymember.adapter.out.persistence.entity.GrapeJpaEntity;
+
+public interface JpaGrapeRepository extends JpaRepository<GrapeJpaEntity, Long> {
+}

--- a/src/main/java/com/stumeet/server/studymember/adapter/out/persistence/repository/JpaStudyMemberRepository.java
+++ b/src/main/java/com/stumeet/server/studymember/adapter/out/persistence/repository/JpaStudyMemberRepository.java
@@ -1,8 +1,10 @@
-package com.stumeet.server.studymember.adapter.out.persistence;
+package com.stumeet.server.studymember.adapter.out.persistence.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+
+import com.stumeet.server.studymember.adapter.out.persistence.entity.StudyMemberJpaEntity;
 
 public interface JpaStudyMemberRepository extends JpaRepository<StudyMemberJpaEntity, Long>, JpaStudyMemberRepositoryCustom {
     long countByStudyId(Long studyId);

--- a/src/main/java/com/stumeet/server/studymember/adapter/out/persistence/repository/JpaStudyMemberRepositoryCustom.java
+++ b/src/main/java/com/stumeet/server/studymember/adapter/out/persistence/repository/JpaStudyMemberRepositoryCustom.java
@@ -1,12 +1,14 @@
-package com.stumeet.server.studymember.adapter.out.persistence;
+package com.stumeet.server.studymember.adapter.out.persistence.repository;
 
+import com.stumeet.server.studymember.adapter.out.persistence.entity.StudyMemberJpaEntity;
 import com.stumeet.server.studymember.application.port.in.response.SimpleStudyMemberResponse;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface JpaStudyMemberRepositoryCustom {
 
-    StudyMemberJpaEntity findStudyMemberByStudyIdAndMemberId(Long studyId, Long memberId);
+    Optional<StudyMemberJpaEntity> findStudyMemberByStudyIdAndMemberId(Long studyId, Long memberId);
 
     List<SimpleStudyMemberResponse> findStudyMembersByStudyId(Long studyId);
 

--- a/src/main/java/com/stumeet/server/studymember/adapter/out/persistence/repository/JpaStudyMemberRepositoryCustomImpl.java
+++ b/src/main/java/com/stumeet/server/studymember/adapter/out/persistence/repository/JpaStudyMemberRepositoryCustomImpl.java
@@ -1,14 +1,16 @@
-package com.stumeet.server.studymember.adapter.out.persistence;
+package com.stumeet.server.studymember.adapter.out.persistence.repository;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.stumeet.server.studymember.adapter.out.persistence.entity.StudyMemberJpaEntity;
 import com.stumeet.server.studymember.application.port.in.response.QSimpleStudyMemberResponse;
 import com.stumeet.server.studymember.application.port.in.response.SimpleStudyMemberResponse;
 
 import lombok.RequiredArgsConstructor;
 
 import java.util.List;
+import java.util.Optional;
 
-import static com.stumeet.server.studymember.adapter.out.persistence.QStudyMemberJpaEntity.studyMemberJpaEntity;
+import static com.stumeet.server.studymember.adapter.out.persistence.entity.QStudyMemberJpaEntity.studyMemberJpaEntity;
 
 @RequiredArgsConstructor
 public class JpaStudyMemberRepositoryCustomImpl implements JpaStudyMemberRepositoryCustom {
@@ -16,16 +18,17 @@ public class JpaStudyMemberRepositoryCustomImpl implements JpaStudyMemberReposit
     private final JPAQueryFactory query;
 
     @Override
-    public StudyMemberJpaEntity findStudyMemberByStudyIdAndMemberId(Long studyId, Long memberId) {
+    public Optional<StudyMemberJpaEntity> findStudyMemberByStudyIdAndMemberId(Long studyId, Long memberId) {
         return query
-                .select(studyMemberJpaEntity)
-                .from(studyMemberJpaEntity)
-                .innerJoin(studyMemberJpaEntity.member)
-                .where(
-                        studyMemberJpaEntity.study.id.eq(studyId),
-                        studyMemberJpaEntity.member.id.eq(memberId)
-                )
-                .fetchOne();
+            .select(studyMemberJpaEntity)
+            .from(studyMemberJpaEntity)
+            .innerJoin(studyMemberJpaEntity.member)
+            .where(
+                studyMemberJpaEntity.study.id.eq(studyId),
+                studyMemberJpaEntity.member.id.eq(memberId)
+            )
+            .stream()
+            .findFirst();
     }
 
     @Override

--- a/src/main/java/com/stumeet/server/studymember/application/port/in/GrapePraiseSendUseCase.java
+++ b/src/main/java/com/stumeet/server/studymember/application/port/in/GrapePraiseSendUseCase.java
@@ -1,0 +1,8 @@
+package com.stumeet.server.studymember.application.port.in;
+
+import com.stumeet.server.studymember.application.port.in.command.GrapeSendCommand;
+
+public interface GrapePraiseSendUseCase {
+
+    void sendGrape(GrapeSendCommand command);
+}

--- a/src/main/java/com/stumeet/server/studymember/application/port/in/HandleGrapeStatusUseCase.java
+++ b/src/main/java/com/stumeet/server/studymember/application/port/in/HandleGrapeStatusUseCase.java
@@ -1,0 +1,7 @@
+package com.stumeet.server.studymember.application.port.in;
+
+public interface HandleGrapeStatusUseCase {
+    void resetGrapeStatus(Long studyId, Long memberId);
+
+    void markGrapeSent(Long studyMemberId);
+}

--- a/src/main/java/com/stumeet/server/studymember/application/port/in/MemberGrapeQueryUseCase.java
+++ b/src/main/java/com/stumeet/server/studymember/application/port/in/MemberGrapeQueryUseCase.java
@@ -1,0 +1,8 @@
+package com.stumeet.server.studymember.application.port.in;
+
+import com.stumeet.server.studymember.adapter.in.web.dto.GrapeResponses;
+
+public interface MemberGrapeQueryUseCase {
+
+    GrapeResponses findMemberGrapes(Long memberId, int page, int size);
+}

--- a/src/main/java/com/stumeet/server/studymember/application/port/in/StudyMemberQueryUseCase.java
+++ b/src/main/java/com/stumeet/server/studymember/application/port/in/StudyMemberQueryUseCase.java
@@ -2,7 +2,6 @@ package com.stumeet.server.studymember.application.port.in;
 
 import com.stumeet.server.studymember.application.port.in.response.StudyMemberAdminResponse;
 import com.stumeet.server.studymember.application.port.in.response.StudyMemberDetailResponse;
-import com.stumeet.server.studymember.application.port.in.response.StudyMemberGrapeResponse;
 import com.stumeet.server.studymember.application.port.in.response.StudyMemberResponses;
 
 public interface StudyMemberQueryUseCase {
@@ -12,5 +11,5 @@ public interface StudyMemberQueryUseCase {
 
     StudyMemberAdminResponse isMemberAdmin(Long studyId, Long memberId);
 
-    StudyMemberGrapeResponse canStudyMemberSendGrape(Long studyId, Long memberId);
+    boolean canSendGrape(Long studyId, Long memberId);
 }

--- a/src/main/java/com/stumeet/server/studymember/application/port/in/StudyMemberValidationUseCase.java
+++ b/src/main/java/com/stumeet/server/studymember/application/port/in/StudyMemberValidationUseCase.java
@@ -1,6 +1,8 @@
 package com.stumeet.server.studymember.application.port.in;
 
 public interface StudyMemberValidationUseCase {
+    void checkById(Long id);
+
     void checkStudyJoinMember(Long studyId, Long memberId);
 
     void checkAlreadyStudyJoinMember(Long studyId, Long memberId);

--- a/src/main/java/com/stumeet/server/studymember/application/port/in/command/GrapeSendCommand.java
+++ b/src/main/java/com/stumeet/server/studymember/application/port/in/command/GrapeSendCommand.java
@@ -1,0 +1,16 @@
+package com.stumeet.server.studymember.application.port.in.command;
+
+import com.stumeet.server.studymember.domain.ComplimentType;
+
+import lombok.Builder;
+
+public record GrapeSendCommand(
+    Long senderMemberId,
+    Long studyMemberId,
+    ComplimentType complimentType
+) {
+    @Builder
+    public GrapeSendCommand(Long senderMemberId, Long studyMemberId, String complimentTypeName) {
+        this(senderMemberId, studyMemberId, ComplimentType.safeValueOf(complimentTypeName));
+    }
+}

--- a/src/main/java/com/stumeet/server/studymember/application/port/out/StudyMemberQueryPort.java
+++ b/src/main/java/com/stumeet/server/studymember/application/port/out/StudyMemberQueryPort.java
@@ -10,5 +10,7 @@ public interface StudyMemberQueryPort {
 
     StudyMember findStudyMember(Long studyId, Long memberId);
 
+    StudyMember findStudyMember(Long studyMemberId);
+
     boolean isSentGrape(Long studyId, Long memberId);
 }

--- a/src/main/java/com/stumeet/server/studymember/application/port/out/StudyMemberValidationPort.java
+++ b/src/main/java/com/stumeet/server/studymember/application/port/out/StudyMemberValidationPort.java
@@ -1,6 +1,8 @@
 package com.stumeet.server.studymember.application.port.out;
 
 public interface StudyMemberValidationPort {
+    boolean isExist(Long id);
+
     boolean isNotStudyJoinMember(Long studyId, Long memberId);
 
     boolean isAlreadyStudyJoinMember(Long studyId, Long memberId);

--- a/src/main/java/com/stumeet/server/studymember/application/service/GrapePraiseSendService.java
+++ b/src/main/java/com/stumeet/server/studymember/application/service/GrapePraiseSendService.java
@@ -1,0 +1,59 @@
+package com.stumeet.server.studymember.application.service;
+
+import com.stumeet.server.common.annotation.UseCase;
+import com.stumeet.server.common.event.EventPublisher;
+import com.stumeet.server.studymember.adapter.out.event.model.GrapePraiseAlertEvent;
+import com.stumeet.server.studymember.application.port.in.GrapePraiseSendUseCase;
+import com.stumeet.server.studymember.application.port.in.command.GrapeSendCommand;
+import com.stumeet.server.review.application.port.out.GrapeSavePort;
+import com.stumeet.server.studymember.application.port.out.StudyMemberQueryPort;
+import com.stumeet.server.studymember.domain.Grape;
+import com.stumeet.server.studymember.domain.StudyMember;
+import com.stumeet.server.study.application.port.in.StudyQueryUseCase;
+import com.stumeet.server.studymember.application.port.in.HandleGrapeStatusUseCase;
+import com.stumeet.server.studymember.application.port.in.StudyMemberValidationUseCase;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+
+@UseCase
+@Transactional
+@RequiredArgsConstructor
+public class GrapePraiseSendService implements GrapePraiseSendUseCase {
+    private final StudyQueryUseCase studyQueryUseCase;
+    private final HandleGrapeStatusUseCase handleGrapeStatusUseCase;
+
+    private final GrapeSavePort grapeSavePort;
+    private final StudyMemberQueryPort studyMemberQueryPort;
+
+    @Override
+    public void sendGrape(GrapeSendCommand command) {
+        StudyMember receiver = studyMemberQueryPort.findStudyMember(command.studyMemberId());
+        StudyMember sender = studyMemberQueryPort.findStudyMember(receiver.getStudy().getId(),
+            command.senderMemberId());
+
+        validateReceiverAndSender(receiver, sender);
+
+        Grape grape = createGrape(receiver, command);
+        grapeSavePort.save(grape);
+
+        handleGrapeStatusUseCase.markGrapeSent(sender.getId());
+
+        EventPublisher.raise(
+            new GrapePraiseAlertEvent(this, receiver.getStudy().getId(), receiver.getMember().getId()));
+    }
+
+    private void validateReceiverAndSender(StudyMember receiver, StudyMember sender) {
+        sender.checkAlreadySentGrape();
+        sender.checkSelfPraise(receiver.getMember().getId());
+    }
+
+    private Grape createGrape(StudyMember receiver, GrapeSendCommand command) {
+        return Grape.create(
+            receiver.getMember().getId(),
+            receiver.getStudy().getId(),
+            studyQueryUseCase.getStudyName(receiver.getStudy().getId()),
+            command.complimentType()
+        );
+    }
+}

--- a/src/main/java/com/stumeet/server/studymember/application/service/GrapeQueryService.java
+++ b/src/main/java/com/stumeet/server/studymember/application/service/GrapeQueryService.java
@@ -1,0 +1,46 @@
+package com.stumeet.server.studymember.application.service;
+
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.stumeet.server.activity.application.port.in.mapper.PageInfoUseCaseMapper;
+import com.stumeet.server.common.annotation.UseCase;
+import com.stumeet.server.review.application.port.out.GrapeQueryPort;
+import com.stumeet.server.studymember.adapter.in.web.dto.GrapeResponse;
+import com.stumeet.server.studymember.adapter.in.web.dto.GrapeResponses;
+import com.stumeet.server.studymember.application.port.in.MemberGrapeQueryUseCase;
+import com.stumeet.server.studymember.domain.Grape;
+
+import lombok.RequiredArgsConstructor;
+
+@UseCase
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class GrapeQueryService implements MemberGrapeQueryUseCase {
+
+    private final GrapeQueryPort grapeQueryPort;
+    private final PageInfoUseCaseMapper pageInfoUseCaseMapper;
+
+    @Override
+    public GrapeResponses findMemberGrapes(Long memberId, int page, int size) {
+        Page<Grape> grapePages = grapeQueryPort.findPageByMemberId(memberId, page, size);
+        List<GrapeResponse> grapes = mapToGrapeResponse(grapePages);
+
+        return GrapeResponses.builder()
+            .grapes(grapes)
+            .pageInfo(pageInfoUseCaseMapper.toPageInfoResponse(grapePages))
+            .build();
+    }
+
+    private List<GrapeResponse> mapToGrapeResponse(Page<Grape> pages) {
+        return pages.map(grape -> GrapeResponse.builder()
+                .id(grape.getId())
+                .studyName(grape.getStudyName())
+                .compliment(grape.getComplimentType().getDescription())
+                .createdAt(grape.getCreatedAt())
+                .build())
+            .stream().toList();
+    }
+}

--- a/src/main/java/com/stumeet/server/studymember/application/service/HandleGrapeStatusService.java
+++ b/src/main/java/com/stumeet/server/studymember/application/service/HandleGrapeStatusService.java
@@ -1,0 +1,32 @@
+package com.stumeet.server.studymember.application.service;
+
+import com.stumeet.server.common.annotation.UseCase;
+import com.stumeet.server.studymember.application.port.in.HandleGrapeStatusUseCase;
+import com.stumeet.server.studymember.application.port.out.StudyMemberQueryPort;
+import com.stumeet.server.studymember.application.port.out.StudyMemberUpdatePort;
+import com.stumeet.server.studymember.domain.StudyMember;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+
+@UseCase
+@Transactional
+@RequiredArgsConstructor
+public class HandleGrapeStatusService implements HandleGrapeStatusUseCase {
+    private final StudyMemberQueryPort studyMemberQueryPort;
+    private final StudyMemberUpdatePort studyMemberUpdatePort;
+
+    @Override
+    public void resetGrapeStatus(Long studyId, Long memberId) {
+        StudyMember studyMember = studyMemberQueryPort.findStudyMember(studyId, memberId);
+        studyMember.resetGrapeStatus();
+        studyMemberUpdatePort.update(studyMember);
+    }
+
+    @Override
+    public void markGrapeSent(Long studyMemberId) {
+        StudyMember studyMember = studyMemberQueryPort.findStudyMember(studyMemberId);
+        studyMember.markGrapeSent();
+        studyMemberUpdatePort.update(studyMember);
+    }
+}

--- a/src/main/java/com/stumeet/server/studymember/application/service/StudyMemberQueryService.java
+++ b/src/main/java/com/stumeet/server/studymember/application/service/StudyMemberQueryService.java
@@ -69,11 +69,9 @@ public class StudyMemberQueryService implements StudyMemberQueryUseCase {
     }
 
     @Override
-    public StudyMemberGrapeResponse canStudyMemberSendGrape(Long studyId, Long memberId) {
+    public boolean canSendGrape(Long studyId, Long memberId) {
         studyValidationUseCase.checkById(studyId);
 
-        return new StudyMemberGrapeResponse(
-                !studyMemberQueryPort.isSentGrape(studyId, memberId)
-        );
+        return !studyMemberQueryPort.isSentGrape(studyId, memberId);
     }
 }

--- a/src/main/java/com/stumeet/server/studymember/application/service/StudyMemberValidationService.java
+++ b/src/main/java/com/stumeet/server/studymember/application/service/StudyMemberValidationService.java
@@ -2,9 +2,11 @@ package com.stumeet.server.studymember.application.service;
 
 import com.stumeet.server.common.annotation.UseCase;
 import com.stumeet.server.studymember.application.port.in.StudyMemberValidationUseCase;
+import com.stumeet.server.studymember.application.port.out.StudyMemberQueryPort;
 import com.stumeet.server.studymember.application.port.out.StudyMemberValidationPort;
 import com.stumeet.server.studymember.domain.exception.AlreadyStudyJoinMemberException;
 import com.stumeet.server.studymember.domain.exception.NotStudyAdminException;
+import com.stumeet.server.studymember.domain.exception.StudyMemberNotExistException;
 import com.stumeet.server.studymember.domain.exception.StudyMemberNotJoinedException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,6 +17,14 @@ import org.springframework.transaction.annotation.Transactional;
 public class StudyMemberValidationService implements StudyMemberValidationUseCase {
 
     private final StudyMemberValidationPort studyMemberValidationPort;
+    private final StudyMemberQueryPort studyMemberQueryPort;
+
+    @Override
+    public void checkById(Long id) {
+        if (!studyMemberValidationPort.isExist(id)) {
+            throw new StudyMemberNotExistException(id);
+        }
+    }
 
     @Override
     public void checkStudyJoinMember(Long studyId, Long memberId) {

--- a/src/main/java/com/stumeet/server/studymember/domain/ComplimentType.java
+++ b/src/main/java/com/stumeet/server/studymember/domain/ComplimentType.java
@@ -1,0 +1,27 @@
+package com.stumeet.server.studymember.domain;
+
+import org.springframework.security.core.parameters.P;
+
+import com.stumeet.server.common.exception.model.EnumValidationException;
+import com.stumeet.server.common.response.ErrorCode;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public enum ComplimentType {
+    PASSIONATE("열정이 돋보이는 활동이에요"),
+    DILIGENT("성실하게 참여했어요"),
+    OUTSTANDING("결과물이 훌륭해요");
+
+    private String description;
+
+    public static ComplimentType safeValueOf(String name) {
+        try {
+            return ComplimentType.valueOf(name);
+        } catch (IllegalArgumentException | NullPointerException e) {
+            throw new EnumValidationException(ErrorCode.INVALID_COMPLIMENT_TYPE_EXCEPTION, ComplimentType.class, name);
+        }
+    }
+}

--- a/src/main/java/com/stumeet/server/studymember/domain/Grape.java
+++ b/src/main/java/com/stumeet/server/studymember/domain/Grape.java
@@ -1,0 +1,29 @@
+package com.stumeet.server.studymember.domain;
+
+import java.time.LocalDateTime;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class Grape {
+    private Long id;
+    private Long memberId;
+    private Long studyId;
+    private String studyName;
+    private ComplimentType complimentType;
+    private LocalDateTime createdAt;
+
+    public static Grape create(Long memberId, Long studyId, String studyName, ComplimentType complimentType) {
+        return Grape.builder()
+            .memberId(memberId)
+            .studyId(studyId)
+            .studyName(studyName)
+            .complimentType(complimentType)
+            .build();
+    }
+}

--- a/src/main/java/com/stumeet/server/studymember/domain/StudyMember.java
+++ b/src/main/java/com/stumeet/server/studymember/domain/StudyMember.java
@@ -1,5 +1,8 @@
 package com.stumeet.server.studymember.domain;
 
+import com.stumeet.server.studymember.domain.exception.AlreadySentGrapeException;
+import com.stumeet.server.studymember.domain.exception.SelfGrapePraiseForbiddenException;
+
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -23,5 +26,25 @@ public class StudyMember {
 
     public void hideLegacyStudy() {
         this.isLegacyHidden = true;
+    }
+
+    public void resetGrapeStatus() {
+        this.isSentGrape = false;
+    }
+
+    public void markGrapeSent() {
+        this.isSentGrape = true;
+    }
+
+    public void checkAlreadySentGrape() {
+        if (this.isSentGrape()) {
+            throw new AlreadySentGrapeException();
+        }
+    }
+
+    public void checkSelfPraise(long receiverId) {
+        if (this.id == receiverId) {
+            throw new SelfGrapePraiseForbiddenException();
+        }
     }
 }

--- a/src/main/java/com/stumeet/server/studymember/domain/exception/AlreadySentGrapeException.java
+++ b/src/main/java/com/stumeet/server/studymember/domain/exception/AlreadySentGrapeException.java
@@ -1,0 +1,10 @@
+package com.stumeet.server.studymember.domain.exception;
+
+import com.stumeet.server.common.exception.model.InvalidStateException;
+import com.stumeet.server.common.response.ErrorCode;
+
+public class AlreadySentGrapeException extends InvalidStateException {
+    public AlreadySentGrapeException() {
+        super(ErrorCode.ALREADY_SENT_GRAPE_ERROR);
+    }
+}

--- a/src/main/java/com/stumeet/server/studymember/domain/exception/SelfGrapePraiseForbiddenException.java
+++ b/src/main/java/com/stumeet/server/studymember/domain/exception/SelfGrapePraiseForbiddenException.java
@@ -1,0 +1,11 @@
+package com.stumeet.server.studymember.domain.exception;
+
+import com.stumeet.server.common.exception.model.InvalidStateException;
+import com.stumeet.server.common.response.ErrorCode;
+
+public class SelfGrapePraiseForbiddenException extends InvalidStateException {
+
+    public SelfGrapePraiseForbiddenException() {
+        super(ErrorCode.SELF_GRAPE_PRAISE_FORBIDDEN_EXCEPTION);
+    }
+}

--- a/src/main/java/com/stumeet/server/studymember/domain/exception/StudyMemberNotExistException.java
+++ b/src/main/java/com/stumeet/server/studymember/domain/exception/StudyMemberNotExistException.java
@@ -1,0 +1,15 @@
+package com.stumeet.server.studymember.domain.exception;
+
+import java.text.MessageFormat;
+
+import com.stumeet.server.common.exception.model.NotExistsException;
+import com.stumeet.server.common.response.ErrorCode;
+
+public class StudyMemberNotExistException extends NotExistsException {
+
+    public static final String MESSAGE = "존재하지 않는 스터디 멤버입니다. 전달받은 id : {0}";
+
+    public StudyMemberNotExistException(Long id) {
+        super(MessageFormat.format(MESSAGE, id), ErrorCode.STUDY_MEMBER_NOT_FOUND);
+    }
+}

--- a/src/main/resources/db/migration/V1.18__create_grape_table.sql
+++ b/src/main/resources/db/migration/V1.18__create_grape_table.sql
@@ -1,0 +1,14 @@
+CREATE TABLE IF NOT EXISTS `grape`
+(
+    `id`              BIGINT      NOT NULL AUTO_INCREMENT PRIMARY KEY COMMENT '포도 ID',
+    `member_id`       BIGINT      NOT NULL COMMENT '멤버 ID',
+    `study_id`        BIGINT      NULL COMMENT '스터디 ID',
+    `compliment_type` VARCHAR(50) NOT NULL COMMENT '칭찬 타입',
+    `created_at`      DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '생성 시간',
+    `updated_at`      DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '수정 시간',
+    CONSTRAINT `fk_grape_linked_study_id` FOREIGN KEY (`study_id`)
+        REFERENCES `study` (`id`)
+        ON DELETE SET NULL ON UPDATE CASCADE
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci;

--- a/src/test/java/com/stumeet/server/stub/GrapeStub.java
+++ b/src/test/java/com/stumeet/server/stub/GrapeStub.java
@@ -1,0 +1,27 @@
+package com.stumeet.server.stub;
+
+import com.stumeet.server.studymember.adapter.in.web.dto.GrapeSendRequest;
+
+public class GrapeStub {
+
+    public static GrapeSendRequest getGrapeSendRequest() {
+        return GrapeSendRequest.builder()
+            .studyMemberId(4L)
+            .complimentType("DILIGENT")
+            .build();
+    }
+
+    public static GrapeSendRequest getInvalidComplimentTypeGrapeSendRequest() {
+        return GrapeSendRequest.builder()
+            .studyMemberId(4L)
+            .complimentType("HELLO")
+            .build();
+    }
+
+    public static GrapeSendRequest getNotExistStudyMemberGrapeSendRequest() {
+        return GrapeSendRequest.builder()
+            .studyMemberId(0L)
+            .complimentType("OUTSTANDING")
+            .build();
+    }
+}

--- a/src/test/java/com/stumeet/server/studymember/adapter/in/web/GrapePraiseSendApiTest.java
+++ b/src/test/java/com/stumeet/server/studymember/adapter/in/web/GrapePraiseSendApiTest.java
@@ -1,0 +1,170 @@
+package com.stumeet.server.studymember.adapter.in.web;
+
+import static org.springframework.restdocs.headers.HeaderDocumentation.*;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+
+import com.stumeet.server.common.auth.model.AuthenticationHeader;
+import com.stumeet.server.helper.WithMockMember;
+import com.stumeet.server.stub.GrapeStub;
+import com.stumeet.server.stub.TokenStub;
+import com.stumeet.server.studymember.adapter.in.web.dto.GrapeSendRequest;
+import com.stumeet.server.template.ApiTest;
+
+class GrapePraiseSendApiTest extends ApiTest {
+
+    @Nested
+    @DisplayName("포도알 칭찬 전송 API")
+    class SendGrapePraise {
+
+        private final String path = "/api/v1/reviews/grape";
+
+        @Test
+        @WithMockMember
+        @DisplayName("[성공] 포도알 칭찬 전송에 성공한다.")
+        void success() throws Exception {
+            GrapeSendRequest request = GrapeStub.getGrapeSendRequest();
+
+            mockMvc.perform(post(path)
+                    .header(AuthenticationHeader.ACCESS_TOKEN.getName(), TokenStub.getMockAccessToken())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(toJson(request)))
+                .andExpect(status().isCreated())
+                .andDo(document("send-grape-praise/success",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    requestHeaders(
+                        headerWithName(AuthenticationHeader.ACCESS_TOKEN.getName())
+                            .description("서버로부터 전달받은 액세스 토큰")
+                    ),
+                    requestFields(
+                        fieldWithPath("studyMemberId").description("칭찬 받을 멤버의 스터디 멤버 ID"),
+                        fieldWithPath("complimentType").description("칭찬 타입")
+                    ),
+                    responseFields(
+                        fieldWithPath("code").description("응답 상태"),
+                        fieldWithPath("message").description("응답 메시지")
+                    )));
+        }
+
+        @Test
+        @WithMockMember
+        @DisplayName("[실패] 유효하지 않은 칭찬 타입으로 요청한 경우 포도알 칭찬 전송에 실패한다.")
+        void fail_when_invalid_compliment_type() throws Exception {
+            GrapeSendRequest request = GrapeStub.getInvalidComplimentTypeGrapeSendRequest();
+
+            mockMvc.perform(post(path)
+                    .header(AuthenticationHeader.ACCESS_TOKEN.getName(), TokenStub.getMockAccessToken())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(toJson(request)))
+                .andExpect(status().isBadRequest())
+                .andDo(document("send-grape-praise/fail/invalid-compliment-type",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    requestHeaders(
+                        headerWithName(AuthenticationHeader.ACCESS_TOKEN.getName())
+                            .description("서버로부터 전달받은 액세스 토큰")
+                    ),
+                    requestFields(
+                        fieldWithPath("studyMemberId").description("칭찬 받을 멤버의 스터디 멤버 ID"),
+                        fieldWithPath("complimentType").description("칭찬 타입")
+                    ),
+                    responseFields(
+                        fieldWithPath("code").description("응답 상태"),
+                        fieldWithPath("message").description("응답 메시지")
+                    )));
+        }
+
+        @Test
+        @WithMockMember
+        @DisplayName("[실패] 존재하지 않는 스터디 멤버 ID로 요청한 경우 포도알 칭찬 전송에 실패한다.")
+        void fail_when_study_member_not_found() throws Exception {
+            GrapeSendRequest request = GrapeStub.getNotExistStudyMemberGrapeSendRequest();
+
+            mockMvc.perform(post(path)
+                    .header(AuthenticationHeader.ACCESS_TOKEN.getName(), TokenStub.getMockAccessToken())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(toJson(request)))
+                .andExpect(status().isNotFound())
+                .andDo(document("send-grape-praise/fail/study-member-not-found",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    requestHeaders(
+                        headerWithName(AuthenticationHeader.ACCESS_TOKEN.getName())
+                            .description("서버로부터 전달받은 액세스 토큰")
+                    ),
+                    requestFields(
+                        fieldWithPath("studyMemberId").description("칭찬 받을 멤버의 스터디 멤버 ID"),
+                        fieldWithPath("complimentType").description("칭찬 타입")
+                    ),
+                    responseFields(
+                        fieldWithPath("code").description("응답 상태"),
+                        fieldWithPath("message").description("응답 메시지")
+                    )));
+        }
+
+        @Test
+        @WithMockMember(id = 3L)
+        @DisplayName("[실패] 전송자가 해당 스터디의 스터디원이 아닐 때 포도알 칭찬 전송에 실패한다.")
+        void fail_when_sender_is_not_the_study_member() throws Exception {
+            GrapeSendRequest request = GrapeStub.getGrapeSendRequest();
+
+            mockMvc.perform(post(path)
+                    .header(AuthenticationHeader.ACCESS_TOKEN.getName(), TokenStub.getMockAccessToken())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(toJson(request)))
+                .andExpect(status().isNotFound())
+                .andDo(document("send-grape-praise/fail/sender_is_not_the_study_member",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    requestHeaders(
+                        headerWithName(AuthenticationHeader.ACCESS_TOKEN.getName())
+                            .description("서버로부터 전달받은 액세스 토큰")
+                    ),
+                    requestFields(
+                        fieldWithPath("studyMemberId").description("칭찬 받을 멤버의 스터디 멤버 ID"),
+                        fieldWithPath("complimentType").description("칭찬 타입")
+                    ),
+                    responseFields(
+                        fieldWithPath("code").description("응답 상태"),
+                        fieldWithPath("message").description("응답 메시지")
+                    )));
+        }
+
+        @Test
+        @WithMockMember(id = 4L)
+        @DisplayName("[실패] 전송자가 해당 스터디의 이미 이번주 포도알을 전송한 경우 포도알 칭찬 전송에 실패한다.")
+        void fail_when_sender_already_sent_grape() throws Exception {
+            GrapeSendRequest request = GrapeStub.getGrapeSendRequest();
+
+            mockMvc.perform(post(path)
+                    .header(AuthenticationHeader.ACCESS_TOKEN.getName(), TokenStub.getMockAccessToken())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(toJson(request)))
+                .andExpect(status().isConflict())
+                .andDo(document("send-grape-praise/fail/sender_already_sent_grape",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    requestHeaders(
+                        headerWithName(AuthenticationHeader.ACCESS_TOKEN.getName())
+                            .description("서버로부터 전달받은 액세스 토큰")
+                    ),
+                    requestFields(
+                        fieldWithPath("studyMemberId").description("칭찬 받을 멤버의 스터디 멤버 ID"),
+                        fieldWithPath("complimentType").description("칭찬 타입")
+                    ),
+                    responseFields(
+                        fieldWithPath("code").description("응답 상태"),
+                        fieldWithPath("message").description("응답 메시지")
+                    )));
+        }
+    }
+}

--- a/src/test/java/com/stumeet/server/studymember/adapter/in/web/GrapeQueryApiTest.java
+++ b/src/test/java/com/stumeet/server/studymember/adapter/in/web/GrapeQueryApiTest.java
@@ -1,0 +1,69 @@
+package com.stumeet.server.studymember.adapter.in.web;
+
+import static org.springframework.restdocs.headers.HeaderDocumentation.*;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import com.stumeet.server.common.auth.model.AuthenticationHeader;
+import com.stumeet.server.helper.WithMockMember;
+import com.stumeet.server.stub.TokenStub;
+import com.stumeet.server.template.ApiTest;
+
+class GrapeQueryApiTest extends ApiTest {
+
+    @Nested
+    @DisplayName("멤버 받은 포도알 목록 조회 API")
+    class GetByMemberId {
+
+        private static final String PATH = "/api/v1/reviews/grapes";
+
+        @Test
+        @WithMockMember
+        @DisplayName("[성공] 멤버의 받은 포도알 목록 조회에 성공한다.")
+        void success() throws Exception {
+            Integer size = 10;
+            Integer page = 0;
+
+            mockMvc.perform(get(PATH)
+                    .param("size", size.toString())
+                    .param("page", page.toString())
+                    .header(AuthenticationHeader.ACCESS_TOKEN.getName(), TokenStub.getMockAccessToken()))
+                .andExpect(status().isOk())
+                .andDo(document("get-member-grapes/success",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    requestHeaders(
+                        headerWithName(AuthenticationHeader.ACCESS_TOKEN.getName())
+                            .description("서버로부터 전달받은 액세스 토큰")
+                    ),
+                    queryParameters(
+                        parameterWithName("size").description("페이지 크기"),
+                        parameterWithName("page").description("페이지 번호")
+                    ),
+                    responseFields(
+                        fieldWithPath("code").description("응답 코드"),
+                        fieldWithPath("message").description("응답 메시지"),
+                        fieldWithPath("data").description("응답 데이터"),
+                        fieldWithPath("data.grapes").description("받은 포도알 목록"),
+                        fieldWithPath("data.grapes[].id").description("포도알 ID"),
+                        fieldWithPath("data.grapes[].studyName").description("받은 포도알 목록"),
+                        fieldWithPath("data.grapes[].compliment").description("받은 포도알 목록"),
+                        fieldWithPath("data.grapes[].createdAt").description("받은 포도알 목록"),
+                        fieldWithPath("data.pageInfo").description("페이지 메타 정보"),
+                        fieldWithPath("data.pageInfo.totalPages").description("전체 페이지 수"),
+                        fieldWithPath("data.pageInfo.totalElements").description("전체 요소 수"),
+                        fieldWithPath("data.pageInfo.currentPage").description("현재 페이지"),
+                        fieldWithPath("data.pageInfo.pageSize").description("페이지 크기")
+                    )
+                ));
+        }
+    }
+}

--- a/src/test/java/com/stumeet/server/studymember/adapter/out/persistence/JpaStudyMemberRepositoryCustomImplTest.java
+++ b/src/test/java/com/stumeet/server/studymember/adapter/out/persistence/JpaStudyMemberRepositoryCustomImplTest.java
@@ -2,6 +2,7 @@ package com.stumeet.server.studymember.adapter.out.persistence;
 
 import com.stumeet.server.stub.MemberStub;
 import com.stumeet.server.stub.StudyStub;
+import com.stumeet.server.studymember.adapter.out.persistence.repository.JpaStudyMemberRepositoryCustomImpl;
 import com.stumeet.server.studymember.application.port.in.response.SimpleStudyMemberResponse;
 import com.stumeet.server.template.IntegrationTest;
 import org.junit.jupiter.api.DisplayName;

--- a/src/test/java/com/stumeet/server/studymember/application/service/integration/StudyMemberJoinServiceIntegrationTest.java
+++ b/src/test/java/com/stumeet/server/studymember/application/service/integration/StudyMemberJoinServiceIntegrationTest.java
@@ -3,7 +3,7 @@ package com.stumeet.server.studymember.application.service.integration;
 import com.stumeet.server.member.domain.exception.MemberNotExistsException;
 import com.stumeet.server.stub.StudyMemberStub;
 import com.stumeet.server.study.domain.exception.StudyNotExistsException;
-import com.stumeet.server.studymember.adapter.out.persistence.JpaStudyMemberRepository;
+import com.stumeet.server.studymember.adapter.out.persistence.repository.JpaStudyMemberRepository;
 import com.stumeet.server.studymember.application.port.in.command.StudyMemberJoinCommand;
 import com.stumeet.server.studymember.application.service.StudyMemberJoinService;
 import com.stumeet.server.template.IntegrationTest;

--- a/src/test/resources/db/setup.sql
+++ b/src/test/resources/db/setup.sql
@@ -59,6 +59,13 @@ VALUES(1, '[자바를 자바]', '공지사항이 올라왔어요!', 'http://exam
 INSERT INTO notification_log (member_id, title, body, img_url, data)
 VALUES(1, '[자바를 자바]', '공지사항이 업데이트 되었어요!', 'http://example.com/welcome.png', '{"type":"update"}');
 
+INSERT INTO grape (member_id, study_id, compliment_type, created_at, updated_at)
+VALUES (1, 1, 'PASSIONATE', NOW(), NOW());
+INSERT INTO grape (member_id, study_id, compliment_type, created_at, updated_at)
+VALUES (1, 2, 'DILIGENT', NOW(), NOW());
+INSERT INTO grape (member_id, study_id, compliment_type, created_at, updated_at)
+VALUES (1, 3, 'OUTSTANDING', NOW(), NOW());
+
 
 -- member id 2: study id 1의 멤버
 INSERT INTO member (id, name, image, region, profession_id, role, auth_type, tier, experience, is_deleted, deleted_at)

--- a/src/test/resources/db/setup.sql
+++ b/src/test/resources/db/setup.sql
@@ -78,14 +78,14 @@ VALUES (3, 'test3', 'http://localhost:4572/user/1/profile/2024030416531039839905
 
 INSERT INTO device (member_id, device_id, notification_token) VALUES (3, 'GFGHGFJFDX', 'ERAHGFJJGYFY');
 
--- member id 4: study id 1을 참여했지만 활동은 참여하지 않은 멤버, 멤버 1이 리뷰 작성 완료
+-- member id 4: study id 1을 참여했지만 활동은 참여하지 않은 멤버, 멤버 1이 리뷰 작성 완료, 스터디 1 이번주 포도알 전송 완료
 INSERT INTO member (id, name, image, region, profession_id, role, auth_type, tier, experience, is_deleted, deleted_at)
 VALUES (4, 'test4', 'http://localhost:4572/user/1/profile/2024030416531039839905-b7e8-4ad3-9552-7d9cbc01cb14-test.jpg',
         '서울', 1, 'MEMBER', 'OAUTH', 'SEED', 0.0, false, null);
 
 INSERT INTO device (member_id, device_id, notification_token) VALUES (4, 'ADGERGRGJSJHG', 'AHFGFJHGHKHVV');
 
-INSERT INTO study_member (member_id, study_id, is_admin, is_sent_grape) VALUES (4, 1, false, false);
+INSERT INTO study_member (member_id, study_id, is_admin, is_sent_grape) VALUES (4, 1, false, true);
 
 INSERT INTO topic_subscription (topic_id, member_id) VALUES (1, 4);
 


### PR DESCRIPTION
## 💁 해결 하려는 문제를 적어주세요 

- 포도알 칭찬 전송 API
- 멤버의 받은 포도알 목록 페이지네이션 조회 API
- hub api에서 canGrapeSend 메서드의 반환 값을 dto가 아닌 boolean 값으로 변경하여 간소화

## 🙋 중점적으로 리뷰 했으면 하는 부분이 있다면 적어주세요 

기존의 설계에서는 포도알 테이블에 스터디 관련 외래키가 아닌 스터디 명만을 저장하기로 했었지만, 스터디 외래키를 추가하는 방식으로 변경했습니다.

이후 추가될 기획에 포도알 관련 통계 처리를 할 가능성이 높고, 관련 정보가 활동 정도를 판단할 수 있어 운영에 도움이 되기에 외래키를 추가하도록 변경했습니다.

- 변경된 DDL
``` SQL
CREATE TABLE IF NOT EXISTS `grape`
(
    `id`              BIGINT      NOT NULL AUTO_INCREMENT PRIMARY KEY COMMENT '포도 ID',
    `member_id`       BIGINT      NOT NULL COMMENT '멤버 ID',
    `study_id`        BIGINT      NULL COMMENT '스터디 ID',
    `compliment_type` VARCHAR(50) NOT NULL COMMENT '칭찬 타입',
    `created_at`      DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '생성 시간',
    `updated_at`      DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '수정 시간',
    CONSTRAINT `fk_grape_linked_study_id` FOREIGN KEY (`study_id`)
        REFERENCES `study` (`id`)
        ON DELETE SET NULL ON UPDATE CASCADE
) ENGINE = InnoDB
  DEFAULT CHARSET = utf8mb4
  COLLATE = utf8mb4_unicode_ci;
```