### PR TITLE
✨ [STMT-89] 멤버 프로필 조회 API 응답 값에 포도알 개수 추가

### DIFF
--- a/src/main/java/com/stumeet/server/member/adapter/in/web/MemberProfileApi.java
+++ b/src/main/java/com/stumeet/server/member/adapter/in/web/MemberProfileApi.java
@@ -39,6 +39,7 @@ public class MemberProfileApi {
             @AuthenticationPrincipal LoginMember member
     ) {
         MemberProfileResponse response = memberProfileUseCase.getProfileById(member.getMember().getId());
+
         return new ResponseEntity<>(
                 ApiResponse.success(HttpStatus.OK.value(), "내 프로필 조회에 성공했습니다.", response),
                 HttpStatus.OK

--- a/src/main/java/com/stumeet/server/member/adapter/in/web/response/MemberProfileResponse.java
+++ b/src/main/java/com/stumeet/server/member/adapter/in/web/response/MemberProfileResponse.java
@@ -10,6 +10,7 @@ public record MemberProfileResponse(
         String region,
         String profession,
         String tier,
-        double experience
-) {
+        double experience,
+        Integer grapeCount
+        ) {
 }

--- a/src/main/java/com/stumeet/server/member/application/port/in/mapper/MemberUseCaseMapper.java
+++ b/src/main/java/com/stumeet/server/member/application/port/in/mapper/MemberUseCaseMapper.java
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class MemberUseCaseMapper {
 
-    public MemberProfileResponse toProfileResponse(Member member) {
+    public MemberProfileResponse toProfileResponse(Member member, int grapeCount) {
         return MemberProfileResponse.builder()
                 .id(member.getId())
                 .image(member.getImage())
@@ -16,6 +16,7 @@ public class MemberUseCaseMapper {
                 .profession(member.getProfession().getName())
                 .tier(member.getLevel().getTier().getName())
                 .experience(member.getLevel().getExperience())
+                .grapeCount(grapeCount)
                 .build();
     }
 }

--- a/src/main/java/com/stumeet/server/member/application/service/MemberProfileService.java
+++ b/src/main/java/com/stumeet/server/member/application/service/MemberProfileService.java
@@ -14,6 +14,8 @@ import com.stumeet.server.member.application.port.out.MemberQueryPort;
 import com.stumeet.server.member.domain.Member;
 import com.stumeet.server.profession.application.port.in.ProfessionQueryUseCase;
 import com.stumeet.server.profession.domain.Profession;
+import com.stumeet.server.studymember.application.port.in.MemberGrapeQueryUseCase;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -25,8 +27,11 @@ public class MemberProfileService implements MemberProfileUseCase {
     private final ProfessionQueryUseCase professionQueryUseCase;
     private final FileUploadUseCase fileUploadUseCase;
     private final MemberValidationUseCase memberValidationUseCase;
+    private final MemberGrapeQueryUseCase memberGrapeQueryUseCase;
+
     private final MemberCommandPort memberCommandPort;
     private final MemberQueryPort memberQueryPort;
+
     private final MemberUseCaseMapper memberUseCaseMapper;
 
 
@@ -74,7 +79,8 @@ public class MemberProfileService implements MemberProfileUseCase {
     @Override
     public MemberProfileResponse getProfileById(Long id) {
         Member member = memberQueryPort.getById(id);
-        return memberUseCaseMapper.toProfileResponse(member);
-    }
+        int grapeCount = memberGrapeQueryUseCase.countMemberGrape(id);
 
+        return memberUseCaseMapper.toProfileResponse(member, grapeCount);
+    }
 }

--- a/src/main/java/com/stumeet/server/review/application/port/out/GrapeQueryPort.java
+++ b/src/main/java/com/stumeet/server/review/application/port/out/GrapeQueryPort.java
@@ -7,4 +7,6 @@ import com.stumeet.server.studymember.domain.Grape;
 public interface GrapeQueryPort {
 
     Page<Grape> findPageByMemberId(Long memberId, int page, int size);
+
+    int countMemberGrapes(Long memberId);
 }

--- a/src/main/java/com/stumeet/server/studymember/adapter/out/persistence/GrapePersistenceAdapter.java
+++ b/src/main/java/com/stumeet/server/studymember/adapter/out/persistence/GrapePersistenceAdapter.java
@@ -26,6 +26,11 @@ public class GrapePersistenceAdapter implements GrapeQueryPort, GrapeSavePort {
     }
 
     @Override
+    public int countMemberGrapes(Long memberId) {
+        return jpaGrapeRepository.countByMemberId(memberId);
+    }
+
+    @Override
     public void save(Grape grape) {
         GrapeJpaEntity entity = grapePersistenceMapper.toEntity(grape);
         jpaGrapeRepository.save(entity);

--- a/src/main/java/com/stumeet/server/studymember/adapter/out/persistence/repository/JpaGrapeRepository.java
+++ b/src/main/java/com/stumeet/server/studymember/adapter/out/persistence/repository/JpaGrapeRepository.java
@@ -9,4 +9,6 @@ import com.stumeet.server.studymember.adapter.out.persistence.entity.GrapeJpaEnt
 public interface JpaGrapeRepository extends JpaRepository<GrapeJpaEntity, Long> {
 
     Page<GrapeJpaEntity> findAllByMemberIdOrderByCreatedAtDesc(Long memberId, Pageable pageable);
+
+    int countByMemberId(Long memberId);
 }

--- a/src/main/java/com/stumeet/server/studymember/application/port/in/MemberGrapeQueryUseCase.java
+++ b/src/main/java/com/stumeet/server/studymember/application/port/in/MemberGrapeQueryUseCase.java
@@ -5,4 +5,6 @@ import com.stumeet.server.studymember.adapter.in.web.dto.GrapeResponses;
 public interface MemberGrapeQueryUseCase {
 
     GrapeResponses findMemberGrapes(Long memberId, int page, int size);
+
+    int countMemberGrape(Long memberId);
 }

--- a/src/main/java/com/stumeet/server/studymember/application/service/GrapeQueryService.java
+++ b/src/main/java/com/stumeet/server/studymember/application/service/GrapeQueryService.java
@@ -34,6 +34,11 @@ public class GrapeQueryService implements MemberGrapeQueryUseCase {
             .build();
     }
 
+    @Override
+    public int countMemberGrape(Long memberId) {
+        return grapeQueryPort.countMemberGrapes(memberId);
+    }
+
     private List<GrapeResponse> mapToGrapeResponse(Page<Grape> pages) {
         return pages.map(grape -> GrapeResponse.builder()
                 .id(grape.getId())

--- a/src/test/java/com/stumeet/server/member/adapter/in/web/MemberProfileApiTest.java
+++ b/src/test/java/com/stumeet/server/member/adapter/in/web/MemberProfileApiTest.java
@@ -125,7 +125,8 @@ class MemberProfileApiTest extends ApiTest {
                                     fieldWithPath("data.region").description("지역"),
                                     fieldWithPath("data.profession").description("분야 이름"),
                                     fieldWithPath("data.tier").description("회원 레벨 - 랭크"),
-                                    fieldWithPath("data.experience").description("회원 레벨 - 경험치")
+                                    fieldWithPath("data.experience").description("회원 레벨 - 경험치"),
+                                    fieldWithPath("data.grapeCount").description("포도알 개수")
                             )));
         }
     }

--- a/src/test/java/com/stumeet/server/member/application/service/MemberProfileServiceTest.java
+++ b/src/test/java/com/stumeet/server/member/application/service/MemberProfileServiceTest.java
@@ -11,7 +11,9 @@ import com.stumeet.server.profession.application.port.in.ProfessionQueryUseCase;
 import com.stumeet.server.stub.FileStub;
 import com.stumeet.server.stub.MemberStub;
 import com.stumeet.server.stub.ProfessionStub;
+import com.stumeet.server.studymember.application.port.in.MemberGrapeQueryUseCase;
 import com.stumeet.server.template.UnitTest;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -21,7 +23,6 @@ import org.mockito.Mock;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
-
 
 class MemberProfileServiceTest extends UnitTest {
 
@@ -36,6 +37,9 @@ class MemberProfileServiceTest extends UnitTest {
 
     @Mock
     private ProfessionQueryUseCase professionQueryUseCase;
+
+    @Mock
+    private MemberGrapeQueryUseCase memberGrapeQueryUseCase;
 
     @Mock
     private MemberQueryPort memberQueryPort;
@@ -72,10 +76,13 @@ class MemberProfileServiceTest extends UnitTest {
         void successTest() {
             Member member = MemberStub.getMember();
             MemberProfileResponse want = MemberStub.getMemberProfileResponse(member);
+            int grapeCount = 115;
 
             given(memberQueryPort.getById(member.getId()))
                     .willReturn(member);
-            given(memberUseCaseMapper.toProfileResponse(member))
+            given(memberGrapeQueryUseCase.countMemberGrape(member.getId()))
+                    .willReturn(grapeCount);
+            given(memberUseCaseMapper.toProfileResponse(member, grapeCount))
                     .willReturn(want);
 
             MemberProfileResponse got = memberProfileService.getProfileById(member.getId());
@@ -83,5 +90,4 @@ class MemberProfileServiceTest extends UnitTest {
             assertThat(got).usingRecursiveComparison().isEqualTo(want);
         }
     }
-
 }

--- a/src/test/java/com/stumeet/server/stub/MemberStub.java
+++ b/src/test/java/com/stumeet/server/stub/MemberStub.java
@@ -97,6 +97,7 @@ public class MemberStub {
                 .profession(member.getProfession().getName())
                 .tier(member.getLevel().getTier().getName())
                 .experience(member.getLevel().getExperience())
+                .grapeCount(115)
                 .build();
     }
 


### PR DESCRIPTION
## 💁 해결 하려는 문제를 적어주세요 
멤버의 프로필을 조회하는 API 응답 값에 포도알 개수를 추가했습니다.

## 🤔 어떤 방식으로 해결했는지 적어주세요 

- MemberGrapeQueryUseCase에 포도알 개수를 쿼리하는 메서드를 구현했습니다.
- MemberProfileQueryService에서 해당 개수를 받아 응답으로 전송합니다.
- 기획 / ui 변경에 따른 변경을 방지하기 위해 `00 송이 00 개`가 아니라 포도알 개수 자체를 반환하도록 구현했습니다.