### PR TITLE
✨ [STMT-187] 활동 목록 간략/상세 조회 API: 복수 카테고리 선택, 정렬 기준 추가

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -759,7 +759,15 @@ include::{snippets}/update-activity/fail/not-author/response-fields.adoc[]
 
 스터디 활동 상세 목록을 조회하는 API입니다.
 
-* 정렬 기준: 생성일
+.정렬 기준
+[horizontal]
+`LATEST`:: 최신순
+** 모든 유형: 생성일 기준 정렬
+`SPECIFIC`:: 각 유형 기준
+** 활동 유형 `MEET`: 활동 시작일
+** 활동 유형 `ASSIGNMENT`: 활동 종료일
+** 활동 유형 `DEFAULT`: 생성일
+** 활동 유형 조건이 없는 경우: 생성일
 
 ==== GET /api/v1/studies/activities/detail
 ===== 요청
@@ -786,16 +794,20 @@ include::{snippets}/get-activity-details-by-condition/fail/study-not-found/respo
 
 스터디 활동 간략 목록을 조회하는 API입니다. 페이지네이션과 단순 조회를 모두 지원합니다.
 
-* 날짜 기준
-- 활동 유형 `MEET`: 활동 시작일
-- 활동 유형 `ASSIGNMENT`: 활동 종료일
-- 활동 유형 `DEFAULT`: 생성일
+.날짜 기준
+* 활동 유형 `MEET`: 활동 시작일
+* 활동 유형 `ASSIGNMENT`: 활동 종료일
+* 활동 유형 `DEFAULT`: 생성일
 
-* 정렬 기준
-- 활동 유형 `MEET`: 활동 시작일
-- 활동 유형 `ASSIGNMENT`: 활동 종료일
-- 활동 유형 `DEFAULT`: 생성일
-- 활동 유형 조건이 없는 경우: 생성일
+.정렬 기준
+[horizontal]
+`LATEST`:: 최신순
+** 모든 유형: 생성일 기준 정렬
+`SPECIFIC`:: 각 유형 기준
+** 활동 유형 `MEET`: 활동 시작일
+** 활동 유형 `ASSIGNMENT`: 활동 종료일
+** 활동 유형 `DEFAULT`: 생성일
+** 활동 유형 조건이 없는 경우: 생성일
 
 ==== GET /api/v1/studies/activities/brief
 ===== 요청

--- a/src/main/java/com/stumeet/server/activity/adapter/in/ActivityQueryApi.java
+++ b/src/main/java/com/stumeet/server/activity/adapter/in/ActivityQueryApi.java
@@ -54,7 +54,7 @@ public class ActivityQueryApi {
 			@RequestParam @Min(value = 0) Integer page,
 			@RequestParam(required = false) Boolean isNotice,
 			@RequestParam(required = false) Long studyId,
-			@RequestParam(required = false) List<ActivityCategory> category,
+			@RequestParam(name = "category", required = false) List<ActivityCategory> categories,
 			@RequestParam(required = false) ActivitySort sort
 	) {
 		ActivityListDetailedQuery query = ActivityListDetailedQuery.builder()
@@ -63,7 +63,7 @@ public class ActivityQueryApi {
 				.isNotice(isNotice)
 				.studyId(studyId)
 				.memberId(member.getId())
-				.categories(category)
+				.categories(categories)
 				.sort(sort)
 				.build();
 		ActivityListDetailedPageResponses response = activityQueryUseCase.getDetails(query);
@@ -80,9 +80,10 @@ public class ActivityQueryApi {
 			@RequestParam(required = false) Boolean isNotice,
 			@RequestParam(required = false) Long studyId,
 			@RequestParam(required = false) Long memberId,
-			@RequestParam(required = false) String category,
+			@RequestParam(name = "category", required = false) List<ActivityCategory> categories,
 			@RequestParam(required = false) LocalDateTime fromDate,
-			@RequestParam(required = false) LocalDateTime toDate
+			@RequestParam(required = false) LocalDateTime toDate,
+			@RequestParam(required = false) ActivitySort sort
 	) {
 		ActivityListBriefQuery query = ActivityListBriefQuery.builder()
 				.size(size)
@@ -90,9 +91,10 @@ public class ActivityQueryApi {
 				.isNotice(isNotice)
 				.studyId(studyId)
 				.memberId(memberId != null ? memberId : member.getId())
-				.categoryName(category)
+				.categories(categories)
 				.fromDate(fromDate)
 				.toDate(toDate)
+				.sort(sort)
 				.build();
 		ActivityListBriefResponses response = activityQueryUseCase.getBriefs(query);
 

--- a/src/main/java/com/stumeet/server/activity/adapter/in/ActivityQueryApi.java
+++ b/src/main/java/com/stumeet/server/activity/adapter/in/ActivityQueryApi.java
@@ -1,6 +1,7 @@
 package com.stumeet.server.activity.adapter.in;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import com.stumeet.server.activity.adapter.in.response.ActivityDetailResponse;
 import com.stumeet.server.activity.adapter.in.response.ActivityListBriefResponses;
@@ -8,6 +9,8 @@ import com.stumeet.server.activity.adapter.in.response.ActivityListDetailedPageR
 import com.stumeet.server.activity.application.port.in.ActivityQueryUseCase;
 import com.stumeet.server.activity.application.port.in.query.ActivityListBriefQuery;
 import com.stumeet.server.activity.application.port.in.query.ActivityListDetailedQuery;
+import com.stumeet.server.activity.domain.model.ActivityCategory;
+import com.stumeet.server.activity.domain.model.ActivitySort;
 import com.stumeet.server.common.annotation.WebAdapter;
 import com.stumeet.server.common.auth.model.LoginMember;
 import com.stumeet.server.common.model.ApiResponse;
@@ -51,7 +54,8 @@ public class ActivityQueryApi {
 			@RequestParam @Min(value = 0) Integer page,
 			@RequestParam(required = false) Boolean isNotice,
 			@RequestParam(required = false) Long studyId,
-			@RequestParam(required = false) String category
+			@RequestParam(required = false) List<ActivityCategory> category,
+			@RequestParam(required = false) ActivitySort sort
 	) {
 		ActivityListDetailedQuery query = ActivityListDetailedQuery.builder()
 				.size(size)
@@ -59,7 +63,8 @@ public class ActivityQueryApi {
 				.isNotice(isNotice)
 				.studyId(studyId)
 				.memberId(member.getId())
-				.categoryName(category)
+				.categories(category)
+				.sort(sort)
 				.build();
 		ActivityListDetailedPageResponses response = activityQueryUseCase.getDetails(query);
 

--- a/src/main/java/com/stumeet/server/activity/adapter/in/converter/ActivityCategoryConverter.java
+++ b/src/main/java/com/stumeet/server/activity/adapter/in/converter/ActivityCategoryConverter.java
@@ -1,0 +1,21 @@
+package com.stumeet.server.activity.adapter.in.converter;
+
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+
+import com.stumeet.server.activity.domain.exception.NotExistsActivityCategoryException;
+import com.stumeet.server.activity.domain.model.ActivityCategory;
+import com.stumeet.server.common.exception.model.EnumValidationException;
+import com.stumeet.server.common.response.ErrorCode;
+
+@Component
+public class ActivityCategoryConverter implements Converter<String, ActivityCategory> {
+    @Override
+    public ActivityCategory convert(String source) {
+        try {
+            return ActivityCategory.getByName(source.toUpperCase());
+        } catch (NotExistsActivityCategoryException e) {
+            throw new EnumValidationException(ErrorCode.INVALID_ACTIVITY_CATEGORY_EXCEPTION, ActivityCategory.class, source);
+        }
+    }
+}

--- a/src/main/java/com/stumeet/server/activity/adapter/in/converter/ActivitySortConverter.java
+++ b/src/main/java/com/stumeet/server/activity/adapter/in/converter/ActivitySortConverter.java
@@ -1,0 +1,21 @@
+package com.stumeet.server.activity.adapter.in.converter;
+
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+
+import com.stumeet.server.activity.domain.exception.NotExistsActivitySortException;
+import com.stumeet.server.activity.domain.model.ActivitySort;
+import com.stumeet.server.common.exception.model.EnumValidationException;
+import com.stumeet.server.common.response.ErrorCode;
+
+@Component
+public class ActivitySortConverter implements Converter<String, ActivitySort> {
+    @Override
+    public ActivitySort convert(String source) {
+        try {
+            return ActivitySort.getByName(source.toUpperCase());
+        } catch (NotExistsActivitySortException e) {
+            throw new EnumValidationException(ErrorCode.INVALID_ACTIVITY_SORT_EXCEPTION, ActivitySort.class, source);
+        }
+    }
+}

--- a/src/main/java/com/stumeet/server/activity/adapter/out/persistence/ActivityPersistenceAdapter.java
+++ b/src/main/java/com/stumeet/server/activity/adapter/out/persistence/ActivityPersistenceAdapter.java
@@ -16,6 +16,7 @@ import com.stumeet.server.activity.application.port.out.ActivityQueryPort;
 import com.stumeet.server.activity.domain.exception.NotExistsActivityException;
 import com.stumeet.server.activity.domain.model.Activity;
 import com.stumeet.server.activity.domain.model.ActivityCategory;
+import com.stumeet.server.activity.domain.model.ActivitySort;
 import com.stumeet.server.common.annotation.PersistenceAdapter;
 
 import lombok.RequiredArgsConstructor;
@@ -51,9 +52,9 @@ public class ActivityPersistenceAdapter implements ActivitySavePort, ActivityQue
     }
 
     @Override
-    public Page<Activity> getDetailPagesByCondition(Pageable pageable, Boolean isNotice, Long studyId, ActivityCategory category) {
+    public Page<Activity> getDetailPagesByCondition(Pageable pageable, Boolean isNotice, Long studyId, List<ActivityCategory> categories, ActivitySort sort) {
         Page<ActivityJpaEntity> entities =
-                jpaActivityRepository.findDetailPagesByCondition(pageable, isNotice, studyId, category);
+                jpaActivityRepository.findDetailPagesByCondition(pageable, isNotice, studyId, categories, sort);
 
         return activityPersistenceMapper.toDomainPages(entities);
     }

--- a/src/main/java/com/stumeet/server/activity/adapter/out/persistence/ActivityPersistenceAdapter.java
+++ b/src/main/java/com/stumeet/server/activity/adapter/out/persistence/ActivityPersistenceAdapter.java
@@ -61,14 +61,15 @@ public class ActivityPersistenceAdapter implements ActivitySavePort, ActivityQue
 
     @Override
     public Page<ActivityListBriefResponse> getPaginatedBriefsByCondition(Pageable pageable, Boolean isNotice, Long memberId,
-            Long studyId, ActivityCategory category, LocalDateTime startDate, LocalDateTime endDate) {
-        return jpaActivityRepository.findBriefsByConditionWithPagination(pageable, isNotice, memberId, studyId, category, startDate, endDate);
+            Long studyId, List<ActivityCategory> categories, LocalDateTime startDate, LocalDateTime endDate, ActivitySort sort) {
+        return jpaActivityRepository.findBriefsByConditionWithPagination(pageable, isNotice, memberId, studyId,
+                categories, startDate, endDate, sort);
     }
 
     @Override
     public List<ActivityListBriefResponse> getBriefsByCondition(Boolean isNotice, Long memberId, Long studyId,
-            ActivityCategory category, LocalDateTime startDate, LocalDateTime endDate) {
-        return jpaActivityRepository.findBriefsByCondition(isNotice, memberId, studyId, category, startDate, endDate);
+            List<ActivityCategory> categories, LocalDateTime startDate, LocalDateTime endDate, ActivitySort sort) {
+        return jpaActivityRepository.findBriefsByCondition(isNotice, memberId, studyId, categories, startDate, endDate, sort);
     }
 
     @Override

--- a/src/main/java/com/stumeet/server/activity/adapter/out/persistence/JpaActivityRepositoryCustom.java
+++ b/src/main/java/com/stumeet/server/activity/adapter/out/persistence/JpaActivityRepositoryCustom.java
@@ -9,9 +9,10 @@ import org.springframework.data.domain.Pageable;
 import com.stumeet.server.activity.adapter.in.response.ActivityListBriefResponse;
 import com.stumeet.server.activity.adapter.out.model.ActivityJpaEntity;
 import com.stumeet.server.activity.domain.model.ActivityCategory;
+import com.stumeet.server.activity.domain.model.ActivitySort;
 
 public interface JpaActivityRepositoryCustom {
-	Page<ActivityJpaEntity> findDetailPagesByCondition(Pageable pageable, Boolean isNotice, Long studyId, ActivityCategory category);
+	Page<ActivityJpaEntity> findDetailPagesByCondition(Pageable pageable, Boolean isNotice, Long studyId, List<ActivityCategory> categories, ActivitySort sort);
 
 	Page<ActivityListBriefResponse> findBriefsByConditionWithPagination(Pageable pageable, Boolean isNotice, Long memberId, Long studyId, ActivityCategory category, LocalDateTime startDate, LocalDateTime endDate);
 

--- a/src/main/java/com/stumeet/server/activity/adapter/out/persistence/JpaActivityRepositoryCustom.java
+++ b/src/main/java/com/stumeet/server/activity/adapter/out/persistence/JpaActivityRepositoryCustom.java
@@ -14,7 +14,7 @@ import com.stumeet.server.activity.domain.model.ActivitySort;
 public interface JpaActivityRepositoryCustom {
 	Page<ActivityJpaEntity> findDetailPagesByCondition(Pageable pageable, Boolean isNotice, Long studyId, List<ActivityCategory> categories, ActivitySort sort);
 
-	Page<ActivityListBriefResponse> findBriefsByConditionWithPagination(Pageable pageable, Boolean isNotice, Long memberId, Long studyId, ActivityCategory category, LocalDateTime startDate, LocalDateTime endDate);
+	Page<ActivityListBriefResponse> findBriefsByConditionWithPagination(Pageable pageable, Boolean isNotice, Long memberId, Long studyId, List<ActivityCategory> categories, LocalDateTime startDate, LocalDateTime endDate, ActivitySort sort);
 
-	List<ActivityListBriefResponse> findBriefsByCondition(Boolean isNotice, Long memberId, Long studyId, ActivityCategory category, LocalDateTime startDate, LocalDateTime endDate);
+	List<ActivityListBriefResponse> findBriefsByCondition(Boolean isNotice, Long memberId, Long studyId, List<ActivityCategory> categories, LocalDateTime startDate, LocalDateTime endDate, ActivitySort sort);
 }

--- a/src/main/java/com/stumeet/server/activity/adapter/out/persistence/JpaActivityRepositoryCustomImpl.java
+++ b/src/main/java/com/stumeet/server/activity/adapter/out/persistence/JpaActivityRepositoryCustomImpl.java
@@ -13,6 +13,7 @@ import org.springframework.data.support.PageableExecutionUtils;
 
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.CaseBuilder;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -20,6 +21,7 @@ import com.stumeet.server.activity.adapter.in.response.ActivityListBriefResponse
 import com.stumeet.server.activity.adapter.in.response.QActivityListBriefResponse;
 import com.stumeet.server.activity.adapter.out.model.ActivityJpaEntity;
 import com.stumeet.server.activity.domain.model.ActivityCategory;
+import com.stumeet.server.activity.domain.model.ActivitySort;
 
 import lombok.RequiredArgsConstructor;
 
@@ -30,18 +32,18 @@ public class JpaActivityRepositoryCustomImpl implements JpaActivityRepositoryCus
 
     @Override
     public Page<ActivityJpaEntity> findDetailPagesByCondition(
-            Pageable pageable, Boolean isNotice, Long studyId, ActivityCategory category) {
+            Pageable pageable, Boolean isNotice, Long studyId, List<ActivityCategory> categories, ActivitySort sort) {
         List<ActivityJpaEntity> content = query
                 .selectFrom(activityJpaEntity)
                 .join(activityJpaEntity.study, activityLinkedStudyJpaEntity).fetchJoin()
                 .where(
                         isNoticeEq(isNotice),
                         studyIdEq(studyId),
-                        categoryEq(category)
+                        categoriesEq(categories)
                 )
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
-                .orderBy(activityJpaEntity.createdAt.desc())
+                .orderBy(orderBy(sort).toArray(OrderSpecifier[]::new))
                 .fetch();
 
         JPAQuery<Long> countQuery = query
@@ -50,7 +52,7 @@ public class JpaActivityRepositoryCustomImpl implements JpaActivityRepositoryCus
                 .where(
                         isNoticeEq(isNotice),
                         studyIdEq(studyId),
-                        categoryEq(category)
+                        categoriesEq(categories)
                 );
 
         return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
@@ -147,6 +149,10 @@ public class JpaActivityRepositoryCustomImpl implements JpaActivityRepositoryCus
                 .fetch();
     }
 
+    private BooleanExpression alwaysTrue() {
+        return Expressions.asBoolean(true).isTrue();
+    }
+
     private BooleanExpression isNoticeEq(Boolean isNotice) {
         return isNotice != null ? activityJpaEntity.isNotice.eq(isNotice) : null;
     }
@@ -156,7 +162,15 @@ public class JpaActivityRepositoryCustomImpl implements JpaActivityRepositoryCus
     }
 
     private BooleanExpression categoryEq(ActivityCategory category) {
-        return category != null ? activityJpaEntity.category.eq(category) : null;
+        return category != null ? activityJpaEntity.category.eq(category) : alwaysTrue();
+    }
+
+    private BooleanExpression categoriesEq(List<ActivityCategory> categories) {
+        if (categories == null || categories.isEmpty()) {
+            return alwaysTrue();
+        }
+
+        return activityJpaEntity.category.in(categories);
     }
 
     private BooleanExpression startDateBetween(LocalDateTime fromDate, LocalDateTime toDate) {
@@ -164,11 +178,11 @@ public class JpaActivityRepositoryCustomImpl implements JpaActivityRepositoryCus
     }
 
     private BooleanExpression startDateGoe(LocalDateTime fromDate) {
-        return fromDate != null ? activityJpaEntity.startDate.goe(fromDate) : Expressions.asBoolean(true).isTrue();
+        return fromDate != null ? activityJpaEntity.startDate.goe(fromDate) : alwaysTrue();
     }
 
     private BooleanExpression startDateLoe(LocalDateTime toDate) {
-        return toDate != null ? activityJpaEntity.startDate.loe(toDate) : Expressions.asBoolean(true).isTrue();
+        return toDate != null ? activityJpaEntity.startDate.loe(toDate) : alwaysTrue();
     }
 
     private BooleanExpression endDateBetween(LocalDateTime fromDate, LocalDateTime toDate) {
@@ -176,11 +190,11 @@ public class JpaActivityRepositoryCustomImpl implements JpaActivityRepositoryCus
     }
 
     private BooleanExpression endDateGoe(LocalDateTime fromDate) {
-        return fromDate != null ? activityJpaEntity.endDate.goe(fromDate) : Expressions.asBoolean(true).isTrue();
+        return fromDate != null ? activityJpaEntity.endDate.goe(fromDate) : alwaysTrue();
     }
 
     private BooleanExpression endDateLoe(LocalDateTime toDate) {
-        return toDate != null ? activityJpaEntity.endDate.loe(toDate) : Expressions.asBoolean(true).isTrue();
+        return toDate != null ? activityJpaEntity.endDate.loe(toDate) : alwaysTrue();
     }
 
     private BooleanExpression createdAtBetween(LocalDateTime fromDate, LocalDateTime toDate) {
@@ -188,11 +202,11 @@ public class JpaActivityRepositoryCustomImpl implements JpaActivityRepositoryCus
     }
 
     private BooleanExpression createdAtGoe(LocalDateTime fromDate) {
-        return fromDate != null ? activityJpaEntity.createdAt.goe(fromDate) : Expressions.asBoolean(true).isTrue();
+        return fromDate != null ? activityJpaEntity.createdAt.goe(fromDate) : alwaysTrue();
     }
 
     private BooleanExpression createdAtLoe(LocalDateTime toDate) {
-        return toDate != null ? activityJpaEntity.createdAt.loe(toDate) : Expressions.asBoolean(true).isTrue();
+        return toDate != null ? activityJpaEntity.createdAt.loe(toDate) : alwaysTrue();
     }
 
     private BooleanExpression dateBetweenByCategory(ActivityCategory category, LocalDateTime fromDate, LocalDateTime toDate) {
@@ -218,6 +232,19 @@ public class JpaActivityRepositoryCustomImpl implements JpaActivityRepositoryCus
             case MEET -> activityJpaEntity.startDate.desc();
             case ASSIGNMENT -> activityJpaEntity.endDate.desc();
             case DEFAULT -> activityJpaEntity.createdAt.desc();
+        };
+    }
+
+    private List<OrderSpecifier<LocalDateTime>> orderBy(ActivitySort sort) {
+        return switch (sort) {
+            case SPECIFIC -> List.of(
+                        new CaseBuilder()
+                                .when(categoryEq(ActivityCategory.MEET)).then(activityJpaEntity.startDate)
+                                .when(categoryEq(ActivityCategory.ASSIGNMENT)).then(activityJpaEntity.endDate)
+                                .otherwise(activityJpaEntity.createdAt)
+                                .asc(),
+                        activityJpaEntity.createdAt.desc());
+            case null, default -> List.of(activityJpaEntity.createdAt.desc());
         };
     }
 }

--- a/src/main/java/com/stumeet/server/activity/application/port/in/ActivityQuery.java
+++ b/src/main/java/com/stumeet/server/activity/application/port/in/ActivityQuery.java
@@ -9,11 +9,12 @@ import org.springframework.data.domain.Pageable;
 import com.stumeet.server.activity.adapter.in.response.ActivityListBriefResponse;
 import com.stumeet.server.activity.domain.model.Activity;
 import com.stumeet.server.activity.domain.model.ActivityCategory;
+import com.stumeet.server.activity.domain.model.ActivitySort;
 
 public interface ActivityQuery {
     Activity getById(Long activityId);
 
-    Page<Activity> getDetailsByCondition(Pageable pageable, Boolean isNotice, Long studyId, ActivityCategory category);
+    Page<Activity> getDetailsByCondition(Pageable pageable, Boolean isNotice, Long studyId, List<ActivityCategory> categories, ActivitySort sort);
 
     Page<ActivityListBriefResponse> getPaginatedBriefsByCondition(Pageable pageable, Boolean isNotice, Long memberId, Long studyId, ActivityCategory category, LocalDateTime startDate, LocalDateTime endDate);
 

--- a/src/main/java/com/stumeet/server/activity/application/port/in/ActivityQuery.java
+++ b/src/main/java/com/stumeet/server/activity/application/port/in/ActivityQuery.java
@@ -16,7 +16,7 @@ public interface ActivityQuery {
 
     Page<Activity> getDetailsByCondition(Pageable pageable, Boolean isNotice, Long studyId, List<ActivityCategory> categories, ActivitySort sort);
 
-    Page<ActivityListBriefResponse> getPaginatedBriefsByCondition(Pageable pageable, Boolean isNotice, Long memberId, Long studyId, ActivityCategory category, LocalDateTime startDate, LocalDateTime endDate);
+    Page<ActivityListBriefResponse> getPaginatedBriefsByCondition(Pageable pageable, Boolean isNotice, Long memberId, Long studyId, List<ActivityCategory> categories, LocalDateTime startDate, LocalDateTime endDate, ActivitySort sort);
 
-    List<ActivityListBriefResponse> getBriefsByCondition(Boolean isNotice, Long memberId, Long studyId, ActivityCategory category, LocalDateTime startDate, LocalDateTime endDate);
+    List<ActivityListBriefResponse> getBriefsByCondition(Boolean isNotice, Long memberId, Long studyId, List<ActivityCategory> categories, LocalDateTime startDate, LocalDateTime endDate, ActivitySort sort);
 }

--- a/src/main/java/com/stumeet/server/activity/application/port/in/query/ActivityListBriefQuery.java
+++ b/src/main/java/com/stumeet/server/activity/application/port/in/query/ActivityListBriefQuery.java
@@ -1,16 +1,16 @@
 package com.stumeet.server.activity.application.port.in.query;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import com.stumeet.server.activity.domain.model.ActivityCategory;
+import com.stumeet.server.activity.domain.model.ActivitySort;
 import com.stumeet.server.common.exception.model.BadRequestException;
 import com.stumeet.server.common.response.ErrorCode;
 
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
-@AllArgsConstructor
 @Getter
 public class ActivityListBriefQuery {
 	private final Integer size;
@@ -18,16 +18,23 @@ public class ActivityListBriefQuery {
 	private final Boolean isNotice;
 	private final Long memberId;
 	private final Long studyId;
-	private final ActivityCategory category;
 	private final LocalDateTime fromDate;
 	private final LocalDateTime toDate;
+	private List<ActivityCategory> categories;
+	private ActivitySort sort;
 
 	@Builder
 	private ActivityListBriefQuery(Integer size, Integer page, Boolean isNotice, Long memberId, Long studyId,
-			String categoryName, LocalDateTime fromDate, LocalDateTime toDate) {
-		this(size, page, isNotice, memberId, studyId,
-				categoryName != null ? ActivityCategory.getByName(categoryName) : null,
-				fromDate, toDate);
+			LocalDateTime fromDate, LocalDateTime toDate, List<ActivityCategory> categories, ActivitySort sort) {
+		this.size = size;
+		this.page = page;
+		this.isNotice = isNotice;
+		this.memberId = memberId;
+		this.studyId = studyId;
+		this.fromDate = fromDate;
+		this.toDate = toDate;
+		this.categories = categories;
+		this.sort = sort;
 		validate();
 	}
 

--- a/src/main/java/com/stumeet/server/activity/application/port/in/query/ActivityListDetailedQuery.java
+++ b/src/main/java/com/stumeet/server/activity/application/port/in/query/ActivityListDetailedQuery.java
@@ -1,10 +1,16 @@
 package com.stumeet.server.activity.application.port.in.query;
 
-import com.stumeet.server.activity.domain.model.ActivityCategory;
+import java.util.List;
 
+import com.stumeet.server.activity.domain.model.ActivityCategory;
+import com.stumeet.server.activity.domain.model.ActivitySort;
+
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
+@AllArgsConstructor
+@Builder
 @Getter
 public class ActivityListDetailedQuery {
 	private final Integer size;
@@ -12,19 +18,6 @@ public class ActivityListDetailedQuery {
 	private final Boolean isNotice;
 	Long memberId;
 	Long studyId;
-	ActivityCategory category;
-
-	@Builder
-	private ActivityListDetailedQuery(Integer size, Integer page, Boolean isNotice, Long memberId, Long studyId, String categoryName) {
-		this(size, page, isNotice, memberId, studyId, categoryName != null ? ActivityCategory.getByName(categoryName) : null);
-	}
-
-	private ActivityListDetailedQuery(Integer size, Integer page, Boolean isNotice, Long memberId, Long studyId, ActivityCategory category) {
-		this.size = size;
-		this.page = page;
-		this.isNotice = isNotice;
-		this.memberId = memberId;
-		this.studyId = studyId;
-		this.category = category;
-	}
+	List<ActivityCategory> categories;
+	ActivitySort sort;
 }

--- a/src/main/java/com/stumeet/server/activity/application/port/out/ActivityQueryPort.java
+++ b/src/main/java/com/stumeet/server/activity/application/port/out/ActivityQueryPort.java
@@ -18,7 +18,7 @@ public interface ActivityQueryPort {
 
     Page<Activity> getDetailPagesByCondition(Pageable pageable, Boolean isNotice, Long studyId, List<ActivityCategory> categories, ActivitySort sort);
 
-    Page<ActivityListBriefResponse> getPaginatedBriefsByCondition(Pageable pageable, Boolean isNotice, Long memberId, Long studyId, ActivityCategory category, LocalDateTime startDate, LocalDateTime endDate);
+    Page<ActivityListBriefResponse> getPaginatedBriefsByCondition(Pageable pageable, Boolean isNotice, Long memberId, Long studyId, List<ActivityCategory> categories, LocalDateTime startDate, LocalDateTime endDate, ActivitySort sort);
 
-    List<ActivityListBriefResponse> getBriefsByCondition(Boolean isNotice, Long memberId, Long studyId, ActivityCategory category, LocalDateTime startDate, LocalDateTime endDate);
+    List<ActivityListBriefResponse> getBriefsByCondition(Boolean isNotice, Long memberId, Long studyId, List<ActivityCategory> categories, LocalDateTime startDate, LocalDateTime endDate, ActivitySort sort);
 }

--- a/src/main/java/com/stumeet/server/activity/application/port/out/ActivityQueryPort.java
+++ b/src/main/java/com/stumeet/server/activity/application/port/out/ActivityQueryPort.java
@@ -9,13 +9,14 @@ import org.springframework.data.domain.Pageable;
 import com.stumeet.server.activity.adapter.in.response.ActivityListBriefResponse;
 import com.stumeet.server.activity.domain.model.Activity;
 import com.stumeet.server.activity.domain.model.ActivityCategory;
+import com.stumeet.server.activity.domain.model.ActivitySort;
 
 public interface ActivityQueryPort {
     Activity getById(Long activityId);
 
     Activity getByStudyIdAndId(Long studyId, Long id);
 
-    Page<Activity> getDetailPagesByCondition(Pageable pageable, Boolean isNotice, Long studyId, ActivityCategory category);
+    Page<Activity> getDetailPagesByCondition(Pageable pageable, Boolean isNotice, Long studyId, List<ActivityCategory> categories, ActivitySort sort);
 
     Page<ActivityListBriefResponse> getPaginatedBriefsByCondition(Pageable pageable, Boolean isNotice, Long memberId, Long studyId, ActivityCategory category, LocalDateTime startDate, LocalDateTime endDate);
 

--- a/src/main/java/com/stumeet/server/activity/application/service/ActivityQueryFacade.java
+++ b/src/main/java/com/stumeet/server/activity/application/service/ActivityQueryFacade.java
@@ -84,7 +84,8 @@ public class ActivityQueryFacade implements ActivityQueryUseCase {
                 PageRequest.of(query.getPage(), query.getSize()),
                 query.getIsNotice(),
                 query.getStudyId(),
-                query.getCategory());
+                query.getCategories(),
+                query.getSort());
 
         return activityUseCaseMapper
                 .toListDetailedPageResponses(activities, pageInfoUseCaseMapper.toPageInfoResponse(activities));

--- a/src/main/java/com/stumeet/server/activity/application/service/ActivityQueryFacade.java
+++ b/src/main/java/com/stumeet/server/activity/application/service/ActivityQueryFacade.java
@@ -17,6 +17,7 @@ import com.stumeet.server.activity.application.port.in.query.ActivityListDetaile
 import com.stumeet.server.activity.domain.model.Activity;
 import com.stumeet.server.activity.domain.model.ActivityImage;
 import com.stumeet.server.activity.domain.model.ActivityParticipant;
+import com.stumeet.server.activity.domain.model.ActivitySort;
 import com.stumeet.server.common.annotation.UseCase;
 import com.stumeet.server.study.application.port.in.StudyValidationUseCase;
 import com.stumeet.server.studymember.application.port.in.StudyMemberValidationUseCase;
@@ -103,9 +104,10 @@ public class ActivityQueryFacade implements ActivityQueryUseCase {
                     query.getIsNotice(),
                     query.getMemberId(),
                     query.getStudyId(),
-                    query.getCategory(),
+                    query.getCategories(),
                     query.getFromDate(),
-                    query.getToDate());
+                    query.getToDate(),
+                    query.getSort());
 
             return ActivityListBriefResponses.builder()
                     .items(activities.toList())
@@ -116,9 +118,10 @@ public class ActivityQueryFacade implements ActivityQueryUseCase {
                     query.getIsNotice(),
                     query.getMemberId(),
                     query.getStudyId(),
-                    query.getCategory(),
+                    query.getCategories(),
                     query.getFromDate(),
-                    query.getToDate());
+                    query.getToDate(),
+                    query.getSort());
 
             return ActivityListBriefResponses.builder()
                     .items(activities)

--- a/src/main/java/com/stumeet/server/activity/application/service/ActivityQueryService.java
+++ b/src/main/java/com/stumeet/server/activity/application/service/ActivityQueryService.java
@@ -8,6 +8,7 @@ import com.stumeet.server.activity.application.port.in.ActivityQuery;
 import com.stumeet.server.activity.application.port.out.ActivityQueryPort;
 import com.stumeet.server.activity.domain.model.Activity;
 import com.stumeet.server.activity.domain.model.ActivityCategory;
+import com.stumeet.server.activity.domain.model.ActivitySort;
 import com.stumeet.server.common.annotation.UseCase;
 
 import lombok.RequiredArgsConstructor;
@@ -33,8 +34,9 @@ public class ActivityQueryService implements ActivityQuery {
             Pageable pageable,
             Boolean isNotice,
             Long studyId,
-            ActivityCategory category) {
-        return activityQueryPort.getDetailPagesByCondition(pageable, isNotice, studyId, category);
+            List<ActivityCategory> categories,
+            ActivitySort sort) {
+        return activityQueryPort.getDetailPagesByCondition(pageable, isNotice, studyId, categories, sort);
     }
 
     @Override

--- a/src/main/java/com/stumeet/server/activity/application/service/ActivityQueryService.java
+++ b/src/main/java/com/stumeet/server/activity/application/service/ActivityQueryService.java
@@ -45,11 +45,11 @@ public class ActivityQueryService implements ActivityQuery {
             Boolean isNotice,
             Long memberId,
             Long studyId,
-            ActivityCategory category,
+            List<ActivityCategory> categories,
             LocalDateTime startDate,
-            LocalDateTime endDate) {
-        return activityQueryPort.getPaginatedBriefsByCondition(pageable, isNotice, memberId, studyId, category,
-                startDate, endDate);
+            LocalDateTime endDate,
+            ActivitySort sort) {
+        return activityQueryPort.getPaginatedBriefsByCondition(pageable, isNotice, memberId, studyId, categories, startDate, endDate, sort);
     }
 
     @Override
@@ -57,9 +57,10 @@ public class ActivityQueryService implements ActivityQuery {
             Boolean isNotice,
             Long memberId,
             Long studyId,
-            ActivityCategory category,
+            List<ActivityCategory> categories,
             LocalDateTime startDate,
-            LocalDateTime endDate) {
-        return activityQueryPort.getBriefsByCondition(isNotice, memberId, studyId, category, startDate, endDate);
+            LocalDateTime endDate,
+            ActivitySort sort) {
+        return activityQueryPort.getBriefsByCondition(isNotice, memberId, studyId, categories, startDate, endDate, sort);
     }
 }

--- a/src/main/java/com/stumeet/server/activity/domain/exception/NotExistsActivitySortException.java
+++ b/src/main/java/com/stumeet/server/activity/domain/exception/NotExistsActivitySortException.java
@@ -1,0 +1,14 @@
+package com.stumeet.server.activity.domain.exception;
+
+import java.text.MessageFormat;
+
+import com.stumeet.server.common.exception.model.InvalidStateException;
+import com.stumeet.server.common.response.ErrorCode;
+
+public class NotExistsActivitySortException  extends InvalidStateException {
+    private static final String MESSAGE = "존재하지 않는 활동 정렬 입니다. 입력받은 정렬 : {0}";
+
+    public NotExistsActivitySortException(String sort) {
+        super(MessageFormat.format(MESSAGE, sort), ErrorCode.INVALID_ACTIVITY_SORT_EXCEPTION);
+    }
+}

--- a/src/main/java/com/stumeet/server/activity/domain/model/ActivitySort.java
+++ b/src/main/java/com/stumeet/server/activity/domain/model/ActivitySort.java
@@ -1,0 +1,17 @@
+package com.stumeet.server.activity.domain.model;
+
+import java.util.Arrays;
+
+import com.stumeet.server.activity.domain.exception.NotExistsActivitySortException;
+
+public enum ActivitySort {
+    LATEST,
+    SPECIFIC;
+
+    public static ActivitySort getByName(String sort) {
+        return Arrays.stream(ActivitySort.values())
+                .filter(s -> s.name().equalsIgnoreCase(sort))
+                .findAny()
+                .orElseThrow(() -> new NotExistsActivitySortException(sort));
+    }
+}

--- a/src/main/java/com/stumeet/server/common/response/ErrorCode.java
+++ b/src/main/java/com/stumeet/server/common/response/ErrorCode.java
@@ -42,6 +42,7 @@ public enum ErrorCode {
     INVALID_REVIEW_TAG_COUNT_EXCEPTION(HttpStatus.BAD_REQUEST, "리뷰 태그 개수는 3개를 초과할 수 없습니다."),
 
     INVALID_ACTIVITY_CATEGORY_EXCEPTION(HttpStatus.BAD_REQUEST, "유효하지 않은 활동 카테고리입니다."),
+    INVALID_ACTIVITY_SORT_EXCEPTION(HttpStatus.BAD_REQUEST, "유효하지 않은 활동 종류입니다."),
     INVALID_COMPLIMENT_TYPE_EXCEPTION(HttpStatus.BAD_REQUEST, "유효하지 않은 칭찬 타입입니다."),
 
     /*

--- a/src/test/java/com/stumeet/server/activity/adapter/in/ActivityQueryApiTest.java
+++ b/src/test/java/com/stumeet/server/activity/adapter/in/ActivityQueryApiTest.java
@@ -1,6 +1,7 @@
 package com.stumeet.server.activity.adapter.in;
 
 import com.stumeet.server.activity.domain.model.ActivityCategory;
+import com.stumeet.server.activity.domain.model.ActivitySort;
 import com.stumeet.server.common.auth.model.AuthenticationHeader;
 import com.stumeet.server.common.response.ErrorCode;
 import com.stumeet.server.common.response.SuccessCode;
@@ -187,6 +188,8 @@ class ActivityQueryApiTest extends ApiTest {
                             .param("isNotice", "true")
                             .param("studyId", StudyStub.getStudyId().toString())
                             .param("category", ActivityCategory.MEET.name())
+                            .param("category", ActivityCategory.ASSIGNMENT.name())
+                            .param("sort", ActivitySort.SPECIFIC.name())
                             .header(AuthenticationHeader.ACCESS_TOKEN.getName(), TokenStub.getMockAccessToken()))
                     .andExpect(status().isOk())
                     .andDo(document("get-activity-details-by-condition/success",
@@ -201,7 +204,8 @@ class ActivityQueryApiTest extends ApiTest {
                                     parameterWithName("page").description("조회할 페이지 번호"),
                                     parameterWithName("isNotice").description("공지사항 여부 (true/false)").optional(),
                                     parameterWithName("studyId").description("특정 스터디 ID").optional(),
-                                    parameterWithName("category").description("활동 유형 (DEFAULT/MEET/ASSIGNMENT)").optional()
+                                    parameterWithName("category").description("활동 유형 (DEFAULT/MEET/ASSIGNMENT) 복수 선택 가능").optional(),
+                                    parameterWithName("sort").description("정렬 종류 (LATEST/SPECIFIC) 단일 선택").optional()
                             ),
                             responseFields(
                                     fieldWithPath("code").description("응답 코드"),
@@ -213,9 +217,9 @@ class ActivityQueryApiTest extends ApiTest {
                                     fieldWithPath("data.items[].category").description("활동 유형"),
                                     fieldWithPath("data.items[].title").description("활동 제목"),
                                     fieldWithPath("data.items[].content").description("활동 내용"),
-                                    fieldWithPath("data.items[].startDate").description("활동 시작일"),
-                                    fieldWithPath("data.items[].endDate").description("활동 종료일"),
-                                    fieldWithPath("data.items[].location").description("장소"),
+                                    fieldWithPath("data.items[].startDate").optional().description("활동 시작일"),
+                                    fieldWithPath("data.items[].endDate").optional().description("활동 종료일"),
+                                    fieldWithPath("data.items[].location").optional().description("장소"),
                                     fieldWithPath("data.items[].author.memberId").description("활동 작성자 ID"),
                                     fieldWithPath("data.items[].author.name").description("활동 작성자 이름"),
                                     fieldWithPath("data.items[].author.profileImageUrl").description("활동 작성자 프로필 이미지 URL"),
@@ -251,7 +255,8 @@ class ActivityQueryApiTest extends ApiTest {
                                     parameterWithName("page").description("조회할 페이지 번호"),
                                     parameterWithName("isNotice").description("공지사항 여부 (true/false)").optional(),
                                     parameterWithName("studyId").description("특정 스터디 ID").optional(),
-                                    parameterWithName("category").description("활동 유형 (DEFAULT/MEET/ASSIGNMENT)").optional()
+                                    parameterWithName("category").description("활동 유형 (DEFAULT/MEET/ASSIGNMENT) 복수 선택 가능").optional(),
+                                    parameterWithName("sort").description("정렬 종류 (LATEST/SPECIFIC) 단일 선택").optional()
                             ),
                             responseFields(
                                     fieldWithPath("code").description("응답 코드"),
@@ -282,7 +287,8 @@ class ActivityQueryApiTest extends ApiTest {
                                     parameterWithName("page").description("조회할 페이지 번호"),
                                     parameterWithName("isNotice").description("공지사항 여부 (true/false)").optional(),
                                     parameterWithName("studyId").description("특정 스터디 ID").optional(),
-                                    parameterWithName("category").description("활동 유형 (DEFAULT/MEET/ASSIGNMENT)").optional()
+                                    parameterWithName("category").description("활동 유형 (DEFAULT/MEET/ASSIGNMENT) 복수 선택 가능").optional(),
+                                    parameterWithName("sort").description("정렬 종류 (LATEST/SPECIFIC) 단일 선택").optional()
                             ),
                             responseFields(
                                     fieldWithPath("code").description("응답 코드"),

--- a/src/test/java/com/stumeet/server/activity/adapter/in/ActivityQueryApiTest.java
+++ b/src/test/java/com/stumeet/server/activity/adapter/in/ActivityQueryApiTest.java
@@ -312,10 +312,12 @@ class ActivityQueryApiTest extends ApiTest {
                             .param("page", "0")
                             .param("isNotice", "true")
                             .param("category", ActivityCategory.MEET.name())
+                            .param("category", ActivityCategory.ASSIGNMENT.name())
                             .param("studyId", StudyStub.getStudyId().toString())
                             .param("memberId", MemberStub.getMemberId().toString())
                             .param("fromDate", "2024-04-01T00:00:00")
                             .param("toDate", "2024-04-30T00:00:00")
+                            .param("sort", ActivitySort.SPECIFIC.name())
                             .header(AuthenticationHeader.ACCESS_TOKEN.getName(), TokenStub.getMockAccessToken()))
                     .andExpect(status().isOk())
                     .andDo(document("get-activity-briefs-by-condition/success",
@@ -333,7 +335,8 @@ class ActivityQueryApiTest extends ApiTest {
                                     parameterWithName("memberId").description("멤버 ID (생략 시 로그인 멤버 id로 조회)").optional(),
                                     parameterWithName("category").description("활동 유형 (DEFAULT/MEET/ASSIGNMENT)").optional(),
                                     parameterWithName("fromDate").description("YYYY-MM-DDThh:mm:ss").optional(),
-                                    parameterWithName("toDate").description("YYYY-MM-DDThh:mm:ss").optional()
+                                    parameterWithName("toDate").description("YYYY-MM-DDThh:mm:ss").optional(),
+                                    parameterWithName("sort").description("정렬 기준 (LATEST/SPECIFIC)").optional()
                             ),
                             responseFields(
                                     fieldWithPath("code").description("응답 코드"),
@@ -344,9 +347,9 @@ class ActivityQueryApiTest extends ApiTest {
                                     fieldWithPath("data.items[].studyName").description("활동 연관 스터디명"),
                                     fieldWithPath("data.items[].category").description("활동 유형"),
                                     fieldWithPath("data.items[].title").description("활동 제목"),
-                                    fieldWithPath("data.items[].startDate").description("활동 시작일"),
-                                    fieldWithPath("data.items[].endDate").description("활동 종료일"),
-                                    fieldWithPath("data.items[].location").description("장소"),
+                                    fieldWithPath("data.items[].startDate").optional().description("활동 시작일"),
+                                    fieldWithPath("data.items[].endDate").optional().description("활동 종료일"),
+                                    fieldWithPath("data.items[].location").description("장소").optional(),
                                     fieldWithPath("data.items[].status").description("내 활동 상태"),
                                     fieldWithPath("data.items[].createdAt").description("활동 생성일"),
                                     fieldWithPath("data.pageInfo").description("페이지 메타 정보"),
@@ -381,7 +384,8 @@ class ActivityQueryApiTest extends ApiTest {
                                     parameterWithName("memberId").description("멤버 ID (생략 시 로그인 멤버 id로 조회)").optional(),
                                     parameterWithName("category").description("활동 유형 (DEFAULT/MEET/ASSIGNMENT)").optional(),
                                     parameterWithName("fromDate").description("YYYY-MM-DDThh:mm:ss").optional(),
-                                    parameterWithName("toDate").description("YYYY-MM-DDThh:mm:ss").optional()
+                                    parameterWithName("toDate").description("YYYY-MM-DDThh:mm:ss").optional(),
+                                    parameterWithName("sort").description("정렬 기준 (LATEST/SPECIFIC)").optional()
                             ),
                             responseFields(
                                     fieldWithPath("code").description("응답 코드"),
@@ -414,7 +418,8 @@ class ActivityQueryApiTest extends ApiTest {
                                     parameterWithName("memberId").description("멤버 ID (생략 시 로그인 멤버 id로 조회)").optional(),
                                     parameterWithName("category").description("활동 유형 (DEFAULT/MEET/ASSIGNMENT)").optional(),
                                     parameterWithName("fromDate").description("YYYY-MM-DDThh:mm:ss").optional(),
-                                    parameterWithName("toDate").description("YYYY-MM-DDThh:mm:ss").optional()
+                                    parameterWithName("toDate").description("YYYY-MM-DDThh:mm:ss").optional(),
+                                    parameterWithName("sort").description("정렬 기준 (LATEST/SPECIFIC)").optional()
                             ),
                             responseFields(
                                     fieldWithPath("code").description("응답 코드"),
@@ -446,7 +451,8 @@ class ActivityQueryApiTest extends ApiTest {
                                     parameterWithName("memberId").description("멤버 ID (생략 시 로그인 멤버 id로 조회)").optional(),
                                     parameterWithName("category").description("활동 유형 (DEFAULT/MEET/ASSIGNMENT)").optional(),
                                     parameterWithName("fromDate").description("YYYY-MM-DDThh:mm:ss").optional(),
-                                    parameterWithName("toDate").description("YYYY-MM-DDThh:mm:ss").optional()
+                                    parameterWithName("toDate").description("YYYY-MM-DDThh:mm:ss").optional(),
+                                    parameterWithName("sort").description("정렬 기준 (LATEST/SPECIFIC)").optional()
                             ),
                             responseFields(
                                     fieldWithPath("code").description("응답 코드"),
@@ -478,7 +484,8 @@ class ActivityQueryApiTest extends ApiTest {
                                     parameterWithName("memberId").description("멤버 ID (생략 시 로그인 멤버 id로 조회)").optional(),
                                     parameterWithName("category").description("활동 유형 (DEFAULT/MEET/ASSIGNMENT)").optional(),
                                     parameterWithName("fromDate").description("YYYY-MM-DDThh:mm:ss").optional(),
-                                    parameterWithName("toDate").description("YYYY-MM-DDThh:mm:ss").optional()
+                                    parameterWithName("toDate").description("YYYY-MM-DDThh:mm:ss").optional(),
+                                    parameterWithName("sort").description("정렬 기준 (LATEST/SPECIFIC)").optional()
                             ),
                             responseFields(
                                     fieldWithPath("code").description("응답 코드"),
@@ -511,7 +518,8 @@ class ActivityQueryApiTest extends ApiTest {
                                     parameterWithName("memberId").description("멤버 ID (생략 시 로그인 멤버 id로 조회)").optional(),
                                     parameterWithName("category").description("활동 유형 (DEFAULT/MEET/ASSIGNMENT)").optional(),
                                     parameterWithName("fromDate").description("YYYY-MM-DDThh:mm:ss").optional(),
-                                    parameterWithName("toDate").description("YYYY-MM-DDThh:mm:ss").optional()
+                                    parameterWithName("toDate").description("YYYY-MM-DDThh:mm:ss").optional(),
+                                    parameterWithName("sort").description("정렬 기준 (LATEST/SPECIFIC)").optional()
                             ),
                             responseFields(
                                     fieldWithPath("code").description("응답 코드"),


### PR DESCRIPTION
## 💁 해결 하려는 문제를 적어주세요 

기획 변경으로 홈 화면에서 조회되는 활동 목록 간략/상세 조회 API에서 기존에 지원하지 않던 복수 카테고리 선택과 `최신순`, `각 유형 기준순` 정렬이 필요해졌습니다.

## 🤔 어떤 방식으로 해결했는지 적어주세요 

- `ActivitySort` Enum 클래스를 추가하여 최신순, 각 유형기준순 정렬을 정의했습니다.
- QueryDsl의 CaseBuilder를 사용하여 category별 정렬 기준을 적용했습니다.
- 기존 쿼리 조회 기준을 리팩터링 했습니다.
- Spring Enum Converter를 구현하여 `ActivityCategory`와 `ActivitySort` 변환과 예외를 처리했습니다.

## 🧑‍🏫 이해를 위해 필요한 자료가 있다면 첨부해주세요
- 명세서
https://stumeet.shop/docs/index.html#_%EC%8A%A4%ED%84%B0%EB%94%94_%ED%99%9C%EB%8F%99_%EC%83%81%EC%84%B8_%EB%AA%A9%EB%A1%9D_%EC%A1%B0%ED%9A%8C
https://stumeet.shop/docs/index.html#_%EC%8A%A4%ED%84%B0%EB%94%94_%ED%99%9C%EB%8F%99_%EA%B0%84%EB%9E%B5_%EB%AA%A9%EB%A1%9D_%EC%A1%B0%ED%9A%8C 