### PR TITLE
✨ [STMT-307] 리뷰 통계 조회 API 응답에 태그 총 개수 필드 추가

### DIFF
--- a/src/main/java/com/stumeet/server/review/adapter/out/persistence/JpaReviewTagRepository.java
+++ b/src/main/java/com/stumeet/server/review/adapter/out/persistence/JpaReviewTagRepository.java
@@ -17,4 +17,6 @@ public interface JpaReviewTagRepository extends JpaRepository<ReviewTagJpaEntity
         + "GROUP BY rt.reviewTag "
         + "ORDER BY COUNT(rt) DESC, rt.reviewTag ASC ")
     List<ReviewTagCountDto> countReviewTagByRevieweeIdOrdered(Long memberId);
+
+    long countByReview_RevieweeId(Long memberId);
 }

--- a/src/main/java/com/stumeet/server/review/adapter/out/persistence/ReviewPersistenceAdapter.java
+++ b/src/main/java/com/stumeet/server/review/adapter/out/persistence/ReviewPersistenceAdapter.java
@@ -74,4 +74,9 @@ public class ReviewPersistenceAdapter implements ReviewSavePort, ReviewQueryPort
     public long getStudyMemberReviewCount(Long studyId, Long memberId) {
         return jpaReviewRepository.countByReviewerIdAndStudyId(memberId, studyId);
     }
+
+    @Override
+    public long getMemberReviewTagCount(Long memberId) {
+        return jpaReviewTagRepository.countByReview_RevieweeId(memberId);
+    }
 }

--- a/src/main/java/com/stumeet/server/review/adapter/out/web/ReviewQueryApi.java
+++ b/src/main/java/com/stumeet/server/review/adapter/out/web/ReviewQueryApi.java
@@ -14,6 +14,7 @@ import com.stumeet.server.common.auth.model.LoginMember;
 import com.stumeet.server.common.model.ApiResponse;
 import com.stumeet.server.common.response.SuccessCode;
 import com.stumeet.server.review.adapter.out.web.dto.ReviewDetailResponse;
+import com.stumeet.server.review.adapter.out.web.dto.ReviewStatsResponse;
 import com.stumeet.server.review.adapter.out.web.dto.ReviewTagCountStatsResponse;
 import com.stumeet.server.review.application.port.in.ReviewQueryUseCase;
 
@@ -41,11 +42,10 @@ public class ReviewQueryApi {
     }
 
     @GetMapping("/reviews/tags/stats")
-    public ResponseEntity<ApiResponse<List<ReviewTagCountStatsResponse>>> getReviewStats(
+    public ResponseEntity<ApiResponse<ReviewStatsResponse>> getReviewStats(
         @AuthenticationPrincipal LoginMember member
     ) {
-        List<ReviewTagCountStatsResponse> response =
-            reviewQueryUseCase.getMemberReviewTagStats(member.getId());
+        ReviewStatsResponse response = reviewQueryUseCase.getReviewStats(member.getId());
 
         return new ResponseEntity<>(
             ApiResponse.success(SuccessCode.GET_SUCCESS, response),

--- a/src/main/java/com/stumeet/server/review/adapter/out/web/dto/ReviewStatsResponse.java
+++ b/src/main/java/com/stumeet/server/review/adapter/out/web/dto/ReviewStatsResponse.java
@@ -1,0 +1,12 @@
+package com.stumeet.server.review.adapter.out.web.dto;
+
+import java.util.List;
+
+import lombok.Builder;
+
+@Builder
+public record ReviewStatsResponse(
+        long totalCount,
+        List<ReviewTagCountStatsResponse> tagCountStats
+) {
+}

--- a/src/main/java/com/stumeet/server/review/application/port/in/ReviewQueryUseCase.java
+++ b/src/main/java/com/stumeet/server/review/application/port/in/ReviewQueryUseCase.java
@@ -3,13 +3,18 @@ package com.stumeet.server.review.application.port.in;
 import java.util.List;
 
 import com.stumeet.server.review.adapter.out.web.dto.ReviewDetailResponse;
+import com.stumeet.server.review.adapter.out.web.dto.ReviewStatsResponse;
 import com.stumeet.server.review.adapter.out.web.dto.ReviewTagCountStatsResponse;
 
 public interface ReviewQueryUseCase {
 
     List<ReviewDetailResponse> getMemberReview(Long memberId, int size, int page, String sortName);
 
+    ReviewStatsResponse getReviewStats(Long memberId);
+
     List<ReviewTagCountStatsResponse> getMemberReviewTagStats(Long memberId);
 
     long getStudyMemberReviewCount(Long studyId, Long memberId);
+
+    long getMemberReviewTagCount(Long memberId);
 }

--- a/src/main/java/com/stumeet/server/review/application/port/out/ReviewQueryPort.java
+++ b/src/main/java/com/stumeet/server/review/application/port/out/ReviewQueryPort.java
@@ -15,4 +15,6 @@ public interface ReviewQueryPort {
     List<ReviewTagCountStatsResponse> countMemberReviewTags(Long memberId);
 
     long getStudyMemberReviewCount(Long studyId, Long memberId);
+
+    long getMemberReviewTagCount(Long memberId);
 }

--- a/src/main/java/com/stumeet/server/review/application/service/ReviewQueryService.java
+++ b/src/main/java/com/stumeet/server/review/application/service/ReviewQueryService.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import com.stumeet.server.common.annotation.UseCase;
 import com.stumeet.server.review.adapter.out.web.dto.ReviewDetailResponse;
+import com.stumeet.server.review.adapter.out.web.dto.ReviewStatsResponse;
 import com.stumeet.server.review.adapter.out.web.dto.ReviewTagCountStatsResponse;
 import com.stumeet.server.review.application.port.in.ReviewQueryUseCase;
 import com.stumeet.server.review.application.port.out.ReviewQueryPort;
@@ -38,13 +39,28 @@ public class ReviewQueryService implements ReviewQueryUseCase {
     }
 
     @Override
+    public ReviewStatsResponse getReviewStats(Long memberId) {
+        long reviewTagCount = reviewQueryPort.getMemberReviewTagCount(memberId);
+        List<ReviewTagCountStatsResponse> reviewTagStats = getMemberReviewTagStats(memberId);
+
+        return ReviewStatsResponse.builder()
+                .totalCount(reviewTagCount)
+                .tagCountStats(reviewTagStats)
+                .build();
+    }
+
+    @Override
     public List<ReviewTagCountStatsResponse> getMemberReviewTagStats(Long memberId) {
-        List<ReviewTagCountStatsResponse> reviewTagsCnt = reviewQueryPort.countMemberReviewTags(memberId);
-        return reviewTagsCnt;
+        return reviewQueryPort.countMemberReviewTags(memberId);
     }
 
     @Override
     public long getStudyMemberReviewCount(Long studyId, Long memberId) {
         return reviewQueryPort.getStudyMemberReviewCount(studyId, memberId);
+    }
+
+    @Override
+    public long getMemberReviewTagCount(Long memberId) {
+        return reviewQueryPort.getMemberReviewTagCount(memberId);
     }
 }

--- a/src/test/java/com/stumeet/server/review/adapter/out/web/ReviewQueryApiTest.java
+++ b/src/test/java/com/stumeet/server/review/adapter/out/web/ReviewQueryApiTest.java
@@ -91,8 +91,9 @@ class ReviewQueryApiTest extends ApiTest {
                         fieldWithPath("code").description("응답 코드"),
                         fieldWithPath("message").description("응답 메시지"),
                         fieldWithPath("data").description("리뷰 태그 개수 통계"),
-                        fieldWithPath("data[].reviewTagName").description("리뷰 태그 이름"),
-                        fieldWithPath("data[].count").description("리뷰 태그 개수")
+                        fieldWithPath("data.totalCount").description("총 리뷰 태그 개수"),
+                        fieldWithPath("data.tagCountStats[].reviewTagName").description("리뷰 태그 이름"),
+                        fieldWithPath("data.tagCountStats[].count").description("리뷰 태그 개수")
                     )
                 ));
         }


### PR DESCRIPTION
## 💁 해결 하려는 문제를 적어주세요 

- UI의 리뷰 통계 퍼센트 게이지 산출을 위해 리뷰 태그의 총 개수가 필요했습니다.

## 🤔 어떤 방식으로 해결했는지 적어주세요 

- 리뷰 통계 조회 API 응답에 태그 총 개수를 추가했습니다.