### PR TITLE
fix: elastic cache valkey 연결 ssl 설정

### DIFF
--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -27,6 +27,8 @@ spring:
     redis:
       host: ${REDIS_URL}
       port: ${REDIS_PORT}
+      ssl:
+        enabled: true
   jpa:
     hibernate:
       ddl-auto: none


### PR DESCRIPTION
## 💁 해결 하려는 문제를 적어주세요 

- AWS elastic cache의 valkey 연결 시 time out 에러 발생
## 🤔 어떤 방식으로 해결했는지 적어주세요 

- 암호화 설정이 활성화 되어 있기 때문에 spring redis 설정에 ssl을 활성화