### PR TITLE
✨ [STMT-314] 특정 멤버 기준의 스터디 멤버 리뷰 상태 목록 조회 API 구현

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -444,6 +444,40 @@ include::{snippets}/get-study-members/fail/not-joined-member/response-fields.ado
 include::{snippets}/get-study-members/fail/not-exist-study/response-body.adoc[]
 include::{snippets}/get-study-members/fail/not-exist-study/response-fields.adoc[]
 
+=== 스터디 멤버 리뷰 상태 목록 조회
+
+로그인 멤버 기준으로 해당 스터디 멤버들의 리뷰 상태를 포함하는 정보를 조회하는 API 입니다.
+
+==== GET /v1/api/studies/{studyId}/members/review-status
+
+===== 요청
+include::{snippets}/get-study-member-review-status/success/http-request.adoc[]
+
+====== 헤더
+include::{snippets}/get-study-member-review-status/success/request-headers.adoc[]
+
+====== 경로 변수
+include::{snippets}/get-study-member-review-status/success/path-parameters.adoc[]
+
+===== 응답 성공 (200)
+include::{snippets}/get-study-member-review-status/success/response-body.adoc[]
+include::{snippets}/get-study-member-review-status/success/response-fields.adoc[]
+
+===== 응답 실패 (403)
+.요청 멤버가 해당 스터디의 멤버가 아닌 경우
+include::{snippets}/get-study-member-review-status/fail/member-not-joined-member/response-body.adoc[]
+include::{snippets}/get-study-member-review-status/fail/member-not-joined-member/response-fields.adoc[]
+
+===== 응답 실패 (404)
+.요청한 스터디가 존재하지 않는 경우
+include::{snippets}/get-study-member-review-status/fail/study-not-found/response-body.adoc[]
+include::{snippets}/get-study-member-review-status/fail/study-not-found/response-fields.adoc[]
+
+===== 응답 실패 (409)
+.요청한 스터디가 완료 스터디가 아닌 경우
+include::{snippets}/get-study-member-review-status/fail/study-not-legacy/response-body.adoc[]
+include::{snippets}/get-study-member-review-status/fail/study-not-legacy/response-fields.adoc[]
+
 === 스터디 멤버 탈퇴
 
 전달받은 스터디에 대해 탈퇴하는 API입니다.

--- a/src/main/java/com/stumeet/server/review/application/service/ReviewRegisterService.java
+++ b/src/main/java/com/stumeet/server/review/application/service/ReviewRegisterService.java
@@ -24,6 +24,7 @@ public class ReviewRegisterService implements ReviewRegisterUseCase {
     @Override
     public void register(ReviewRegisterCommand command) {
         studyValidationUseCase.checkById(command.studyId());
+        studyValidationUseCase.checkLegacyStudy(command.studyId());
         studyMemberValidationUseCase.checkStudyJoinMember(command.studyId(), command.reviewerId());
         studyMemberValidationUseCase.checkStudyJoinMember(command.studyId(), command.revieweeId());
         reviewValidationUseCase.validateDuplicate(command.studyId(), command.reviewerId(), command.revieweeId());

--- a/src/main/java/com/stumeet/server/studymember/adapter/in/web/StudyMemberQueryApi.java
+++ b/src/main/java/com/stumeet/server/studymember/adapter/in/web/StudyMemberQueryApi.java
@@ -1,5 +1,7 @@
 package com.stumeet.server.studymember.adapter.in.web;
 
+import java.util.List;
+
 import com.stumeet.server.common.annotation.WebAdapter;
 import com.stumeet.server.common.auth.model.LoginMember;
 import com.stumeet.server.common.model.ApiResponse;
@@ -9,6 +11,8 @@ import com.stumeet.server.studymember.application.port.in.response.StudyMemberDe
 import com.stumeet.server.studymember.application.port.in.response.StudyMemberGrapeResponse;
 import com.stumeet.server.studymember.application.port.in.response.StudyMemberResponses;
 import com.stumeet.server.studymember.application.port.in.StudyMemberQueryUseCase;
+import com.stumeet.server.studymember.application.port.in.response.StudyMemberReviewStatusResponse;
+
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.http.HttpStatus;
@@ -69,6 +73,19 @@ public class StudyMemberQueryApi {
     ) {
         boolean canSendGrape = studyMemberQueryUseCase.canSendGrape(studyId, member.getId());
         StudyMemberGrapeResponse response = new StudyMemberGrapeResponse(canSendGrape);
+
+        return ResponseEntity.ok(
+                ApiResponse.success(SuccessCode.GET_SUCCESS, response)
+        );
+    }
+
+    @GetMapping("/studies/{studyId}/members/review-status")
+    public ResponseEntity<ApiResponse<List<StudyMemberReviewStatusResponse>>> getStudyMembersReviewStatus(
+            @AuthenticationPrincipal LoginMember member,
+            @PathVariable Long studyId
+    ) {
+        List<StudyMemberReviewStatusResponse> response =
+                studyMemberQueryUseCase.getStudyMemberReviewStatusByMember(studyId, member.getId());
 
         return ResponseEntity.ok(
                 ApiResponse.success(SuccessCode.GET_SUCCESS, response)

--- a/src/main/java/com/stumeet/server/studymember/adapter/out/persistence/StudyMemberPersistenceAdapter.java
+++ b/src/main/java/com/stumeet/server/studymember/adapter/out/persistence/StudyMemberPersistenceAdapter.java
@@ -5,6 +5,7 @@ import com.stumeet.server.studymember.adapter.out.persistence.entity.StudyMember
 import com.stumeet.server.studymember.adapter.out.persistence.mapper.StudyMemberPersistenceMapper;
 import com.stumeet.server.studymember.adapter.out.persistence.repository.JpaStudyMemberRepository;
 import com.stumeet.server.studymember.application.port.in.response.SimpleStudyMemberResponse;
+import com.stumeet.server.studymember.application.port.in.response.StudyMemberReviewStatusResponse;
 import com.stumeet.server.studymember.application.port.out.StudyMemberJoinPort;
 import com.stumeet.server.studymember.application.port.out.StudyMemberQueryPort;
 import com.stumeet.server.studymember.application.port.out.StudyMemberUpdatePort;
@@ -60,6 +61,11 @@ public class StudyMemberPersistenceAdapter
     @Override
     public boolean isSentGrape(Long studyId, Long memberId) {
         return jpaStudyMemberRepository.isSentGrape(studyId, memberId);
+    }
+
+    @Override
+    public List<StudyMemberReviewStatusResponse> findStudyMemberReviewStatusByMember(Long studyId, Long memberId) {
+        return jpaStudyMemberRepository.findStudyMemberReviewStatusByMember(studyId, memberId);
     }
 
     @Override

--- a/src/main/java/com/stumeet/server/studymember/adapter/out/persistence/entity/StudyMemberReview.java
+++ b/src/main/java/com/stumeet/server/studymember/adapter/out/persistence/entity/StudyMemberReview.java
@@ -1,0 +1,30 @@
+package com.stumeet.server.studymember.adapter.out.persistence.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+@Table(name = "review")
+public class StudyMemberReview {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "reviewer_id")
+    private Long reviewerId;
+
+    @Column(name = "reviewee_id")
+    private Long revieweeId;
+}

--- a/src/main/java/com/stumeet/server/studymember/adapter/out/persistence/repository/JpaStudyMemberRepositoryCustom.java
+++ b/src/main/java/com/stumeet/server/studymember/adapter/out/persistence/repository/JpaStudyMemberRepositoryCustom.java
@@ -2,6 +2,7 @@ package com.stumeet.server.studymember.adapter.out.persistence.repository;
 
 import com.stumeet.server.studymember.adapter.out.persistence.entity.StudyMemberJpaEntity;
 import com.stumeet.server.studymember.application.port.in.response.SimpleStudyMemberResponse;
+import com.stumeet.server.studymember.application.port.in.response.StudyMemberReviewStatusResponse;
 
 import java.util.List;
 import java.util.Optional;
@@ -11,6 +12,8 @@ public interface JpaStudyMemberRepositoryCustom {
     Optional<StudyMemberJpaEntity> findStudyMemberByStudyIdAndMemberId(Long studyId, Long memberId);
 
     List<SimpleStudyMemberResponse> findStudyMembersByStudyId(Long studyId);
+
+    List<StudyMemberReviewStatusResponse> findStudyMemberReviewStatusByMember(Long studyId, Long memberId);
 
     boolean isStudyJoinMember(Long studyId, Long memberId);
 

--- a/src/main/java/com/stumeet/server/studymember/adapter/out/persistence/repository/JpaStudyMemberRepositoryCustomImpl.java
+++ b/src/main/java/com/stumeet/server/studymember/adapter/out/persistence/repository/JpaStudyMemberRepositoryCustomImpl.java
@@ -1,9 +1,11 @@
 package com.stumeet.server.studymember.adapter.out.persistence.repository;
 
+import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.stumeet.server.studymember.adapter.out.persistence.entity.StudyMemberJpaEntity;
 import com.stumeet.server.studymember.application.port.in.response.QSimpleStudyMemberResponse;
 import com.stumeet.server.studymember.application.port.in.response.SimpleStudyMemberResponse;
+import com.stumeet.server.studymember.application.port.in.response.StudyMemberReviewStatusResponse;
 
 import lombok.RequiredArgsConstructor;
 
@@ -11,6 +13,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static com.stumeet.server.studymember.adapter.out.persistence.entity.QStudyMemberJpaEntity.studyMemberJpaEntity;
+import static com.stumeet.server.studymember.adapter.out.persistence.entity.QStudyMemberReview.studyMemberReview;
 
 @RequiredArgsConstructor
 public class JpaStudyMemberRepositoryCustomImpl implements JpaStudyMemberRepositoryCustom {
@@ -47,6 +50,28 @@ public class JpaStudyMemberRepositoryCustomImpl implements JpaStudyMemberReposit
                 .from(studyMemberJpaEntity)
                 .innerJoin(studyMemberJpaEntity.member)
                 .where(studyMemberJpaEntity.study.id.eq(studyId))
+                .fetch();
+    }
+
+    @Override
+    public List<StudyMemberReviewStatusResponse> findStudyMemberReviewStatusByMember(Long studyId, Long memberId) {
+        return query
+                .select(Projections.constructor(
+                        StudyMemberReviewStatusResponse.class,
+                        studyMemberJpaEntity.id,
+                        studyMemberJpaEntity.member.id,
+                        studyMemberJpaEntity.member.name,
+                        studyMemberJpaEntity.member.region,
+                        studyMemberJpaEntity.member.profession.name,
+                        studyMemberJpaEntity.member.image,
+                        studyMemberReview.id.isNotNull()
+                ))
+                .from(studyMemberJpaEntity)
+                .leftJoin(studyMemberReview)
+                .on(studyMemberReview.reviewerId.eq(memberId)
+                        .and(studyMemberReview.revieweeId.eq(studyMemberJpaEntity.member.id)))
+                .where(studyMemberJpaEntity.study.id.eq(studyId)
+                        .and(studyMemberJpaEntity.member.id.ne(memberId)))
                 .fetch();
     }
 

--- a/src/main/java/com/stumeet/server/studymember/application/port/in/StudyMemberQueryUseCase.java
+++ b/src/main/java/com/stumeet/server/studymember/application/port/in/StudyMemberQueryUseCase.java
@@ -1,8 +1,11 @@
 package com.stumeet.server.studymember.application.port.in;
 
+import java.util.List;
+
 import com.stumeet.server.studymember.application.port.in.response.StudyMemberAdminResponse;
 import com.stumeet.server.studymember.application.port.in.response.StudyMemberDetailResponse;
 import com.stumeet.server.studymember.application.port.in.response.StudyMemberResponses;
+import com.stumeet.server.studymember.application.port.in.response.StudyMemberReviewStatusResponse;
 
 public interface StudyMemberQueryUseCase {
     StudyMemberResponses getStudyMembers(Long studyId, Long requesterId);
@@ -12,4 +15,6 @@ public interface StudyMemberQueryUseCase {
     StudyMemberAdminResponse isMemberAdmin(Long studyId, Long memberId);
 
     boolean canSendGrape(Long studyId, Long memberId);
+
+    List<StudyMemberReviewStatusResponse> getStudyMemberReviewStatusByMember(Long studyId, Long memberId);
 }

--- a/src/main/java/com/stumeet/server/studymember/application/port/in/response/StudyMemberReviewStatusResponse.java
+++ b/src/main/java/com/stumeet/server/studymember/application/port/in/response/StudyMemberReviewStatusResponse.java
@@ -1,0 +1,17 @@
+package com.stumeet.server.studymember.application.port.in.response;
+
+import com.querydsl.core.annotations.QueryProjection;
+
+public record StudyMemberReviewStatusResponse(
+        Long studyMemberId,
+        Long memberId,
+        String name,
+        String region,
+        String profession,
+        String image,
+        Boolean isReviewed
+) {
+    @QueryProjection
+    public StudyMemberReviewStatusResponse {
+    }
+}

--- a/src/main/java/com/stumeet/server/studymember/application/port/out/StudyMemberQueryPort.java
+++ b/src/main/java/com/stumeet/server/studymember/application/port/out/StudyMemberQueryPort.java
@@ -1,6 +1,7 @@
 package com.stumeet.server.studymember.application.port.out;
 
 import com.stumeet.server.studymember.application.port.in.response.SimpleStudyMemberResponse;
+import com.stumeet.server.studymember.application.port.in.response.StudyMemberReviewStatusResponse;
 import com.stumeet.server.studymember.domain.StudyMember;
 
 import java.util.List;
@@ -13,4 +14,6 @@ public interface StudyMemberQueryPort {
     StudyMember findStudyMember(Long studyMemberId);
 
     boolean isSentGrape(Long studyId, Long memberId);
+
+    List<StudyMemberReviewStatusResponse> findStudyMemberReviewStatusByMember(Long studyId, Long memberId);
 }

--- a/src/main/java/com/stumeet/server/studymember/application/service/StudyMemberQueryService.java
+++ b/src/main/java/com/stumeet/server/studymember/application/service/StudyMemberQueryService.java
@@ -10,6 +10,7 @@ import com.stumeet.server.studymember.application.port.in.response.StudyMemberGr
 import com.stumeet.server.studymember.application.port.in.response.StudyMemberResponses;
 import com.stumeet.server.studymember.application.port.in.StudyMemberQueryUseCase;
 import com.stumeet.server.studymember.application.port.in.StudyMemberValidationUseCase;
+import com.stumeet.server.studymember.application.port.in.response.StudyMemberReviewStatusResponse;
 import com.stumeet.server.studymember.application.port.out.StudyMemberQueryPort;
 import com.stumeet.server.studymember.application.port.out.StudyMemberValidationPort;
 import com.stumeet.server.studymember.domain.StudyMember;
@@ -73,5 +74,14 @@ public class StudyMemberQueryService implements StudyMemberQueryUseCase {
         studyValidationUseCase.checkById(studyId);
 
         return !studyMemberQueryPort.isSentGrape(studyId, memberId);
+    }
+
+    @Override
+    public List<StudyMemberReviewStatusResponse> getStudyMemberReviewStatusByMember(Long studyId, Long memberId) {
+        studyValidationUseCase.checkById(studyId);
+        studyValidationUseCase.checkLegacyStudy(studyId);
+        studyMemberValidationUseCase.checkStudyJoinMember(studyId, memberId);
+
+        return studyMemberQueryPort.findStudyMemberReviewStatusByMember(studyId, memberId);
     }
 }

--- a/src/test/java/com/stumeet/server/stub/ReviewStub.java
+++ b/src/test/java/com/stumeet/server/stub/ReviewStub.java
@@ -9,7 +9,7 @@ public class ReviewStub {
     public static ReviewRegisterRequest getReviewRegisterRequest() {
         return new ReviewRegisterRequest(
             2L,
-            1L,
+            3L,
             5,
             "성실하게 참여해주셨습니다.",
             List.of("TASK_COMMITMENT", "CONSISTENT_ATTENDANCE")
@@ -29,7 +29,7 @@ public class ReviewStub {
     public static ReviewRegisterRequest getRevieweeNotJoinedReviewRegisterRequest() {
         return new ReviewRegisterRequest(
             3L,
-            1L,
+            3L,
             5,
             "성실하게 참여해주셨습니다.",
             List.of("TASK_COMMITMENT", "CONSISTENT_ATTENDANCE")
@@ -39,7 +39,7 @@ public class ReviewStub {
     public static ReviewRegisterRequest getRateOutOfRangeReviewRegisterRequest() {
         return new ReviewRegisterRequest(
             2L,
-            1L,
+            3L,
             10,
             "성실하게 참여해주셨습니다.",
             List.of("TASK_COMMITMENT", "CONSISTENT_ATTENDANCE")
@@ -49,7 +49,7 @@ public class ReviewStub {
     public static ReviewRegisterRequest getInvalidReviewTagCountReviewRegisterRequest() {
         return new ReviewRegisterRequest(
             2L,
-            1L,
+            3L,
             10,
             "성실하게 참여해주셨습니다.",
             List.of("TASK_COMMITMENT", "CONSISTENT_ATTENDANCE")
@@ -59,7 +59,7 @@ public class ReviewStub {
     public static ReviewRegisterRequest getAlreadyReviewedRegisterRequest() {
         return new ReviewRegisterRequest(
             4L,
-            1L,
+            3L,
             5,
             "성실하게 참여해주셨습니다.",
             List.of("TASK_COMMITMENT", "CONSISTENT_ATTENDANCE")

--- a/src/test/java/com/stumeet/server/studymember/adapter/in/web/LegacyStudyHideApiTest.java
+++ b/src/test/java/com/stumeet/server/studymember/adapter/in/web/LegacyStudyHideApiTest.java
@@ -49,7 +49,7 @@ class LegacyStudyHideApiTest extends ApiTest {
         }
 
         @Test
-        @WithMockMember(id = 2L)
+        @WithMockMember(id = 3L)
         @DisplayName("[실패] 요청자가 스터디 멤버가 아닌 경우 경우 숨김 처리에 실패한다.")
         void fail_when_requester_not_joined_study_member() throws Exception {
             mockMvc.perform(patch(PATH, StudyStub.getFinishedStudyId())

--- a/src/test/java/com/stumeet/server/studymember/adapter/in/web/StudyMemberQueryApiTest.java
+++ b/src/test/java/com/stumeet/server/studymember/adapter/in/web/StudyMemberQueryApiTest.java
@@ -64,7 +64,6 @@ class StudyMemberQueryApiTest extends ApiTest {
                                     fieldWithPath("data.studyMembers[].profession").description("스터디 멤버 분야"),
                                     fieldWithPath("data.studyMembers[].isAdmin").description("스터디 관리자 여부")
                             )));
-
         }
 
         @Test
@@ -332,6 +331,136 @@ class StudyMemberQueryApiTest extends ApiTest {
                                     fieldWithPath("message").description("응답 메시지")
                             ))
                     );
+        }
+    }
+
+    @Nested
+    @DisplayName("특정 멤버의 스터디 멤버 리뷰 상태 조회")
+    class GetUnreviewedStudyMembersForMember {
+        private final String path = "/api/v1/studies/{studyId}/members/review-status";
+
+        @Test
+        @WithMockMember
+        @DisplayName("[성공] 특정 멤버의 스터디 멤버 리뷰 상태 목록을 조회할 수 있다.")
+        void success() throws Exception {
+            Long studyId = StudyStub.getFinishedStudyId();
+
+            mockMvc.perform(get(path, studyId)
+                            .header(AuthenticationHeader.ACCESS_TOKEN.getName(), TokenStub.getKakaoAccessToken()))
+                    .andExpect(status().isOk())
+                    .andDo(document("get-study-member-review-status/success",
+                            preprocessRequest(prettyPrint()),
+                            preprocessResponse(prettyPrint()),
+                            requestHeaders(
+                                    headerWithName(AuthenticationHeader.ACCESS_TOKEN.getName()).description(
+                                            "서버로부터 전달받은 액세스 토큰")
+                            ),
+                            pathParameters(
+                                    parameterWithName("studyId").description("스터디 ID")
+                            ),
+                            requestHeaders(
+                                    headerWithName(AuthenticationHeader.ACCESS_TOKEN.getName()).description(
+                                            "서버로부터 전달받은 액세스 토큰")
+                            ),
+                            responseFields(
+                                    fieldWithPath("code").description("응답 코드"),
+                                    fieldWithPath("message").description("응답 메시지"),
+                                    fieldWithPath("data").description("스터디 멤버 리뷰 상태 목록"),
+                                    fieldWithPath("data[].studyMemberId").description("스터디 멤버 ID"),
+                                    fieldWithPath("data[].memberId").description("멤버 ID"),
+                                    fieldWithPath("data[].name").description("멤버 이름"),
+                                    fieldWithPath("data[].region").description("멤버가 활동하는 지역"),
+                                    fieldWithPath("data[].profession").description("멤버의 직업"),
+                                    fieldWithPath("data[].image").description("멤버 프로필 이미지 URL"),
+                                    fieldWithPath("data[].isReviewed").description("리뷰가 작성되었는지 여부")
+                            )));
+        }
+
+        @Test
+        @WithMockMember
+        @DisplayName("[실패] 스터디가 존재하지 않으면, 특정 멤버의 스터디 멤버 리뷰 상태 목록 조회에 실패한다.")
+        void fail_when_study_not_found() throws Exception {
+            Long studyId = StudyStub.getInvalidStudyId();
+
+            mockMvc.perform(get(path, studyId)
+                            .header(AuthenticationHeader.ACCESS_TOKEN.getName(), TokenStub.getKakaoAccessToken()))
+                    .andExpect(status().isNotFound())
+                    .andDo(document("get-study-member-review-status/fail/study-not-found",
+                            preprocessRequest(prettyPrint()),
+                            preprocessResponse(prettyPrint()),
+                            requestHeaders(
+                                    headerWithName(AuthenticationHeader.ACCESS_TOKEN.getName()).description(
+                                            "서버로부터 전달받은 액세스 토큰")
+                            ),
+                            pathParameters(
+                                    parameterWithName("studyId").description("스터디 ID")
+                            ),
+                            requestHeaders(
+                                    headerWithName(AuthenticationHeader.ACCESS_TOKEN.getName()).description(
+                                            "서버로부터 전달받은 액세스 토큰")
+                            ),
+                            responseFields(
+                                    fieldWithPath("code").description("응답 코드"),
+                                    fieldWithPath("message").description("응답 메시지")
+                            )));
+        }
+
+        @Test
+        @WithMockMember
+        @DisplayName("[실패] 완료된 스터디가 아니라면, 특정 멤버의 스터디 멤버 리뷰 상태 목록 조회에 실패한다.")
+        void fail_when_study_not_legacy() throws Exception {
+            Long studyId = StudyStub.getStudyId();
+
+            mockMvc.perform(get(path, studyId)
+                            .header(AuthenticationHeader.ACCESS_TOKEN.getName(), TokenStub.getKakaoAccessToken()))
+                    .andExpect(status().isConflict())
+                    .andDo(document("get-study-member-review-status/fail/study-not-legacy",
+                            preprocessRequest(prettyPrint()),
+                            preprocessResponse(prettyPrint()),
+                            requestHeaders(
+                                    headerWithName(AuthenticationHeader.ACCESS_TOKEN.getName()).description(
+                                            "서버로부터 전달받은 액세스 토큰")
+                            ),
+                            pathParameters(
+                                    parameterWithName("studyId").description("스터디 ID")
+                            ),
+                            requestHeaders(
+                                    headerWithName(AuthenticationHeader.ACCESS_TOKEN.getName()).description(
+                                            "서버로부터 전달받은 액세스 토큰")
+                            ),
+                            responseFields(
+                                    fieldWithPath("code").description("응답 코드"),
+                                    fieldWithPath("message").description("응답 메시지")
+                            )));
+        }
+
+        @Test
+        @WithMockMember(id = 3L)
+        @DisplayName("[실패] 요청 멤버가 해당 스터디의 멤버가 아니라면, 특정 멤버의 스터디 멤버 리뷰 상태 목록 조회에 실패한다.")
+        void fail_when_member_not_study_member() throws Exception {
+            Long studyId = StudyStub.getFinishedStudyId();
+
+            mockMvc.perform(get(path, studyId)
+                            .header(AuthenticationHeader.ACCESS_TOKEN.getName(), TokenStub.getKakaoAccessToken()))
+                    .andExpect(status().isForbidden())
+                    .andDo(document("get-study-member-review-status/fail/member-not-joined-member",
+                            preprocessRequest(prettyPrint()),
+                            preprocessResponse(prettyPrint()),
+                            requestHeaders(
+                                    headerWithName(AuthenticationHeader.ACCESS_TOKEN.getName()).description(
+                                            "서버로부터 전달받은 액세스 토큰")
+                            ),
+                            pathParameters(
+                                    parameterWithName("studyId").description("스터디 ID")
+                            ),
+                            requestHeaders(
+                                    headerWithName(AuthenticationHeader.ACCESS_TOKEN.getName()).description(
+                                            "서버로부터 전달받은 액세스 토큰")
+                            ),
+                            responseFields(
+                                    fieldWithPath("code").description("응답 코드"),
+                                    fieldWithPath("message").description("응답 메시지")
+                            )));
         }
     }
 }

--- a/src/test/resources/db/setup.sql
+++ b/src/test/resources/db/setup.sql
@@ -75,6 +75,7 @@ VALUES (2, 'test2', 'http://localhost:4572/user/1/profile/2024030416531039839905
 INSERT INTO device (member_id, device_id, notification_token) VALUES (2, 'AJDLKJGALKJ', 'WEAGEEWXVVVV');
 
 INSERT INTO study_member (member_id, study_id, is_admin, is_sent_grape) VALUES (2, 1, false, false);
+INSERT INTO study_member (member_id, study_id, is_admin, is_sent_grape) VALUES (2, 3, false, false);
 
 INSERT INTO topic_subscription (topic_id, member_id) VALUES (1, 2);
 
@@ -93,24 +94,9 @@ VALUES (4, 'test4', 'http://localhost:4572/user/1/profile/2024030416531039839905
 INSERT INTO device (member_id, device_id, notification_token) VALUES (4, 'ADGERGRGJSJHG', 'AHFGFJHGHKHVV');
 
 INSERT INTO study_member (member_id, study_id, is_admin, is_sent_grape) VALUES (4, 1, false, true);
+INSERT INTO study_member (member_id, study_id, is_admin, is_sent_grape) VALUES (4, 3, false, false);
 
 INSERT INTO topic_subscription (topic_id, member_id) VALUES (1, 4);
-
-INSERT INTO review (id, reviewer_id, reviewee_id, study_id, rate, content)
-VALUES (1, 1, 4, 1, 5, '리뷰 내용입니다.');
-
-INSERT INTO review_tag (review_id, review_tag)
-VALUES (1, 'MAX_RESPONSIBILITY');
-
-INSERT INTO review (id, reviewer_id, reviewee_id, study_id, rate, content)
-VALUES (2, 2, 4, 1, 5, '리뷰 내용입니다.');
-
-INSERT INTO review_tag (review_id, review_tag)
-VALUES (2, 'MAX_RESPONSIBILITY');
-INSERT INTO review_tag (review_id, review_tag)
-VALUES (2, 'FAST_RESPONSE');
-INSERT INTO review_tag (review_id, review_tag)
-VALUES (2, 'MOOD_MAKER');
 
 
 -- [TABLE: activity]
@@ -173,7 +159,7 @@ INSERT INTO activity_participant (activity_id, member_id, status) VALUES (6, 2, 
 INSERT INTO activity (id, study_id, author_id, category, title, content, is_notice, start_date, end_date, location)
 VALUES (7, 1, 1, 'ASSIGNMENT', 'title', 'content', false, '2024-04-08T00:00:00', '2024-04-15T00:00:00', null);
 
-INSERT INTO activity_participant (activity_id, member_id, status) VALUES (6, 2, 'PERFORMED');
+INSERT INTO activity_participant (activity_id, member_id, status) VALUES (7, 2, 'PERFORMED');
 
 -- 스터디 2 (공지) 기본 활동
 INSERT INTO activity(id, study_id, author_id, category, title, content, is_notice, location)
@@ -184,3 +170,21 @@ INSERT INTO activity_image (activity_id, image) VALUES (8, 'https://example.com/
 INSERT INTO activity_image (activity_id, image) VALUES (8, 'https://example.com/images/image3.png');
 INSERT INTO activity_participant (activity_id, member_id, status) VALUES (8, 1, 'NONE');
 INSERT INTO activity_participant (activity_id, member_id, status) VALUES (8, 2, 'NONE');
+
+
+-- [TABLE: review]
+INSERT INTO review (id, reviewer_id, reviewee_id, study_id, rate, content)
+VALUES (1, 1, 4, 3, 5, '리뷰 내용입니다.');
+
+INSERT INTO review_tag (review_id, review_tag)
+VALUES (1, 'MAX_RESPONSIBILITY');
+
+INSERT INTO review (id, reviewer_id, reviewee_id, study_id, rate, content)
+VALUES (2, 2, 4, 3, 5, '리뷰 내용입니다.');
+
+INSERT INTO review_tag (review_id, review_tag)
+VALUES (2, 'MAX_RESPONSIBILITY');
+INSERT INTO review_tag (review_id, review_tag)
+VALUES (2, 'FAST_RESPONSE');
+INSERT INTO review_tag (review_id, review_tag)
+VALUES (2, 'MOOD_MAKER');


### PR DESCRIPTION
## 💁 해결 하려는 문제를 적어주세요 

- 사용자에게 특정 스터디에서 리뷰를 작성하지 않은 스터디 멤버의 목록을 조회할 필요성이 있었습니다.
## 🤔 어떤 방식으로 해결했는지 적어주세요 

- 로그인한 멤버를 기준으로 특정 스터디의 멤버 리뷰 상태 목록을 조회하는 API를 구현했습니다.

## 🧑‍🏫 이해를 위해 필요한 자료가 있다면 첨부해주세요
<img src="https://github.com/user-attachments/assets/c249ac06-2d62-4685-9459-09683da2cce6" width=300>