### PR TITLE
:recycle: [STMT-307] 유저 리뷰 상세 목록 조회 API 응답 결과를 페이지네이션으로 리팩터링

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -1209,7 +1209,7 @@ include::{snippets}/renew-notification-token/fail/invalid-format/response-fields
 
 멤버의 알림 기록 목록을 조회하는 API 입니다.
 
-==== POST /api/v1/notification/logs
+==== GET /api/v1/notification/logs
 
 ===== 요청
 include::{snippets}/get-member-notification-logs/success/http-request.adoc[]

--- a/src/main/java/com/stumeet/server/review/adapter/out/persistence/JpaReviewRepositoryCustom.java
+++ b/src/main/java/com/stumeet/server/review/adapter/out/persistence/JpaReviewRepositoryCustom.java
@@ -1,7 +1,6 @@
 package com.stumeet.server.review.adapter.out.persistence;
 
-import java.util.List;
-
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import com.stumeet.server.review.adapter.out.persistence.entity.ReviewJpaEntity;
@@ -9,5 +8,5 @@ import com.stumeet.server.review.domain.ReviewSort;
 
 public interface JpaReviewRepositoryCustom {
 
-    List<ReviewJpaEntity> findByMemberId(Long memberId, Pageable pageable, ReviewSort sort);
+    Page<ReviewJpaEntity> findByMemberId(Long memberId, Pageable pageable, ReviewSort sort);
 }

--- a/src/main/java/com/stumeet/server/review/adapter/out/persistence/JpaReviewRepositoryCustomImpl.java
+++ b/src/main/java/com/stumeet/server/review/adapter/out/persistence/JpaReviewRepositoryCustomImpl.java
@@ -3,6 +3,7 @@ package com.stumeet.server.review.adapter.out.persistence;
 import java.util.List;
 
 import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.stumeet.server.common.annotation.PersistenceAdapter;
 import com.stumeet.server.review.adapter.out.persistence.entity.ReviewJpaEntity;
@@ -10,10 +11,14 @@ import com.stumeet.server.review.domain.ReviewSort;
 
 import lombok.RequiredArgsConstructor;
 
+import static com.stumeet.server.activity.adapter.out.model.QActivityJpaEntity.*;
+import static com.stumeet.server.activity.adapter.out.model.QActivityParticipantJpaEntity.*;
 import static com.stumeet.server.review.adapter.out.persistence.entity.QReviewJpaEntity.reviewJpaEntity;
 import static com.stumeet.server.review.adapter.out.persistence.entity.QReviewTagJpaEntity.reviewTagJpaEntity;
 
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
 
 @PersistenceAdapter
 @RequiredArgsConstructor
@@ -22,8 +27,8 @@ public class JpaReviewRepositoryCustomImpl implements JpaReviewRepositoryCustom 
     private final JPAQueryFactory query;
 
     @Override
-    public List<ReviewJpaEntity> findByMemberId(Long memberId, Pageable pageable, ReviewSort sort) {
-        return query.selectFrom(reviewJpaEntity)
+    public Page<ReviewJpaEntity> findByMemberId(Long memberId, Pageable pageable, ReviewSort sort) {
+        List<ReviewJpaEntity> content = query.selectFrom(reviewJpaEntity)
             .leftJoin(reviewJpaEntity.tags, reviewTagJpaEntity).fetchJoin()
             .where(
                 reviewJpaEntity.revieweeId.eq(memberId)
@@ -33,6 +38,16 @@ public class JpaReviewRepositoryCustomImpl implements JpaReviewRepositoryCustom 
             .offset(pageable.getOffset())
             .limit(pageable.getPageSize())
             .fetch();
+
+        JPAQuery<Long> countQuery = query
+                .select(reviewJpaEntity.count())
+                .from(reviewJpaEntity)
+                .leftJoin(reviewJpaEntity.tags, reviewTagJpaEntity)
+                .where(
+                        reviewJpaEntity.revieweeId.eq(memberId)
+                );
+
+        return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
     }
 
     private OrderSpecifier<?> toOrderSpecifiers(ReviewSort sort) {

--- a/src/main/java/com/stumeet/server/review/adapter/out/persistence/ReviewPersistenceAdapter.java
+++ b/src/main/java/com/stumeet/server/review/adapter/out/persistence/ReviewPersistenceAdapter.java
@@ -2,6 +2,7 @@ package com.stumeet.server.review.adapter.out.persistence;
 
 import java.util.List;
 
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 
 import com.stumeet.server.common.annotation.PersistenceAdapter;
@@ -53,8 +54,8 @@ public class ReviewPersistenceAdapter implements ReviewSavePort, ReviewQueryPort
     }
 
     @Override
-    public List<Review> findMemberReviews(Long memberId, Integer size, Integer page, ReviewSort sort) {
-        List<ReviewJpaEntity> entities = jpaReviewRepositoryCustom.findByMemberId(memberId, PageRequest.of(page, size), sort);
+    public Page<Review> findMemberReviews(Long memberId, Integer size, Integer page, ReviewSort sort) {
+        Page<ReviewJpaEntity> entities = jpaReviewRepositoryCustom.findByMemberId(memberId, PageRequest.of(page, size), sort);
         return reviewPersistenceMapper.toDomains(entities);
     }
 

--- a/src/main/java/com/stumeet/server/review/adapter/out/persistence/mapper/ReviewPersistenceMapper.java
+++ b/src/main/java/com/stumeet/server/review/adapter/out/persistence/mapper/ReviewPersistenceMapper.java
@@ -2,8 +2,11 @@ package com.stumeet.server.review.adapter.out.persistence.mapper;
 
 import java.util.List;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.stereotype.Component;
 
+import com.stumeet.server.activity.domain.model.Activity;
 import com.stumeet.server.review.adapter.out.persistence.entity.ReviewJpaEntity;
 import com.stumeet.server.review.adapter.out.persistence.entity.ReviewTagJpaEntity;
 import com.stumeet.server.review.domain.Review;
@@ -41,5 +44,13 @@ public class ReviewPersistenceMapper {
         return entities.stream()
             .map(this::toDomain)
             .toList();
+    }
+
+    public Page<Review> toDomains(Page<ReviewJpaEntity> entities) {
+        List<Review> domains = entities.stream()
+                .map(this::toDomain)
+                .toList();
+
+        return new PageImpl<>(domains, entities.getPageable(), entities.getTotalElements());
     }
 }

--- a/src/main/java/com/stumeet/server/review/adapter/out/web/ReviewQueryApi.java
+++ b/src/main/java/com/stumeet/server/review/adapter/out/web/ReviewQueryApi.java
@@ -14,6 +14,7 @@ import com.stumeet.server.common.auth.model.LoginMember;
 import com.stumeet.server.common.model.ApiResponse;
 import com.stumeet.server.common.response.SuccessCode;
 import com.stumeet.server.review.adapter.out.web.dto.ReviewDetailResponse;
+import com.stumeet.server.review.adapter.out.web.dto.ReviewDetailResponses;
 import com.stumeet.server.review.adapter.out.web.dto.ReviewStatsResponse;
 import com.stumeet.server.review.adapter.out.web.dto.ReviewTagCountStatsResponse;
 import com.stumeet.server.review.application.port.in.ReviewQueryUseCase;
@@ -27,13 +28,13 @@ public class ReviewQueryApi {
     private final ReviewQueryUseCase reviewQueryUseCase;
 
     @GetMapping("/reviews")
-    public ResponseEntity<ApiResponse<List<ReviewDetailResponse>>> getReviews(
+    public ResponseEntity<ApiResponse<ReviewDetailResponses>> getReviews(
         @AuthenticationPrincipal LoginMember member,
         @RequestParam Integer size,
         @RequestParam Integer page,
         @RequestParam String sort
     ) {
-        List<ReviewDetailResponse> response =
+        ReviewDetailResponses response =
             reviewQueryUseCase.getMemberReview(member.getId(), size, page, sort);
 
         return new ResponseEntity<>(

--- a/src/main/java/com/stumeet/server/review/adapter/out/web/dto/ReviewDetailResponses.java
+++ b/src/main/java/com/stumeet/server/review/adapter/out/web/dto/ReviewDetailResponses.java
@@ -1,0 +1,14 @@
+package com.stumeet.server.review.adapter.out.web.dto;
+
+import java.util.List;
+
+import com.stumeet.server.common.model.PageInfoResponse;
+
+import lombok.Builder;
+
+@Builder
+public record ReviewDetailResponses(
+        List<ReviewDetailResponse> items,
+        PageInfoResponse pageInfo
+) {
+}

--- a/src/main/java/com/stumeet/server/review/application/port/in/ReviewQueryUseCase.java
+++ b/src/main/java/com/stumeet/server/review/application/port/in/ReviewQueryUseCase.java
@@ -2,13 +2,13 @@ package com.stumeet.server.review.application.port.in;
 
 import java.util.List;
 
-import com.stumeet.server.review.adapter.out.web.dto.ReviewDetailResponse;
+import com.stumeet.server.review.adapter.out.web.dto.ReviewDetailResponses;
 import com.stumeet.server.review.adapter.out.web.dto.ReviewStatsResponse;
 import com.stumeet.server.review.adapter.out.web.dto.ReviewTagCountStatsResponse;
 
 public interface ReviewQueryUseCase {
 
-    List<ReviewDetailResponse> getMemberReview(Long memberId, int size, int page, String sortName);
+    ReviewDetailResponses getMemberReview(Long memberId, int size, int page, String sortName);
 
     ReviewStatsResponse getReviewStats(Long memberId);
 

--- a/src/main/java/com/stumeet/server/review/application/port/out/ReviewQueryPort.java
+++ b/src/main/java/com/stumeet/server/review/application/port/out/ReviewQueryPort.java
@@ -2,6 +2,8 @@ package com.stumeet.server.review.application.port.out;
 
 import java.util.List;
 
+import org.springframework.data.domain.Page;
+
 import com.stumeet.server.review.adapter.out.web.dto.ReviewTagCountStatsResponse;
 import com.stumeet.server.review.domain.Review;
 import com.stumeet.server.review.domain.ReviewSort;
@@ -10,7 +12,7 @@ public interface ReviewQueryPort {
 
     boolean isExists(Long studyId, Long reviewerId, Long revieweeId);
 
-    List<Review> findMemberReviews(Long memberId, Integer size, Integer page, ReviewSort sort);
+    Page<Review> findMemberReviews(Long memberId, Integer size, Integer page, ReviewSort sort);
 
     List<ReviewTagCountStatsResponse> countMemberReviewTags(Long memberId);
 

--- a/src/test/java/com/stumeet/server/review/adapter/out/web/ReviewQueryApiTest.java
+++ b/src/test/java/com/stumeet/server/review/adapter/out/web/ReviewQueryApiTest.java
@@ -30,13 +30,13 @@ class ReviewQueryApiTest extends ApiTest {
         @WithMockMember(id = 4L)
         @DisplayName("[성공] 멤버의 리뷰 목록 조회에 성공한다.")
         void success() throws Exception {
-            Integer size = 2;
-            Integer page = 0;
+            int size = 2;
+            int page = 0;
             ReviewSort sort = ReviewSort.LATEST;
 
             mockMvc.perform(get(PATH)
-                    .param("size", size.toString())
-                    .param("page", page.toString())
+                    .param("size", Integer.toString(size))
+                    .param("page", Integer.toString(page))
                     .param("sort", sort.name())
                     .header(AuthenticationHeader.ACCESS_TOKEN.getName(), TokenStub.getMockAccessToken()))
                 .andExpect(status().isOk())
@@ -57,11 +57,17 @@ class ReviewQueryApiTest extends ApiTest {
                         fieldWithPath("code").description("응답 코드"),
                         fieldWithPath("message").description("응답 메시지"),
                         fieldWithPath("data").description("응답 데이터"),
-                        fieldWithPath("data[].id").description("리뷰 ID"),
-                        fieldWithPath("data[].rate").description("별점"),
-                        fieldWithPath("data[].content").description("내용"),
-                        fieldWithPath("data[].createdAt").description("생성일자"),
-                        fieldWithPath("data[].tags[]").description("리뷰 태그 목록")
+                        fieldWithPath("data.items").description("리뷰 목록"),
+                        fieldWithPath("data.items[].id").description("리뷰 ID"),
+                        fieldWithPath("data.items[].rate").description("별점"),
+                        fieldWithPath("data.items[].content").description("내용"),
+                        fieldWithPath("data.items[].createdAt").description("생성일자"),
+                        fieldWithPath("data.items[].tags[]").description("리뷰 태그 목록"),
+                        fieldWithPath("data.pageInfo").description("페이지 메타 정보"),
+                        fieldWithPath("data.pageInfo.totalPages").description("전체 페이지 수"),
+                        fieldWithPath("data.pageInfo.totalElements").description("전체 요소 수"),
+                        fieldWithPath("data.pageInfo.currentPage").description("현재 페이지"),
+                        fieldWithPath("data.pageInfo.pageSize").description("페이지 크기")
                     )
                 ));
         }


### PR DESCRIPTION
## 💁 해결 하려는 문제를 적어주세요 

- 유저 리뷰 상세 목록 조회 API가 페이지네이션 방식으로 구현되어 있었는데 페이지 정보가 제공되지 않는 문제가 있었습니다.

## 🤔 어떤 방식으로 해결했는지 적어주세요 

- Page 목록을 조회하도록 수정하고, 응답에 pageinfo를 추가했습니다.