### PR TITLE
♻️ [STMT-290] 내 스터디 멤버 정보 조회 API 통합

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -420,6 +420,41 @@ include::{snippets}/get-study-member-detail/fail/study-not-found/response-body.a
 include::{snippets}/get-study-member-detail/fail/study-not-found/response-fields.adoc[]
 
 
+=== 내 스터디 멤버 상세 정보 조회
+
+전달받은 스터디 ID의 내 스터디 멤버 정보를 상세 조회하는 API입니다.
+
+==== GET /v1/api/studies/{studyId}/members/me
+
+===== 요청
+include::{snippets}/get-my-study-member-detail/success/active-study/http-request.adoc[]
+
+====== 헤더
+include::{snippets}/get-my-study-member-detail/success/active-study/request-headers.adoc[]
+
+====== 경로 변수
+include::{snippets}/get-my-study-member-detail/success/active-study/path-parameters.adoc[]
+
+===== 응답 성공 (200)
+.활성화된 스터디의 경우
+include::{snippets}/get-my-study-member-detail/success/active-study/response-body.adoc[]
+include::{snippets}/get-my-study-member-detail/success/active-study/response-fields.adoc[]
+
+.완료된 스터디의 경우
+include::{snippets}/get-my-study-member-detail/success/finished-study/response-body.adoc[]
+include::{snippets}/get-my-study-member-detail/success/finished-study/response-fields.adoc[]
+
+===== 응답 실패 (403)
+.요청자가 스터디의 멤버가 아닌 경우
+include::{snippets}/get-my-study-member-detail/fail/not-joined-study-member/response-body.adoc[]
+include::{snippets}/get-my-study-member-detail/fail/not-joined-study-member/response-fields.adoc[]
+
+===== 응답 실패 (404)
+.요청한 스터디가 존재하지 않는 경우
+include::{snippets}/get-my-study-member-detail/fail/study-not-found/response-body.adoc[]
+include::{snippets}/get-my-study-member-detail/fail/study-not-found/response-fields.adoc[]
+
+
 === 스터디 멤버 목록 조회
 
 전달받은 스터디 ID의 속한 멤버들을 조회하는 API입니다.

--- a/src/main/java/com/stumeet/server/bff/adapter/in/app/StudyHubApi.java
+++ b/src/main/java/com/stumeet/server/bff/adapter/in/app/StudyHubApi.java
@@ -17,6 +17,7 @@ import com.stumeet.server.common.response.SuccessCode;
 import com.stumeet.server.study.adapter.in.web.response.StudyDetailResponse;
 import com.stumeet.server.study.application.port.in.StudyQueryUseCase;
 import com.stumeet.server.studymember.application.port.in.StudyMemberQueryUseCase;
+import com.stumeet.server.studymember.application.port.in.response.MyStudyMemberDetailResponse;
 
 import lombok.RequiredArgsConstructor;
 
@@ -40,15 +41,14 @@ public class StudyHubApi {
         ActivityListDetailedPageResponse activityNotice = activityQueryUseCase.getDetails(noticeQuery)
                 .items()
                 .getFirst();
+        MyStudyMemberDetailResponse myStudyMemberDetail = studyMemberQueryUseCase.getMyStudyMemberDetail(studyId, member.getId());
 
-        boolean isAdmin = studyMemberQueryUseCase.isMemberAdmin(studyId, member.getId()).isAdmin();
-        boolean canSendGrape = studyMemberQueryUseCase.canSendGrape(studyId, member.getId());
 
         StudyDetailFullResponse response = new StudyDetailFullResponse(
                 studyDetailResponse,
                 activityNotice,
-                isAdmin,
-                canSendGrape
+                myStudyMemberDetail.isAdmin(),
+                myStudyMemberDetail.canSendGrape()
         );
 
         return ResponseEntity.ok(

--- a/src/main/java/com/stumeet/server/bff/adapter/in/app/StudyMemberHubApi.java
+++ b/src/main/java/com/stumeet/server/bff/adapter/in/app/StudyMemberHubApi.java
@@ -12,6 +12,7 @@ import com.stumeet.server.common.auth.model.LoginMember;
 import com.stumeet.server.common.model.ApiResponse;
 import com.stumeet.server.common.response.SuccessCode;
 import com.stumeet.server.studymember.application.port.in.StudyMemberQueryUseCase;
+import com.stumeet.server.studymember.application.port.in.response.MyStudyMemberDetailResponse;
 import com.stumeet.server.studymember.application.port.in.response.StudyMemberDetailResponse;
 
 import lombok.RequiredArgsConstructor;
@@ -30,13 +31,12 @@ public class StudyMemberHubApi {
             @PathVariable Long memberId
     ) {
         StudyMemberDetailResponse studyMemberDetail = studyMemberQueryUseCase.getStudyMemberDetail(studyId, memberId, member.getId());
-        boolean isAdmin = studyMemberQueryUseCase.isMemberAdmin(studyId, memberId).isAdmin();
-        boolean canSendGrape = studyMemberQueryUseCase.canSendGrape(studyId, memberId);
+        MyStudyMemberDetailResponse myStudyMemberDetail = studyMemberQueryUseCase.getMyStudyMemberDetail(studyId, memberId);
 
         StudyMemberDetailFullResponse response = new StudyMemberDetailFullResponse(
                 studyMemberDetail,
-                isAdmin,
-                canSendGrape
+                myStudyMemberDetail.isAdmin(),
+                myStudyMemberDetail.canSendGrape()
         );
 
         return ResponseEntity.ok(

--- a/src/main/java/com/stumeet/server/common/response/ErrorCode.java
+++ b/src/main/java/com/stumeet/server/common/response/ErrorCode.java
@@ -51,6 +51,7 @@ public enum ErrorCode {
     JWT_INVALID_SIGNATURE_EXCEPTION(HttpStatus.UNAUTHORIZED, "JWT 서명이 유효하지 않습니다."),
     ILLEGAL_KEY_ALGORITHM_EXCEPTION(HttpStatus.UNAUTHORIZED, "유효하지 않은 키 알고리즘입니다."),
     JWT_TOKEN_PARSING_EXCEPTION(HttpStatus.UNAUTHORIZED, "JWT 토큰 파싱에 실패했습니다."),
+    JWT_TOKEN_NOT_EXIST_EXCEPTION(HttpStatus.UNAUTHORIZED, "JWT 토큰을 찾을 수 없습니다."),
     NOT_EXIST_OAUTH_PROVIDER(HttpStatus.UNAUTHORIZED, "존재하지 않는 OAuth 제공자입니다."),
 
     /*

--- a/src/main/java/com/stumeet/server/common/token/repository/JwtTokenRepository.java
+++ b/src/main/java/com/stumeet/server/common/token/repository/JwtTokenRepository.java
@@ -8,5 +8,7 @@ public interface JwtTokenRepository {
 
     String getByRefreshToken(String refreshToken);
 
+    boolean isExist(String token);
+
     void deleteByToken(String accessToken);
 }

--- a/src/main/java/com/stumeet/server/common/token/repository/JwtTokenRepositoryImpl.java
+++ b/src/main/java/com/stumeet/server/common/token/repository/JwtTokenRepositoryImpl.java
@@ -37,6 +37,11 @@ public class JwtTokenRepositoryImpl implements JwtTokenRepository {
     }
 
     @Override
+    public boolean isExist(String token) {
+        return Boolean.TRUE.equals(redisTemplate.hasKey(token));
+    }
+
+    @Override
     public void deleteByToken(String token) {
         boolean isDeleted = Boolean.TRUE.equals(redisTemplate.delete(token));
         if (!isDeleted) {

--- a/src/main/java/com/stumeet/server/common/token/service/JwtTokenService.java
+++ b/src/main/java/com/stumeet/server/common/token/service/JwtTokenService.java
@@ -25,6 +25,17 @@ public class JwtTokenService {
         jwtTokenRepository.save(refreshToken, renewAccessToken);
     }
 
+    public void validateAccessToken(String accessToken) {
+        validateTokenExpiration(accessToken);
+        validateTokenExist(accessToken);
+    }
+
+    public void validateTokenExist(String token) {
+        if (!jwtTokenRepository.isExist(token)) {
+            throw new BusinessException(ErrorCode.JWT_TOKEN_NOT_EXIST_EXCEPTION);
+        }
+    }
+
     public void validateRefreshToken(String accessToken, String refreshToken) {
         validateTokenExpiration(refreshToken);
         validateTokenNotInBlackList(refreshToken);

--- a/src/main/java/com/stumeet/server/review/adapter/out/persistence/JpaReviewRepository.java
+++ b/src/main/java/com/stumeet/server/review/adapter/out/persistence/JpaReviewRepository.java
@@ -7,4 +7,6 @@ import com.stumeet.server.review.adapter.out.persistence.entity.ReviewJpaEntity;
 public interface JpaReviewRepository extends JpaRepository<ReviewJpaEntity, Long> {
 
     boolean existsByStudyIdAndReviewerIdAndRevieweeId(Long studyId, Long reviewerId, Long revieweeId);
+
+    long countByReviewerIdAndStudyId(Long reviewerId, Long studyId);
 }

--- a/src/main/java/com/stumeet/server/review/adapter/out/persistence/ReviewPersistenceAdapter.java
+++ b/src/main/java/com/stumeet/server/review/adapter/out/persistence/ReviewPersistenceAdapter.java
@@ -69,4 +69,9 @@ public class ReviewPersistenceAdapter implements ReviewSavePort, ReviewQueryPort
                 .build())
             .toList();
     }
+
+    @Override
+    public long getStudyMemberReviewCount(Long studyId, Long memberId) {
+        return jpaReviewRepository.countByReviewerIdAndStudyId(memberId, studyId);
+    }
 }

--- a/src/main/java/com/stumeet/server/review/application/port/in/ReviewQueryUseCase.java
+++ b/src/main/java/com/stumeet/server/review/application/port/in/ReviewQueryUseCase.java
@@ -10,4 +10,6 @@ public interface ReviewQueryUseCase {
     List<ReviewDetailResponse> getMemberReview(Long memberId, int size, int page, String sortName);
 
     List<ReviewTagCountStatsResponse> getMemberReviewTagStats(Long memberId);
+
+    long getStudyMemberReviewCount(Long studyId, Long memberId);
 }

--- a/src/main/java/com/stumeet/server/review/application/port/out/ReviewQueryPort.java
+++ b/src/main/java/com/stumeet/server/review/application/port/out/ReviewQueryPort.java
@@ -13,4 +13,6 @@ public interface ReviewQueryPort {
     List<Review> findMemberReviews(Long memberId, Integer size, Integer page, ReviewSort sort);
 
     List<ReviewTagCountStatsResponse> countMemberReviewTags(Long memberId);
+
+    long getStudyMemberReviewCount(Long studyId, Long memberId);
 }

--- a/src/main/java/com/stumeet/server/review/application/service/ReviewQueryService.java
+++ b/src/main/java/com/stumeet/server/review/application/service/ReviewQueryService.java
@@ -42,4 +42,9 @@ public class ReviewQueryService implements ReviewQueryUseCase {
         List<ReviewTagCountStatsResponse> reviewTagsCnt = reviewQueryPort.countMemberReviewTags(memberId);
         return reviewTagsCnt;
     }
+
+    @Override
+    public long getStudyMemberReviewCount(Long studyId, Long memberId) {
+        return reviewQueryPort.getStudyMemberReviewCount(studyId, memberId);
+    }
 }

--- a/src/main/java/com/stumeet/server/study/application/port/in/StudyQueryUseCase.java
+++ b/src/main/java/com/stumeet/server/study/application/port/in/StudyQueryUseCase.java
@@ -11,4 +11,6 @@ public interface StudyQueryUseCase {
 	JoinedStudiesResponse getJoinedStudiesByStatus(GetJoinedStudyCommand command);
 
 	String getStudyName(Long id);
+
+	boolean isFinishedStudy(Long id);
 }

--- a/src/main/java/com/stumeet/server/study/application/service/StudyQueryService.java
+++ b/src/main/java/com/stumeet/server/study/application/service/StudyQueryService.java
@@ -55,4 +55,10 @@ public class StudyQueryService implements StudyQueryUseCase {
 		Study study = studyQueryPort.getById(id);
 		return study.getName();
 	}
+
+	@Override
+	public boolean isFinishedStudy(Long id) {
+		Study study = studyQueryPort.getById(id);
+		return study.isFinished();
+	}
 }

--- a/src/main/java/com/stumeet/server/studymember/adapter/in/web/StudyMemberQueryApi.java
+++ b/src/main/java/com/stumeet/server/studymember/adapter/in/web/StudyMemberQueryApi.java
@@ -6,9 +6,8 @@ import com.stumeet.server.common.annotation.WebAdapter;
 import com.stumeet.server.common.auth.model.LoginMember;
 import com.stumeet.server.common.model.ApiResponse;
 import com.stumeet.server.common.response.SuccessCode;
-import com.stumeet.server.studymember.application.port.in.response.StudyMemberAdminResponse;
+import com.stumeet.server.studymember.application.port.in.response.MyStudyMemberDetailResponse;
 import com.stumeet.server.studymember.application.port.in.response.StudyMemberDetailResponse;
-import com.stumeet.server.studymember.application.port.in.response.StudyMemberGrapeResponse;
 import com.stumeet.server.studymember.application.port.in.response.StudyMemberResponses;
 import com.stumeet.server.studymember.application.port.in.StudyMemberQueryUseCase;
 import com.stumeet.server.studymember.application.port.in.response.StudyMemberReviewStatusResponse;
@@ -54,25 +53,12 @@ public class StudyMemberQueryApi {
         );
     }
 
-    @GetMapping("/studies/{studyId}/me/admin/check")
-    public ResponseEntity<ApiResponse<StudyMemberAdminResponse>> isMemberAdmin(
+    @GetMapping("/studies/{studyId}/members/me")
+    public ResponseEntity<ApiResponse<MyStudyMemberDetailResponse>> getMyStudyMemberDetail(
             @AuthenticationPrincipal LoginMember member,
             @PathVariable Long studyId
     ) {
-        StudyMemberAdminResponse response = studyMemberQueryUseCase.isMemberAdmin(studyId, member.getId());
-
-        return ResponseEntity.ok(
-                ApiResponse.success(SuccessCode.GET_SUCCESS, response)
-        );
-    }
-
-    @GetMapping("/studies/{studyId}/me/grapes/available")
-    public ResponseEntity<ApiResponse<StudyMemberGrapeResponse>> canMemberSendGrape(
-            @AuthenticationPrincipal LoginMember member,
-            @PathVariable Long studyId
-    ) {
-        boolean canSendGrape = studyMemberQueryUseCase.canSendGrape(studyId, member.getId());
-        StudyMemberGrapeResponse response = new StudyMemberGrapeResponse(canSendGrape);
+        MyStudyMemberDetailResponse response = studyMemberQueryUseCase.getMyStudyMemberDetail(studyId, member.getId());
 
         return ResponseEntity.ok(
                 ApiResponse.success(SuccessCode.GET_SUCCESS, response)

--- a/src/main/java/com/stumeet/server/studymember/adapter/out/persistence/StudyMemberPersistenceAdapter.java
+++ b/src/main/java/com/stumeet/server/studymember/adapter/out/persistence/StudyMemberPersistenceAdapter.java
@@ -20,8 +20,7 @@ import java.util.List;
 @PersistenceAdapter
 @RequiredArgsConstructor
 public class StudyMemberPersistenceAdapter
-    implements StudyMemberJoinPort, StudyMemberQueryPort, StudyMemberValidationPort,
-    StudyMemberUpdatePort {
+        implements StudyMemberJoinPort, StudyMemberQueryPort, StudyMemberValidationPort, StudyMemberUpdatePort {
 
     private final JpaStudyMemberRepository jpaStudyMemberRepository;
     private final StudyMemberPersistenceMapper studyMemberPersistenceMapper;
@@ -34,7 +33,7 @@ public class StudyMemberPersistenceAdapter
     @Override
     public StudyMember findStudyMember(Long studyId, Long memberId) {
         StudyMemberJpaEntity entity = jpaStudyMemberRepository.findStudyMemberByStudyIdAndMemberId(studyId, memberId)
-            .orElseThrow(() -> new StudyMemberNotExistException(memberId));
+                .orElseThrow(() -> new StudyMemberNotExistException(memberId));
 
         return studyMemberPersistenceMapper.toDomain(entity);
     }
@@ -42,7 +41,7 @@ public class StudyMemberPersistenceAdapter
     @Override
     public StudyMember findStudyMember(Long studyMemberId) {
         StudyMemberJpaEntity entity = jpaStudyMemberRepository.findById(studyMemberId)
-            .orElseThrow(() -> new StudyMemberNotExistException(studyMemberId));
+                .orElseThrow(() -> new StudyMemberNotExistException(studyMemberId));
 
         return studyMemberPersistenceMapper.toDomain(entity);
     }
@@ -66,6 +65,11 @@ public class StudyMemberPersistenceAdapter
     @Override
     public List<StudyMemberReviewStatusResponse> findStudyMemberReviewStatusByMember(Long studyId, Long memberId) {
         return jpaStudyMemberRepository.findStudyMemberReviewStatusByMember(studyId, memberId);
+    }
+
+    @Override
+    public long getStudyMemberCount(Long studyId) {
+        return jpaStudyMemberRepository.countByStudyId(studyId);
     }
 
     @Override

--- a/src/main/java/com/stumeet/server/studymember/application/port/in/StudyMemberQueryUseCase.java
+++ b/src/main/java/com/stumeet/server/studymember/application/port/in/StudyMemberQueryUseCase.java
@@ -2,7 +2,7 @@ package com.stumeet.server.studymember.application.port.in;
 
 import java.util.List;
 
-import com.stumeet.server.studymember.application.port.in.response.StudyMemberAdminResponse;
+import com.stumeet.server.studymember.application.port.in.response.MyStudyMemberDetailResponse;
 import com.stumeet.server.studymember.application.port.in.response.StudyMemberDetailResponse;
 import com.stumeet.server.studymember.application.port.in.response.StudyMemberResponses;
 import com.stumeet.server.studymember.application.port.in.response.StudyMemberReviewStatusResponse;
@@ -12,9 +12,11 @@ public interface StudyMemberQueryUseCase {
 
     StudyMemberDetailResponse getStudyMemberDetail(Long studyId, Long targetMemberId, Long requesterId);
 
-    StudyMemberAdminResponse isMemberAdmin(Long studyId, Long memberId);
-
-    boolean canSendGrape(Long studyId, Long memberId);
-
     List<StudyMemberReviewStatusResponse> getStudyMemberReviewStatusByMember(Long studyId, Long memberId);
+
+    MyStudyMemberDetailResponse getMyStudyMemberDetail(Long studyId, Long memberId);
+
+    long getStudyMemberCount(Long studyId);
+
+    boolean isMemberAdmin(Long studyId, Long memberId);
 }

--- a/src/main/java/com/stumeet/server/studymember/application/port/in/response/MyStudyMemberDetailResponse.java
+++ b/src/main/java/com/stumeet/server/studymember/application/port/in/response/MyStudyMemberDetailResponse.java
@@ -1,0 +1,8 @@
+package com.stumeet.server.studymember.application.port.in.response;
+
+public record MyStudyMemberDetailResponse(
+        boolean isAdmin,
+        boolean canSendGrape,
+        Boolean isReviewCompleted
+) {
+}

--- a/src/main/java/com/stumeet/server/studymember/application/port/in/response/StudyMemberAdminResponse.java
+++ b/src/main/java/com/stumeet/server/studymember/application/port/in/response/StudyMemberAdminResponse.java
@@ -1,6 +1,0 @@
-package com.stumeet.server.studymember.application.port.in.response;
-
-public record StudyMemberAdminResponse(
-        Boolean isAdmin
-) {
-}

--- a/src/main/java/com/stumeet/server/studymember/application/port/in/response/StudyMemberGrapeResponse.java
+++ b/src/main/java/com/stumeet/server/studymember/application/port/in/response/StudyMemberGrapeResponse.java
@@ -1,6 +1,0 @@
-package com.stumeet.server.studymember.application.port.in.response;
-
-public record StudyMemberGrapeResponse(
-        Boolean canSendGrape
-) {
-}

--- a/src/main/java/com/stumeet/server/studymember/application/port/out/StudyMemberQueryPort.java
+++ b/src/main/java/com/stumeet/server/studymember/application/port/out/StudyMemberQueryPort.java
@@ -16,4 +16,6 @@ public interface StudyMemberQueryPort {
     boolean isSentGrape(Long studyId, Long memberId);
 
     List<StudyMemberReviewStatusResponse> findStudyMemberReviewStatusByMember(Long studyId, Long memberId);
+
+    long getStudyMemberCount(Long studyId);
 }

--- a/src/main/java/com/stumeet/server/studymember/application/service/StudyMemberQueryService.java
+++ b/src/main/java/com/stumeet/server/studymember/application/service/StudyMemberQueryService.java
@@ -2,11 +2,12 @@ package com.stumeet.server.studymember.application.service;
 
 import com.stumeet.server.activity.application.port.in.EvaluateMemberAchievementUseCase;
 import com.stumeet.server.common.annotation.UseCase;
+import com.stumeet.server.review.application.port.in.ReviewQueryUseCase;
+import com.stumeet.server.study.application.port.in.StudyQueryUseCase;
 import com.stumeet.server.study.application.port.in.StudyValidationUseCase;
+import com.stumeet.server.studymember.application.port.in.response.MyStudyMemberDetailResponse;
 import com.stumeet.server.studymember.application.port.in.response.SimpleStudyMemberResponse;
-import com.stumeet.server.studymember.application.port.in.response.StudyMemberAdminResponse;
 import com.stumeet.server.studymember.application.port.in.response.StudyMemberDetailResponse;
-import com.stumeet.server.studymember.application.port.in.response.StudyMemberGrapeResponse;
 import com.stumeet.server.studymember.application.port.in.response.StudyMemberResponses;
 import com.stumeet.server.studymember.application.port.in.StudyMemberQueryUseCase;
 import com.stumeet.server.studymember.application.port.in.StudyMemberValidationUseCase;
@@ -26,9 +27,11 @@ import java.util.List;
 @RequiredArgsConstructor
 public class StudyMemberQueryService implements StudyMemberQueryUseCase {
 
+    private final StudyQueryUseCase studyQueryUseCase;
     private final StudyValidationUseCase studyValidationUseCase;
     private final StudyMemberValidationUseCase studyMemberValidationUseCase;
     private final EvaluateMemberAchievementUseCase evaluateMemberAchievementUseCase;
+    private final ReviewQueryUseCase reviewQueryUseCase;
 
     private final StudyMemberQueryPort studyMemberQueryPort;
     private final StudyMemberValidationPort studyMemberValidationPort;
@@ -61,27 +64,52 @@ public class StudyMemberQueryService implements StudyMemberQueryUseCase {
     }
 
     @Override
-    public StudyMemberAdminResponse isMemberAdmin(Long studyId, Long memberId) {
-        studyValidationUseCase.checkById(studyId);
-
-        return new StudyMemberAdminResponse(
-                studyMemberValidationPort.isAdmin(studyId, memberId)
-        );
-    }
-
-    @Override
-    public boolean canSendGrape(Long studyId, Long memberId) {
-        studyValidationUseCase.checkById(studyId);
-
-        return !studyMemberQueryPort.isSentGrape(studyId, memberId);
-    }
-
-    @Override
     public List<StudyMemberReviewStatusResponse> getStudyMemberReviewStatusByMember(Long studyId, Long memberId) {
         studyValidationUseCase.checkById(studyId);
         studyValidationUseCase.checkLegacyStudy(studyId);
         studyMemberValidationUseCase.checkStudyJoinMember(studyId, memberId);
 
         return studyMemberQueryPort.findStudyMemberReviewStatusByMember(studyId, memberId);
+    }
+
+    @Override
+    public MyStudyMemberDetailResponse getMyStudyMemberDetail(Long studyId, Long memberId) {
+        studyValidationUseCase.checkById(studyId);
+        studyMemberValidationUseCase.checkStudyJoinMember(studyId, memberId);
+
+        boolean isAdmin = isMemberAdmin(studyId, memberId);
+        boolean canSendGrape = canSendGrape(studyId, memberId);
+        Boolean isReviewCompleted = isMemberReviewCompleted(studyId, memberId);
+
+        return new MyStudyMemberDetailResponse(isAdmin, canSendGrape, isReviewCompleted);
+    }
+
+    @Override
+    public long getStudyMemberCount(Long studyId) {
+        return studyMemberQueryPort.getStudyMemberCount(studyId);
+    }
+
+    @Override
+    public boolean isMemberAdmin(Long studyId, Long memberId) {
+        return studyMemberValidationPort.isAdmin(studyId, memberId);
+    }
+
+    private boolean canSendGrape(Long studyId, Long memberId) {
+        if (studyQueryUseCase.isFinishedStudy(studyId)) {
+            return false;
+        }
+
+        return !studyMemberQueryPort.isSentGrape(studyId, memberId);
+    }
+
+    private Boolean isMemberReviewCompleted(Long studyId, Long memberId) {
+        if (!studyQueryUseCase.isFinishedStudy(studyId)) {
+            return null;
+        }
+
+        long studyMemberCount = getStudyMemberCount(studyId);
+        long studyMemberReviewCount = reviewQueryUseCase.getStudyMemberReviewCount(studyId, memberId);
+
+        return studyMemberCount == studyMemberReviewCount;
     }
 }


### PR DESCRIPTION
## 💁 해결 하려는 문제를 적어주세요 

- 기존에 내 스터디 멤버 정보를 조회할 때, `관리자 여부`, `포도알 칭찬 전송 가능 여부`, `리뷰 완료 여부` 등을 조회할 때마다 개별 api가 하나씩 늘어나는 문제가 있었습니다.

## 🤔 어떤 방식으로 해결했는지 적어주세요 

- 이후로 내 스터디 멤버 정보 추가 시 더 이상 api가 늘어나는 것을 방지하기 위해 해당 정보들을 하나의 api로 얻을 수 있도록 `/studies/{studyId}/members/me` 경로의 api를 구현하여 이전의 상태 조회 api를 통합했습니다.